### PR TITLE
Include position in the modals and arrow like a context panel

### DIFF
--- a/src/app/showcase/components/dialog/showcase-dialog.component.html
+++ b/src/app/showcase/components/dialog/showcase-dialog.component.html
@@ -1,23 +1,27 @@
 <div class="container-fluid">
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showLowerFlexDialog();">Form + lower flex textarea
+            (click)="showLowerFlexDialog()">Form + lower flex textarea
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showTwoTabsDialog();">Two tab rows
+            (click)="showTwoTabsDialog()">Two tab rows
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showTwoColumnsDialog();">Two columns
+            (click)="showTwoColumnsDialog()">Two columns
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showCalendarDialog();">Calendar
+            (click)="showCalendarDialog($event)">Calendar
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showFullFlexDialog();">Flex
+            (click)="showFullFlexDialog()">Flex
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showSplitDialog();">Split
+            (click)="showSplitDialog()">Split
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showStandardDialog();">Standard
+            (click)="showStandardDialog()">Standard
     </button>
+    <button type="button" class="btn mt-2 mr-1" #btnContextModal
+            (click)="showCalendarWithPositionDialog($event)">Calendar with position
+    </button>
+
 </div>

--- a/src/app/showcase/components/dialog/showcase-dialog.component.html
+++ b/src/app/showcase/components/dialog/showcase-dialog.component.html
@@ -9,7 +9,7 @@
             (click)="showTwoColumnsDialog()">Two columns
     </button>
     <button type="button" class="btn mt-2 mr-1"
-            (click)="showCalendarDialog($event)">Calendar
+            (click)="showCalendarDialog()">Calendar
     </button>
     <button type="button" class="btn mt-2 mr-1"
             (click)="showFullFlexDialog()">Flex
@@ -21,7 +21,7 @@
             (click)="showStandardDialog()">Standard
     </button>
     <button type="button" class="btn mt-2 mr-1" #btnContextModal
-            (click)="showCalendarWithPositionDialog($event)">Calendar with position
+            (click)="showCalendarWithPositionDialog()">Calendar with position
     </button>
 
 </div>

--- a/src/app/showcase/components/dialog/showcase-dialog.component.ts
+++ b/src/app/showcase/components/dialog/showcase-dialog.component.ts
@@ -34,12 +34,12 @@ export class ShowcaseDialogComponent {
 		this.dialogService.showDialog(ShowcaseSplitDialog, parameters);
 	}
 
