### PR TITLE
Fix Combo custom height after migration to Angular 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/src/app/systelab-components/combobox/abstract-combobox.component.ts
+++ b/src/app/systelab-components/combobox/abstract-combobox.component.ts
@@ -184,7 +184,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	@ViewChild('dropdownmenu', {static: false}) public dropdownMenuElement: ElementRef;
 	@ViewChild('dropdown', {static: true}) public dropdownElement: ElementRef;
 	@ViewChild('input', {static: false}) public inputElement: ElementRef;
-	@ViewChild('hidden', {static: false}) public hiddenElement: ElementRef;
+	@ViewChild('hidden', {static: true}) public hiddenElement: ElementRef;
 
 	public filterValue = '';
 	public currentSelected: any = {};


### PR DESCRIPTION
Fix Combo custom height after migration to Angular 8 (#257) 