### PR TITLE
Addig to dialog-ref.ts constructor a check to avoid closing the dialog

### DIFF
--- a/src/app/systelab-components/modal/dialog/dialog-ref.ts
+++ b/src/app/systelab-components/modal/dialog/dialog-ref.ts
@@ -14,7 +14,7 @@ export class DialogRef<T extends SystelabModalContext> {
 				.subscribe(
 					() => this.close());
 		}
-		if (context.showClose === undefined || context.showClose) {
+		if (context.showClose) {
 			overlayRef.keydownEvents()
 				.subscribe((k) => {
 					if (k.code === DialogRef.ESCAPE_KEY) {

--- a/src/app/systelab-components/modal/dialog/dialog-ref.ts
+++ b/src/app/systelab-components/modal/dialog/dialog-ref.ts
@@ -14,12 +14,14 @@ export class DialogRef<T extends SystelabModalContext> {
 				.subscribe(
 					() => this.close());
 		}
-		overlayRef.keydownEvents()
-			.subscribe((k) => {
-				if (k.code === DialogRef.ESCAPE_KEY) {
-					this.close();
-				}
-			});
+		if (context.showClose === undefined || context.showClose) {
+			overlayRef.keydownEvents()
+				.subscribe((k) => {
+					if (k.code === DialogRef.ESCAPE_KEY) {
+						this.close();
+					}
+				});
+		}
 	}
 
 	public closeAllDialogs() {

--- a/src/app/systelab-components/modal/dialog/modal-context.ts
+++ b/src/app/systelab-components/modal/dialog/modal-context.ts
@@ -28,7 +28,7 @@ export class SystelabModalContext {
 	public isBlocking = true;
 	public keyboard = null;
 
-	public showClose: boolean;
+	public showClose = true;
 
 	public setDefaultSize(w: number, h: number) {
 		if (!this.width) {


### PR DESCRIPTION
Addig to dialog-ref.ts constructor a check to avoid closing the dialog when pressing ESC key. See #189.
- only if context.showClose is undefined or true the ESC key works. The check on undefined has been added because there are some popup windows that don't have defined "showClose" property and they are inteded to be closed when hitting ESC.