### PR TITLE
Two-lists: more than one with the same name. Wrong management

### DIFF
--- a/src/app/showcase/components/two-list/showcase-two-list.component.html
+++ b/src/app/showcase/components/two-list/showcase-two-list.component.html
@@ -2,8 +2,7 @@
     <div style="height: 200px;">
         <systelab-two-list [(available)]="availableColumns"
                            [(visible)]="visibleColumns"
-                           [initialAvailableColumns]="getDefaultShowcaseColumns()"
-                           displayAttr="displayName">
+                           [initialAvailableColumns]="getDefaultShowcaseColumns()">
         </systelab-two-list>
     </div>
     <div class="pt-2">

--- a/src/app/systelab-components/grid/options/grid-options-dialog.component.html
+++ b/src/app/systelab-components/grid/options/grid-options-dialog.component.html
@@ -5,8 +5,7 @@
         <systelab-two-list class="slab-flex-1 slab-overflow-container"
                            [(available)]="availableColumns"
                            [(visible)]="visibleColumns"
-                           [initialAvailableColumns]="initialAvailableColumns"
-                           displayAttr="displayName">
+                           [initialAvailableColumns]="initialAvailableColumns">
         </systelab-two-list>
     </systelab-tab>
 </systelab-tabs>

--- a/src/app/systelab-components/twolist/README.md
+++ b/src/app/systelab-components/twolist/README.md
@@ -9,8 +9,7 @@ Component to select a group of elements from elements list. Elements to select h
                    [(visible)]="visibleColumns"
                    [initialAvailableColumns]="initialAvailableColumns"
                    [defaultVisibleColumns]="defaultVisibleColumns"
-                   [defaultHiddenColumns]="defaultHiddenColumns"
-                   displayAttr="displayName">
+                   [defaultHiddenColumns]="defaultHiddenColumns">
 </systelab-two-list>
 ```
 

--- a/src/app/systelab-components/twolist/datafilter.pipe.ts
+++ b/src/app/systelab-components/twolist/datafilter.pipe.ts
@@ -13,7 +13,7 @@ export class DataFilterPipe implements PipeTransform {
 		}
 
 		for (const element of input) {
-			if (element.displayName.toLowerCase()
+			if (element.colId.toLowerCase()
 					.indexOf(searchString.toLowerCase()) > -1) {
 				result.push(element);
 			}

--- a/src/app/systelab-components/twolist/datafilter.pipe.ts
+++ b/src/app/systelab-components/twolist/datafilter.pipe.ts
@@ -13,7 +13,7 @@ export class DataFilterPipe implements PipeTransform {
 		}
 
 		for (const element of input) {
-			if (element.colId.toLowerCase()
+			if (element.displayName.toLowerCase()
 					.indexOf(searchString.toLowerCase()) > -1) {
 				result.push(element);
 			}

--- a/src/app/systelab-components/twolist/two-list.component.ts
+++ b/src/app/systelab-components/twolist/two-list.component.ts
@@ -51,7 +51,6 @@ export class TwoListComponent {
 
 	@Output() public availableChange = new EventEmitter();
 
-	@Input() public displayAttr: string;
 	@Input() public initialAvailableColumns: Array<TwoListItem>;
 	@Input() public defaultVisibleColumns: Array<TwoListItem>;
 	@Input() public defaultHiddenColumns: Array<TwoListItem>;

--- a/src/app/systelab-components/twolist/two-list.component.ts
+++ b/src/app/systelab-components/twolist/two-list.component.ts
@@ -120,7 +120,7 @@ export class TwoListComponent {
 				break;
 			}
 			for (let j = 0; j < length; j++) {
-				if (actual.displayName === list[j].displayName) {
+				if (actual.colId === list[j].colId) {
 					arrayAux.push(j);
 					break;
 				}
@@ -149,7 +149,7 @@ export class TwoListComponent {
 		for (const element of list) {
 			let match = false;
 			for (const item of itemsToRemove) {
-				if (item[this.displayAttr] === element[this.displayAttr]) {
+				if (item.colId === element.colId) {
 					match = true;
 					break;
 				}


### PR DESCRIPTION
Make the lists use the colId (that is unique) instead of the displayName to sort and move from list1 to list2