### PR TITLE
Disabled ToggleButtonComponent responds to click event on the icon

### DIFF
--- a/projects/systelab-components/src/lib/toggle-button/toggle-button.component.html
+++ b/projects/systelab-components/src/lib/toggle-button/toggle-button.component.html
@@ -1,1 +1,3 @@
-<button type="button" class="btn" [class.btn-outline-primary]="!isChecked" [class.btn-primary]="isChecked" [disabled]="disabled"><ng-content></ng-content></button>
+<span (click)="doToggle($event)">
+    <button type="button" class="btn" [class.btn-outline-primary]="!isChecked" [class.btn-primary]="isChecked" [disabled]="disabled"><ng-content></ng-content></button>
+</span>

--- a/projects/systelab-components/src/lib/toggle-button/toggle-button.component.ts
+++ b/projects/systelab-components/src/lib/toggle-button/toggle-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
 	selector:    'systelab-toggle-button',
@@ -32,9 +32,10 @@ export class ToggleButtonComponent {
 		return this.element.nativeElement.id;
 	}
 
-	@HostListener('click')
-	public onToggle() {
-		if (!this.disabled) {
+	public doToggle(event: any) {
+		if (this.disabled) {
+			event.stopPropagation();
+		} else {
 			this.isChecked = !this.isChecked;
 		}
 	}


### PR DESCRIPTION
# PR Details

Fix to the issue "Disabled ToggleButtonComponent responds to click event on the icon."

## Description

Fixed by wrapping the template with a span which implements the click event.
Then in the handler we prevent the propagation of the event in case it's triggered from the child (icon).
In the old way with @HostListener directive, the call to event.stopPropagation did not work.

## Related Issue

When a ToggleButtonComponent has an icon embeded, the icon responds to the click event even if the toggle button is disabled.

https://github.com/systelab/systelab-components/issues/454

## Motivation and Context

Toggle buttons with icons ae not very common but when used that issue can lead to unexpecting UI behavior.

## How Has This Been Tested

I've tested the issue in the same library (in the showcase) and in another client project (QUANTA LINK).
It has been tested through exploratory under the following browsers: Chrome, JxBrowser, Opera, Firefox and Edge.
The change affects only the systelab-toggle-button component (template & typescript), specifically the way it binds the click event.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
