### PR TITLE
Add an abstract-grid example and improve systelab-grid documentation

### DIFF
--- a/src/app/showcase/components/dialog/standard-dialog/showcase-standard-dialog.component.html
+++ b/src/app/showcase/components/dialog/standard-dialog/showcase-standard-dialog.component.html
@@ -7,8 +7,8 @@
         <div class="slab-flex-1">Second tab</div>
     </systelab-tab>
     <systelab-tab [title]="'title 1'" [id]="'1'" class="p-1">
-        <showcase-inner-grid #grid2 class="slab-flex-1 position-relative" [menu]="getMenu()" (action)="doMenuAction($event)"
-                             (clickRow)="doSelect($event)"></showcase-inner-grid>
+        <showcase-inner-api-grid #grid2 class="slab-flex-1 position-relative" [menu]="getMenu()" (action)="doMenuAction($event)" [headerMenu]="getHeaderContextMenuOptions()"
+                                 (clickRow)="doSelect($event)"></showcase-inner-api-grid>
     </systelab-tab>
 </systelab-tabs>
 

--- a/src/app/showcase/components/dialog/standard-dialog/showcase-standard-dialog.component.ts
+++ b/src/app/showcase/components/dialog/standard-dialog/showcase-standard-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 import { DialogRef, ModalComponent, SystelabModalContext } from '../../../../systelab-components/modal';
-import { ShowcaseData } from '../../grid/showcase-inner-grid.component';
 import { GridContextMenuOption } from '../../../../systelab-components/grid/contextmenu/grid-context-menu-option';
 import { GridContextMenuActionData } from '../../../../systelab-components/grid/contextmenu/grid-context-menu-action-data';
+import { ShowcaseData } from '../../grid/showcase-grid.model';
 
 export class ShowcaseStandardDialogParameters extends SystelabModalContext {
 	public index: number;
@@ -17,6 +17,10 @@ export class ShowcaseStandardDialog implements ModalComponent<ShowcaseStandardDi
 
 	protected parameters: ShowcaseStandardDialogParameters;
 
+	public static getParameters(): ShowcaseStandardDialogParameters {
+		return new ShowcaseStandardDialogParameters();
+	}
+
 	constructor(public dialog: DialogRef<ShowcaseStandardDialogParameters>) {
 		this.parameters = dialog.context;
 	}
@@ -25,12 +29,8 @@ export class ShowcaseStandardDialog implements ModalComponent<ShowcaseStandardDi
 		this.dialog.close('This is a test');
 	}
 
-	public static getParameters(): ShowcaseStandardDialogParameters {
-		return new ShowcaseStandardDialogParameters();
-	}
-
 	public doSelect(compareProfileData: ShowcaseData): void {
-
+		console.log(compareProfileData);
 	}
 
 	public getMenu(): Array<GridContextMenuOption<ShowcaseData>> {
@@ -46,6 +46,15 @@ export class ShowcaseStandardDialog implements ModalComponent<ShowcaseStandardDi
 		} else if (action.actionId === 'action2') {
 		} else if (action.actionId === 'action3') {
 		}
+	}
+
+	public getHeaderContextMenuOptions(): Array<GridContextMenuOption<string>> {
+		return [
+			new GridContextMenuOption('headeraction1', 'Header Action 1'),
+			new GridContextMenuOption('headeraction2', 'Header Action 2'),
+			new GridContextMenuOption('headeraction3', 'Header Action 3'),
+			new GridContextMenuOption('headeraction4', 'Header Action 4')
+		];
 	}
 }
 

--- a/src/app/showcase/components/grid/showcase-grid.component.html
+++ b/src/app/showcase/components/grid/showcase-grid.component.html
@@ -1,8 +1,19 @@
 <div class="container-fluid">
+    <h5>Grid</h5>
     <form class="position-relative" style="height: 200px;">
-        <showcase-inner-grid #grid [menu]="getMenu()" (action)="doMenuAction($event)" (clickRow)="doSelect($event)"></showcase-inner-grid>
+        <showcase-inner-grid #grid [rowData]="gridData" [menu]="getMenu()" (action)="doMenuAction($event)" [headerMenu]="getHeaderContextMenuOptions()"
+                             (clickRow)="doSelect($event)"></showcase-inner-grid>
     </form>
     <div class="pt-2">
         <button type="button" class="btn" (click)="grid.showOptions();"><i class="icon-info-circle mr-1"></i>Options</button>
