### PR TITLE
#422 Document how to contribute and PR template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,11 @@ The process described here has several goals:
 
 Please follow these steps to have your contribution considered by the maintainers:
 
-1. This repository is aligned with the feature-branch strategy.
+1. This repository is aligned with the feature-branch strategy. The branch naming convention is "bugfix- or feature-" plus the issue number in github. For example: bugfix_200
 2. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
-3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
-4. While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
-5. Once it's merged, the author must transition it to the status "Ready to test" in the [project](https://github.com/systelab/systelab-components/projects)
-6. Based upon need, the library will be published into the npm repository. This process must be done by an authorized user.
-
+3. The changes can be tested in your local before publishing. The library can be generated at "..\dist\systelab-components" by running the command "npm run build-lib". Then, you need to replace the systelab-components folder at "your project > node-modules > systelab-components". Please, ensure the package.json matches the version that you need to test.
+4. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
+5. While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+7. Before merging the pull request, the master branch needs to be merged into current. Then, the version in the package.json needs to be increased.
+6. Once it's merged, the author must transition it to the status "Ready to test" in the [project](https://github.com/systelab/systelab-components/projects)
+7. Based upon need, the library will be published into the npm repository. This process must be done by an authorized user.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to an Angular library
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to the Angular libraries, which are hosted in [Werfen](https://github.com/systelab) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[Code of Conduct](#code-of-conduct)
+
+[I don't want to read this whole thing, I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+  * [systelab-components](#systelab-components)
+  * [Coding Guidelines](#coding-guidelines)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Pull Requests](#pull-requests)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). 
+
+## I don't want to read this whole thing I just have a question!!!
+
+> **Note:** Please don't file an issue to ask a question. You'll get faster results by using the resources below.
+
+We have an Angular Task Force to help you. Please, reach out the channel in Teams.
+
+## What should I know before I get started?
+
+### systelab-components
+
+[Read about the library](README.md)
+
+#### Coding Guidelines
+
+[Coding Guidelines](CODING_GUIDELINES.md)
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for an Angular library. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on the repository and provide the following information by filling in [the template](https://github.com/systelab/systelab-components/blob/master/.github/ISSUE_TEMPLATE/bug_report.md).
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started with the library, e.g. which command exactly you used in the terminal, or how you started it otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you moved the cursor to the end of a line, explain if you used the mouse, or a keyboard shortcut, and if so which one?
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots** which help you demonstrate the steps or point out the part of library which the suggestion is related to.
+* **If you're reporting it crashed**, include a crash report with a stack trace.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an enhancement on the repository and provide the following information by filling in [the template](https://github.com/systelab/systelab-components/blob/master/.github/ISSUE_TEMPLATE/feature_request.md).
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots** which help you demonstrate the steps or point out the part of library which the suggestion is related to.
+
+### Pull Requests
+
+The process described here has several goals:
+
+- Maintain library's quality
+- Fix problems that are important to users
+- Engage the community in working toward the best possible library
+- Enable a sustainable system for library's maintainers to review contributions
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. This repository is aligned with the feature-branch strategy.
+2. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
+4. While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+5. Once it's merged, the author must transition it to the status "Ready to test" in the [project](https://github.com/systelab/systelab-components/projects)
+6. Based upon need, the library will be published into the npm repository. This process must be done by an authorized user.
+

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+# PR Details
+
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail. Do not repeat the Issue description. -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Docs change / refactoring / dependency upgrade
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have read the **CONTRIBUTING** document
+- [ ] My code follows the code style of this project
+- [ ] My change requires a change to the documentation 
+- [ ] I have updated the documentation accordingly (README.md for each UI component)
+- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
+- [ ] All new and existing tests passed
+- [ ] A new branch needs to be created from master to evolve previous versions
+- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
+- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
+- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)


### PR DESCRIPTION
This is based on an example of contribution guidelines published by github at https://docs.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors

All the considerations before creating a PR are included as a checklist in the PR template to make it more clear. Refer to the new file PULL_REQUEST_TEMPLATE.md.

Please, review also the CODING_GUIDELINES.md page that refers to https://github.com/systelab/systelab-angular-doc for Code Conventions.

A template to create the bugs and features already exists, please, review bug_report.md and feature_request.md at https://github.com/atom/.github/tree/master/.github/ISSUE_TEMPLATE

