### PR TITLE
#408 Getting warning in console ag-grid: invalid gridOptions property…

### DIFF
--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -79,7 +79,6 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 			resizable: this.isColResizeEnabled()
 		};
 		options.rowSelection = this.getRowSelectionType();
-		options.rowDeselection = true;
 		options.localeText = {
 			noRowsToShow: this.i18nService.instant('COMMON_NO_ROWS_TO_SHOW'),
 			loadingOoo:   this.i18nService.instant('COMMON_LOADING')

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -94,7 +94,6 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		if (this.multipleSelection) {
 			this.gridOptions.suppressRowClickSelection = true;
 		} else {
-			this.gridOptions.rowDeselection = true;
 			this.gridOptions.suppressRowClickSelection = this.isDisabled;
 		}
 

--- a/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
@@ -95,7 +95,7 @@ export abstract class AbstractListBox<T> implements OnInit {
 		this.gridOptions.defaultColDef = {};
 		this.gridOptions.defaultColDef.resizable = false;
 		this.gridOptions.rowSelection = this.multipleSelection ? 'multiple' : 'single';
-		this.gridOptions.rowDeselection = !this.isDisabled;
+		this.gridOptions.suppressRowDeselection = this.isDisabled;
 
 		this.gridOptions.context = {componentParent: this};
 


### PR DESCRIPTION
Fix #408

_since v24.x, rowDeselection is deprecated and the behaviour is true by default. Please use `suppressRowDeselection` to prevent rows from being deselected._