-	public showCalendarDialog(event) {
+	public showCalendarDialog() {
 		const parameters: CalendarDialogParameters = CalendarDialog.getParameters();
 		this.dialogService.showDialog(CalendarDialog, parameters);
 	}
 
-	public showCalendarWithPositionDialog(event) {
+	public showCalendarWithPositionDialog() {
 		const parameters: CalendarDialogParameters = CalendarDialog.getParameters();
 		parameters.width = 800;
 		parameters.positionX = this.btnContextModal.nativeElement.offsetLeft;

--- a/src/app/showcase/components/dialog/showcase-dialog.component.ts
+++ b/src/app/showcase/components/dialog/showcase-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { LowerFlexDialogParameters, ShowcaseLowerFlexDialog } from './lower-flex/showcase-lower-flex-dialog.component';
 import { ShowcaseSplitDialog, SplitShowcaseDialogParameters } from './split/showcase-split-dialog.component';
 import { CalendarDialog, CalendarDialogParameters } from '../../../systelab-components/calendar/calendar-dialog.component';
@@ -9,10 +9,11 @@ import { ShowcaseStandardDialog } from './standard-dialog/showcase-standard-dial
 import { DialogService } from '../../../systelab-components/modal';
 
 @Component({
-	selector:    'showcase-dialog',
+	selector: 'showcase-dialog',
 	templateUrl: 'showcase-dialog.component.html',
 })
 export class ShowcaseDialogComponent {
+	@ViewChild('btnContextModal') btnContextModal: ElementRef;
 
 	constructor(protected dialogService: DialogService) {
 	}
@@ -33,8 +34,18 @@ export class ShowcaseDialogComponent {
 		this.dialogService.showDialog(ShowcaseSplitDialog, parameters);
 	}
 
-	public showCalendarDialog() {
+	public showCalendarDialog(event) {
 		const parameters: CalendarDialogParameters = CalendarDialog.getParameters();
+		this.dialogService.showDialog(CalendarDialog, parameters);
+	}
+
+	public showCalendarWithPositionDialog(event) {
+		const parameters: CalendarDialogParameters = CalendarDialog.getParameters();
+		parameters.width = 800;
+		parameters.positionX = this.btnContextModal.nativeElement.offsetLeft;
+		parameters.positionY = this.btnContextModal.nativeElement.offsetTop;
+		parameters.isBlocking = false;
+		parameters.isContextDialog = true;
 		this.dialogService.showDialog(CalendarDialog, parameters);
 	}
 
@@ -65,5 +76,4 @@ export class ShowcaseDialogComponent {
 	public showStandardDialog() {
 		this.dialogService.showDialog(ShowcaseStandardDialog, ShowcaseStandardDialog.getParameters());
 	}
-
 }

--- a/src/app/systelab-components/modal/dialog/dialog.service.ts
+++ b/src/app/systelab-components/modal/dialog/dialog.service.ts
@@ -40,10 +40,32 @@ export class DialogService {
 			config.maxHeight = parameters.maxHeight ? parameters.maxHeight : parameters.maxHeightRelative;
 		}
 		config.hasBackdrop = true;
-		config.positionStrategy = this.overlay.position()
-			.global()
-			.centerHorizontally()
-			.centerVertically();
+
+		if (parameters.isContextDialog && parameters.positionX && parameters.positionY) {
+			config.panelClass = ['slab-context-modal', 'slab-context-modal-arrow-center'];
+			const screenWidth = window.innerWidth;
+			let positionX = parameters.positionX - (parameters.width / 2);
+			if ((positionX + parameters.width) > screenWidth) {
+				positionX = screenWidth - parameters.width;
+				config.panelClass = ['slab-context-modal', 'slab-context-modal-arrow-right'];
+			} else if (positionX < 0 ) {
+				positionX = parameters.positionX - (parameters.positionX / 2);
+				config.panelClass = ['slab-context-modal', 'slab-context-modal-arrow-left'];
+			}
+			const positionY = parameters.positionY + 50;
+			positionX = ((positionX / screenWidth) * 100) + 5;
+
+			config.positionStrategy = this.overlay.position()
+				.global().left(positionX
+				.toString() + '%')
+				.top(positionY.toString() + 'px');
+		} else {
+			config.positionStrategy = this.overlay.position()
+				.global()
+				.centerHorizontally()
+				.centerVertically();
+		}
+
 		config.scrollStrategy = this.overlay.scrollStrategies.block();
 
 		return config;

--- a/src/app/systelab-components/modal/dialog/modal-context.ts
+++ b/src/app/systelab-components/modal/dialog/modal-context.ts
@@ -23,10 +23,14 @@ export class SystelabModalContext {
 	public maxWidthRelative: string = null;
 	public maxHeightRelative: string = null;
 
+	public positionX;
+	public positionY;
+
 	public fullScreen = false;
 
 	public isBlocking = true;
 	public keyboard = null;
+	public isContextDialog = false;
 
 	public showClose = true;
 

--- a/src/app/systelab-components/sass/_dialog.scss
+++ b/src/app/systelab-components/sass/_dialog.scss
@@ -300,3 +300,47 @@ $slab-button-size-dialog-header: $slab-button-size !default;
     }
   }
 }
+
+
+/* Context Modal styles
+   ========================================================================== */
+   .slab-context-modal{
+    .slab-dialog-header {
+      &:after{
+        bottom: 100% !important;
+        border: solid transparent;
+        content: " ";
+        height: 0;
+        width: 0;
+        position: absolute;
+        pointer-events: none;
+      }
+      &:after {
+        border-bottom-color: lightgray;
+        border-width: 20px !important;
+        margin-left: -30px !important;
+      }
+    }
+  }
+
+  .slab-context-modal-arrow-center {
+    .slab-dialog-header {
+      &:after{
+        left: 50%;
+      }
+    }
+  }
+  .slab-context-modal-arrow-right {
+    .slab-dialog-header {
+      &:after{
+        right: 5%;
+      }
+    }
+  }
+  .slab-context-modal-arrow-left {
+    .slab-dialog-header {
+      &:after{
+        left: 5%;
+      }
+    }
+  }


### PR DESCRIPTION
 Include in the dialogs the option to be positioned, defining the "x" and "y" and also include styles for the arrow like the context panels
ISSUE #196 