+    </div>
+
+    <h5>Api Grid</h5>
+    <form class="position-relative" style="height: 200px;">
+        <showcase-inner-api-grid #gridapi [menu]="getMenu()" (action)="doMenuAction($event)" [headerMenu]="getHeaderContextMenuOptions()"
+                                 (clickRow)="doSelect($event)"></showcase-inner-api-grid>
+    </form>
+    <div class="pt-2">
+        <button type="button" class="btn" (click)="gridapi.showOptions();"><i class="icon-info-circle mr-1"></i>Options</button>
     </div>
 </div>

--- a/src/app/showcase/components/grid/showcase-grid.component.ts
+++ b/src/app/showcase/components/grid/showcase-grid.component.ts
@@ -1,18 +1,26 @@
-import { Component } from '@angular/core';
-import { ShowcaseData } from './showcase-inner-grid.component';
+import { Component, OnInit } from '@angular/core';
 import { GridContextMenuOption } from '../../../systelab-components/grid/contextmenu/grid-context-menu-option';
 import { GridContextMenuActionData } from '../../../systelab-components/grid/contextmenu/grid-context-menu-action-data';
+import { ShowcaseData } from './showcase-grid.model';
+import { ShowcaseGridUtil } from './showcase-grid.util';
 
 @Component({
 	selector:    'showcase-grid',
 	templateUrl: 'showcase-grid.component.html'
 })
