### PR TITLE
Sass Refactor

### DIFF
--- a/src/app/systelab-components/sass/_form.scss
+++ b/src/app/systelab-components/sass/_form.scss
@@ -20,7 +20,7 @@
   padding-bottom: 1px;
   padding-left: 5px;
   padding-right: 5px;
-  height: $form-elements-height !important;
+  height: $form-elements-height;
 }
 
 .col-form-label {

--- a/src/app/systelab-components/sass/_spinner.scss
+++ b/src/app/systelab-components/sass/_spinner.scss
@@ -3,6 +3,7 @@
   .slab-spinner-input {
     min-width: 0;
     text-align: center;
+    height: $form-elements-height !important;
   }
 }
 

--- a/src/app/systelab-components/spinner/spinner.component.html
+++ b/src/app/systelab-components/spinner/spinner.component.html
@@ -6,7 +6,7 @@
                     class="icon-minus-thin"></i></button>
         </div>
         <input [class.disabled]="disabled" name="sp" [(ngModel)]="valueStr"
-               class="slab-flex-1 form-control text-center" type="text"
+               class="slab-flex-1 slab-spinner-input form-control text-center" type="text"
                (keydown)="($event.keyCode===13||$event.keyCode===9)?pushEnter($event.keyCode):0"
                (keypress)="checkKey($event)"
                (blur)="checkValue(valueStr)"


### PR DESCRIPTION
Revert change in form.scss of height !important. Numpad was affected the height of the buttons and input inside the numpad had been forced to form height because numpad buttons and inputs are inside a form.

Change spinner to force its height with an important because bootstrap has another style that modifies its height