### PR TITLE
Fix Two or more AbstractApiTreeListBox cannot be used together because the checkboxes ids are duplicated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "9.7.6",
+  "version": "9.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "9.7.6",
+  "version": "9.7.7",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/src/app/systelab-components/listbox/renderer/abstract-tree-listbox-renderer.component.html
+++ b/src/app/systelab-components/listbox/renderer/abstract-tree-listbox-renderer.component.html
@@ -1,10 +1,10 @@
 <div class="d-flex column">
     <div *ngIf="isMultipleSelection">
         <div class="slab-flex-1" [style.marginLeft.px]="(level*20)+1">
-            <input type="checkbox" id="{{level}}-{{id}}" [(ngModel)]="params.data.selected"
+            <input type="checkbox" id="{{checkId}}-{{level}}-{{id}}" [(ngModel)]="params.data.selected"
                    [disabled]="params.isDisabled"
                    (change)="changeValue()">
-            <label for="{{level}}-{{id}}">{{description}}</label>
+            <label for="{{checkId}}-{{level}}-{{id}}">{{description}}</label>
         </div>
     </div>
     <div *ngIf="!isMultipleSelection" class="d-flex slab-flex-1">

--- a/src/app/systelab-components/listbox/renderer/abstract-tree-listbox-renderer.component.ts
+++ b/src/app/systelab-components/listbox/renderer/abstract-tree-listbox-renderer.component.ts
@@ -14,6 +14,7 @@ export class AbstractTreeListboxRendererComponent implements AgRendererComponent
 	public description: string;
 	public level: number;
 	public isMultipleSelection = false;
+	public checkId: string = (Math.floor(Math.random() * (999999999999 - 1))).toString();
 
 	public agInit(params: any): void {
 		this.params = params;


### PR DESCRIPTION
Two or more AbstractApiTreeListBox cannot be used together because the checkboxes ids are duplicated #357