-export class ShowcaseGridComponent {
+export class ShowcaseGridComponent implements OnInit {
+
+	public gridData: ShowcaseData[] = [];
 
 	constructor() {
 	}
 
+	public ngOnInit(): void {
+		this.gridData = ShowcaseGridUtil.getGridData();
+	}
+
 	public doSelect(showcaseData: ShowcaseData): void {
+		console.log(showcaseData);
 	}
 
 	public getMenu(): Array<GridContextMenuOption<ShowcaseData>> {
@@ -21,13 +29,22 @@ export class ShowcaseGridComponent {
 			new GridContextMenuOption('action2', 'Action 2', (a) => this.doMenuAction(a)),
 			new GridContextMenuOption('', '', (a) => this.doMenuAction(a), null, true),
 			new GridContextMenuOption('action3', 'Action 3', (a) => this.doMenuAction(a)),
-			new GridContextMenuOption('action4', 'Action 4', (a) => this.doMenuAction(a), a => false)
+			new GridContextMenuOption('action4', 'Action 4', (a) => this.doMenuAction(a), () => false)
 		];
 	}
 
 	public doMenuAction(action: GridContextMenuActionData<ShowcaseData>): void {
 		console.log('Here ' + action.actionId);
 		console.log('With ' + action.data);
-
 	}
+
+	public getHeaderContextMenuOptions(): Array<GridContextMenuOption<string>> {
+		return [
+			new GridContextMenuOption('headeraction1', 'Header Action 1'),
+			new GridContextMenuOption('headeraction2', 'Header Action 2'),
+			new GridContextMenuOption('headeraction3', 'Header Action 3'),
+			new GridContextMenuOption('headeraction4', 'Header Action 4')
+		];
+	}
+
 }

--- a/src/app/showcase/components/grid/showcase-grid.model.ts
+++ b/src/app/showcase/components/grid/showcase-grid.model.ts
@@ -1,0 +1,8 @@
+import { TouchSpinValues } from '../../../systelab-components/spinner/touch.spin-values';
+
+export class ShowcaseData {
+
+	constructor(public eventDate: string, public value: string, public flag: string, public decimalValue: number, public inputValue: number,
+				public checkboxValue: boolean, public checkboxID: number, public spinnerValues: TouchSpinValues) {
+	}
+}

--- a/src/app/showcase/components/grid/showcase-grid.util.ts
+++ b/src/app/showcase/components/grid/showcase-grid.util.ts
@@ -1,0 +1,72 @@
+import { GridHeaderContextMenuComponent } from '../../../systelab-components/grid/contextmenu/grid-header-context-menu.component';
+import { DecimalInputCellEditorComponent } from '../../../systelab-components/grid/custom-cells/decimal-input/decimal-input-cell-editor.component';
+import { InputCellEditorComponent } from '../../../systelab-components/grid/custom-cells/input/input-cell-editor.component';
+import { CheckboxCellRendererComponent } from '../../../systelab-components/grid/custom-cells/checkbox/checkbox-cell-renderer.component';
+import { CheckboxCellEditorComponent } from '../../../systelab-components/grid/custom-cells/checkbox/checkbox-cell-editor.component';
+import { SpinnerCellRendererComponent } from '../../../systelab-components/grid/custom-cells/spinner/spinner-cell-renderer.component';
+import { SpinnerCellEditorComponent } from '../../../systelab-components/grid/custom-cells/spinner/spinner-cell-editor.component';
+import { TouchSpinValues } from '../../../systelab-components/spinner/touch.spin-values';
+import { ShowcaseData } from './showcase-grid.model';
+
+export class ShowcaseGridUtil {
+
+	public static getColumnDefs(): Array<any> {
+		// TODO Translate column names
+		return [{colId: 'date', headerName: 'Date', field: 'eventDate', width: 300},
+			{colId: 'value', headerName: 'Value (%)', field: 'value', width: 120},
+			{
+				colId:                    'flags',
+				headerName:               'Flags',
+				field:                    'flag',
+				width:                    220,
+				headerComponentFramework: GridHeaderContextMenuComponent,
+				headerComponentParams:    {headerName: 'Flags', headerData: 'flags'}
+			}, {
+				colId:               'input',
+				headerName:          'Cell with Decimal Input',
+				field:               'decimalValue',
+				width:               200,
+				cellEditorFramework: DecimalInputCellEditorComponent,
+				editable:            true,
+				onCellValueChanged:  e => console.log('input', e)
+			}, {
+				colId:               'input',
+				headerName:          'Cell with Input',
+				field:               'inputValue',
+				width:               200,
+				cellEditorFramework: InputCellEditorComponent,
+				editable:            true,
+				onCellValueChanged:  e => console.log('input', e)
+			}, {
+				colId:                 'checkbox',
+				headerName:            'Cell with Checkbox',
+				field:                 'checkboxValue',
+				width:                 200,
+				cellRendererFramework: CheckboxCellRendererComponent,
+				cellEditorFramework:   CheckboxCellEditorComponent,
+				onCellValueChanged:    e => console.log('checkbox', e),
+				editable:              true,
+				elementID:             'checkboxID',
+				suppressResize:        true
+			}, {
+				colId:                 'spinner',
+				headerName:            'Cell with Spinner',
+				field:                 'spinnerValues',
+				width:                 200,
+				editable:              true,
+				cellRendererFramework: SpinnerCellRendererComponent,
+				cellEditorFramework:   SpinnerCellEditorComponent,
+				onCellValueChanged:    e => console.log('test', e),
+				suppressResize:        true
+			}];
+	}
+
+	public static getGridData(): ShowcaseData[] {
+		const values: ShowcaseData[] = [];
+		for (let i = 0; i < 10; i++) {
+			values.push(new ShowcaseData('12/12/2017', i + '', '10x', 26, 10,
+				false, i, new TouchSpinValues(5, 0, 100, 1)));
+		}
+		return values;
+	}
+}

--- a/src/app/showcase/components/grid/showcase-inner-api-grid.component.ts
+++ b/src/app/showcase/components/grid/showcase-inner-api-grid.component.ts
@@ -2,16 +2,19 @@ import { Component, OnInit } from '@angular/core';
 import { I18nService } from 'systelab-translate/lib/i18n.service';
 import { PreferencesService } from 'systelab-preferences/lib/preferences.service';
 import { DialogService } from '../../../systelab-components/modal';
-import { AbstractGrid } from '../../../systelab-components/grid/abstract-grid.component';
+import { AbstractApiGrid } from '../../../systelab-components/grid/abstract-api-grid.component';
+import { Observable, of } from 'rxjs';
 import { ShowcaseGridUtil } from './showcase-grid.util';
 import { ShowcaseData } from './showcase-grid.model';
 
 @Component({
-	selector:    'showcase-inner-grid',
+	selector:    'showcase-inner-api-grid',
 	// templateUrl: '../../../../../node_modules/systelab-components/html/abstract-grid.component.html' *This is the template path to be used in your project*
 	templateUrl: '../../..//systelab-components/grid/abstract-grid.component.html'
 })
-export class ShowcaseInnerGridComponent extends AbstractGrid<ShowcaseData> implements OnInit {
+export class ShowcaseInnerApiGridComponent extends AbstractApiGrid<ShowcaseData> implements OnInit {
+
+	private totalItems = 10;
 
 	constructor(protected preferencesService: PreferencesService, protected i18nService: I18nService, protected dialogService: DialogService) {
 		super(preferencesService, i18nService, dialogService);
@@ -24,6 +27,18 @@ export class ShowcaseInnerGridComponent extends AbstractGrid<ShowcaseData> imple
 
 	protected getColumnDefs(): Array<any> {
 		return ShowcaseGridUtil.getColumnDefs();
+	}
+
+	public getTotalItems(): number {
+		return this.totalItems;
+	}
+
+	protected getData(page: number, itemsPerPage: number): Observable<Array<ShowcaseData>> {
+		const values: ShowcaseData[] = ShowcaseGridUtil.getGridData();
+		this.totalItems = values.length;
+		// On a real scenario the data will be retrieved from a API
+		// return this.api.getData(page, itemsPerPage);
+		return of(values);
 	}
 
 }

--- a/src/app/showcase/showcase.module.ts
+++ b/src/app/showcase/showcase.module.ts
@@ -35,7 +35,7 @@ import { ShowcaseComboboxComponent } from './components/combobox/showcase-combob
 import { ShowcaseInputComponent } from './components/input/showcase-input.component';
 import { ShowcaseTableComponent } from './components/table/showcase-table.component';
 import { ShowcaseGridComponent } from './components/grid/showcase-grid.component';
-import { ShowcaseInnerGridComponent } from './components/grid/showcase-inner-grid.component';
+import { ShowcaseInnerApiGridComponent } from './components/grid/showcase-inner-api-grid.component';
 import { ShowcaseIconComponent } from './components/icon/showcase-icon.component';
 import { ShowcaseTwoListComponent } from './components/two-list/showcase-two-list.component';
 import { ShowcaseApplicationFrameComponent } from './components/application-frame/showcase-application-frame.component';
@@ -76,6 +76,7 @@ import { ShowcaseInnerTreeListBox } from './components/listbox/showcase-inner-tr
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ShowcaseAutocomplete } from './components/combobox/showcase-autocomplete-combobox.component';
 import { GridContextMenuCellRendererComponent } from '../systelab-components/grid/contextmenu/grid-context-menu-cell-renderer.component';
+import { ShowcaseInnerGridComponent } from './components/grid/showcase-inner-grid.component';
 
 @NgModule({
 	imports:         [
@@ -132,6 +133,7 @@ import { GridContextMenuCellRendererComponent } from '../systelab-components/gri
 		ShowcaseFullFlexDialog,
 		ShowcaseSplitDialog,
 		ShowcaseInnerGridComponent,
+		ShowcaseInnerApiGridComponent,
 		ShowcaseStandardDialog,
 		SampleRouteComponent,
 		ShowcaseStandardComponent,

--- a/src/app/systelab-components/grid/README.md
+++ b/src/app/systelab-components/grid/README.md
@@ -91,6 +91,14 @@ Be aware that the first page will be page 1.
 ## Using your component
 Once you have your component, you can use it in your templates.
 
+Property rowData must be added for components that extend  AbstractGrid&lt;T&gt;. The value is an array of type T containing the data to be displayed
+```
+<patient-grid #grid [rowData]="patientList" [menu]="getMenu()" (action)="doMenuAction($event)" (clickRow)="doSelect($event)">
+...
+</patient-grid>
+```
+
+Property rowData is not needed for components extending from AbstractApiGrid&lt;T&gt; because data is loaded inside the component calling getData method
 ```
 <patient-grid #grid [menu]="getMenu()" (action)="doMenuAction($event)" (clickRow)="doSelect($event)">
 ...


### PR DESCRIPTION
#114 

Add example of grid extending abstract-grid.
Refactor to share same columns definition and grid data between abstract-grid and abstract-api-grid examples
Improve systelab-grid-documentation adding how to load data in abstract-grid