### PR TITLE
Fix  abstract-combobox.component.ts, method “set code” #163

### DIFF
--- a/src/app/systelab-components/combobox/abstract-combobox.component.ts
+++ b/src/app/systelab-components/combobox/abstract-combobox.component.ts
@@ -152,7 +152,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 				this._code = item[this.getCodeField()];
 			}
 		}
-		this.codeChange.emit(this._description);
+		this.codeChange.emit(this._code);
 	}
 
 	get code() {


### PR DESCRIPTION
The method "set code" in abstract-combobox.component.ts was emitting the value of "this._description" instead of "this._code". This was found while testing "AutocompleteApiComboBox".