### PR TITLE
AbstractApiTreeListBox: Select parent/child nodes.

### DIFF
--- a/src/app/systelab-components/listbox/README.md
+++ b/src/app/systelab-components/listbox/README.md
@@ -247,6 +247,7 @@ In black the Two-Way Data Binding properties.
 | **selectedIDList** | string | | Ids of selected elements separated by comma. Each Id contains a prefix to indicate if selected element is parent or child (defined in getSelectionPrefix method). Only when multipleSelection=true |
 | isDisabled | boolean | false | If true the listbox is disabled  |
 | multipleSelection | boolean | false | Enable to select multiple elements. A checkbox will be rendered in front of each element. |
+| updateHierarchy | boolean | true | If true, the parent/child nodes will be updated when selecting a child/parent node |
 
 In black the Two-Way Data Binding properties.
 

--- a/src/app/systelab-components/listbox/abstract-api-tree-listbox.component.ts
+++ b/src/app/systelab-components/listbox/abstract-api-tree-listbox.component.ts
@@ -235,7 +235,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	}
 
 	private selectUnselectChildTree(event: any) {
-		this.treeValues.filter((value: TreeListBoxElement<T>) => {
+		this.treeValues.forEach((value: TreeListBoxElement<T>) => {
 			if (value.nodeData[this.getIdField(0)] === event.nodeData[this.getIdField(0)]) {
 				value.selected = event.selected;
 				this.addRemoveToMultipleSelectedItem(value);
@@ -247,7 +247,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		const parentID = event.nodeData[this.getIdField(0)];
 		let allChildSelected = true;
 		let anyNode = false;
-		this.treeValues.filter((value: TreeListBoxElement<T>) => {
+		this.treeValues.forEach((value: TreeListBoxElement<T>) => {
 			if (value.nodeData[this.getIdField(0)] === parentID) {
 				anyNode = true;
 				if (!value.selected && value.level === 1) {
@@ -256,7 +256,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 			}
 		});
 		if (anyNode) {
-			this.treeValues.filter((value: TreeListBoxElement<T>) => {
+			this.treeValues.forEach((value: TreeListBoxElement<T>) => {
 				if (value.level === 0 && value.nodeData[this.getIdField(0)] === parentID) {
 					value.selected = allChildSelected;
 					this.addRemoveToMultipleSelectedItem(value);

--- a/src/app/systelab-components/listbox/abstract-api-tree-listbox.component.ts
+++ b/src/app/systelab-components/listbox/abstract-api-tree-listbox.component.ts
@@ -22,6 +22,8 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	public treeValues: Array<TreeListBoxElement<T>> = [];
 	@ViewChild('hidden', {static: true}) public hiddenElement: ElementRef;
 
+	@Input() public updateHierarchy = true;
+
 	public _selectedTreeItem: TreeListBoxElement<T>;
 
 	@Input()
@@ -217,33 +219,11 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	public changeValues(event: any) {
 		if (this.multipleSelection) {
 			this.addRemoveToMultipleSelectedItem(event);
-
-			if (event.level === 0) {
-				this.treeValues.filter((value: TreeListBoxElement<T>) => {
-					if (value.nodeData[this.getIdField(0)] === event.nodeData[this.getIdField(0)]) {
-						value.selected = event.selected;
-						this.addRemoveToMultipleSelectedItem(value);
-					}
-				});
-			} else {
-				const parentID = event.nodeData[this.getIdField(0)];
-				let allChildSelected = true;
-				let anyNode = false;
-				this.treeValues.filter((value: TreeListBoxElement<T>) => {
-					if (value.nodeData[this.getIdField(0)] === parentID) {
-						anyNode = true;
-						if (!value.selected && value.level === 1) {
-							allChildSelected = false;
-						}
-					}
-				});
-				if (anyNode) {
-					this.treeValues.filter((value: TreeListBoxElement<T>) => {
-						if (value.level === 0 && value.nodeData[this.getIdField(0)] === parentID) {
-							value.selected = allChildSelected;
-							this.addRemoveToMultipleSelectedItem(value);
-						}
-					});
+			if (this.updateHierarchy) {
+				if (event.level === 0) {
+					this.selectUnselectChildTree(event);
+				} else {
+					this.selectUnselectParentTree(event);
 				}
 			}
 			this.selectedIDListChange.emit(this.selectedIDList);
@@ -252,7 +232,37 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 			this.gridOptions.api.doLayout();
 			this.gridOptions.api.sizeColumnsToFit();
 		}
+	}
 
+	private selectUnselectChildTree(event: any) {
+		this.treeValues.filter((value: TreeListBoxElement<T>) => {
+			if (value.nodeData[this.getIdField(0)] === event.nodeData[this.getIdField(0)]) {
+				value.selected = event.selected;
+				this.addRemoveToMultipleSelectedItem(value);
+			}
+		});
+	}
+
+	private selectUnselectParentTree(event: any) {
+		const parentID = event.nodeData[this.getIdField(0)];
+		let allChildSelected = true;
+		let anyNode = false;
+		this.treeValues.filter((value: TreeListBoxElement<T>) => {
+			if (value.nodeData[this.getIdField(0)] === parentID) {
+				anyNode = true;
+				if (!value.selected && value.level === 1) {
+					allChildSelected = false;
+				}
+			}
+		});
+		if (anyNode) {
+			this.treeValues.filter((value: TreeListBoxElement<T>) => {
+				if (value.level === 0 && value.nodeData[this.getIdField(0)] === parentID) {
+					value.selected = allChildSelected;
+					this.addRemoveToMultipleSelectedItem(value);
+				}
+			});
+		}
 	}
 
 	private addRemoveToMultipleSelectedItem(event: any) {


### PR DESCRIPTION
Add an input to define if the parent/child nodes should be updated when selecting a child/parent node. By default remains true for compatibility. Issue #292