### PR TITLE
Disabled ToggleButtonComponent responds to click event on the icon #454

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/toggle-button/toggle-button.component.html
+++ b/projects/systelab-components/src/lib/toggle-button/toggle-button.component.html
@@ -1,1 +1,3 @@
-<button type="button" class="btn" [class.btn-outline-primary]="!isChecked" [class.btn-primary]="isChecked" [disabled]="disabled"><ng-content></ng-content></button>
+<span (click)="doToggle($event)">
+    <button type="button" class="btn" [class.btn-outline-primary]="!isChecked" [class.btn-primary]="isChecked" [disabled]="disabled"><ng-content></ng-content></button>
+</span>

--- a/projects/systelab-components/src/lib/toggle-button/toggle-button.component.spec.ts
+++ b/projects/systelab-components/src/lib/toggle-button/toggle-button.component.spec.ts
@@ -12,15 +12,18 @@ import { ToggleButtonComponent } from './toggle-button.component';
 @Component({
 	selector: 'systelab-toggle-button-test',
 	template: `
-                <div>
-                    <systelab-toggle-button [(isChecked)]="check">My Toggle Button</systelab-toggle-button>
-                    <label class="label-value">{{check}}</label>
-                </div>
+        <div>
+            <systelab-toggle-button [(isChecked)]="check" [disabled]="disabled">
+                <i class="icon-plus-circle"></i>My Toggle Button
+            </systelab-toggle-button>
+            <label class="label-value">{{check}}</label>
+        </div>
 	          `,
 	styles:   []
 })
 export class ToggleButtonTestComponent {
 	public check = true;
+	public disabled = false;
 }
 
 describe('Systelab Toggle Button', () => {
@@ -65,6 +68,22 @@ describe('Systelab Toggle Button', () => {
 		clickSwitch(fixture);
 		checkHasValue(fixture, true);
 	});
+
+	it('should not change value if is clicked when is disabled', () => {
+		fixture.componentInstance.disabled = true;
+		clickSwitch(fixture);
+		checkHasValue(fixture, false);
+		clickSwitch(fixture);
+		checkHasValue(fixture, false);
+	});
+
+	it('should not change value if icon is clicked when is disabled', () => {
+		fixture.componentInstance.disabled = true;
+		clickOnIconSwitch(fixture);
+		checkHasValue(fixture, false);
+		clickOnIconSwitch(fixture);
+		checkHasValue(fixture, false);
+	});
 });
 
 function checkHasValue(fixture: ComponentFixture<ToggleButtonTestComponent>, value: boolean) {
@@ -80,6 +99,12 @@ function setValue(fixture: ComponentFixture<ToggleButtonTestComponent>, value: b
 
 function clickSwitch(fixture: ComponentFixture<ToggleButtonTestComponent>) {
 	const button = fixture.debugElement.nativeElement.querySelector('.btn');
+	button.click();
+	fixture.detectChanges();
+}
+
+function clickOnIconSwitch(fixture: ComponentFixture<ToggleButtonTestComponent>) {
+	const button = fixture.debugElement.nativeElement.querySelector('.btn i');
 	button.click();
 	fixture.detectChanges();
 }

--- a/projects/systelab-components/src/lib/toggle-button/toggle-button.component.spec.ts
+++ b/projects/systelab-components/src/lib/toggle-button/toggle-button.component.spec.ts
@@ -69,7 +69,7 @@ describe('Systelab Toggle Button', () => {
 		checkHasValue(fixture, true);
 	});
 
-	it('should not change value if is clicked when is disabled', () => {
+	it('should not change value if is clicked when disabled', () => {
 		fixture.componentInstance.disabled = true;
 		clickSwitch(fixture);
 		checkHasValue(fixture, false);
@@ -77,7 +77,7 @@ describe('Systelab Toggle Button', () => {
 		checkHasValue(fixture, false);
 	});
 
-	it('should not change value if icon is clicked when is disabled', () => {
+	it('should not change value if icon is clicked when disabled', () => {
 		fixture.componentInstance.disabled = true;
 		clickOnIconSwitch(fixture);
 		checkHasValue(fixture, false);

--- a/projects/systelab-components/src/lib/toggle-button/toggle-button.component.ts
+++ b/projects/systelab-components/src/lib/toggle-button/toggle-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
 	selector:    'systelab-toggle-button',
@@ -32,9 +32,10 @@ export class ToggleButtonComponent {
 		return this.element.nativeElement.id;
 	}
 
-	@HostListener('click')
-	public onToggle() {
-		if (!this.disabled) {
+	public doToggle(event: any) {
+		if (this.disabled) {
+			event.stopPropagation();
+		} else {
 			this.isChecked = !this.isChecked;
 		}
 	}


### PR DESCRIPTION
# PR Details

Fix to the issue "Disabled ToggleButtonComponent responds to click event on the icon."
Note: This PR is a replicate of https://github.com/systelab/systelab-components/pull/463 (already merged) but for the branch of the library in Angular 10.

## Description

Fixed by wrapping the template with a \<span\> which implements the click event.
Then in the handler we prevent the propagation of the event in case it's triggered from the child (icon).
In the old way with @HostListener directive, the _stopPropagation_ call did not work.

## Related Issue

When a ToggleButtonComponent has an icon embeded, the icon responds to the click event even if the toggle button is disabled.

https://github.com/systelab/systelab-components/issues/454

## Motivation and Context

Toggle buttons with icons are not very common but when used that issue can lead to unexpecting UI behavior.

## How Has This Been Tested

I've tested the issue in the same library (in the showcase) and in another client project.
It has been tested through exploratory under the following browsers: Chrome, JxBrowser, Opera, Firefox and Edge.
The change affects only the _systelab-toggle-button_ component (template & typescript), specifically the way it binds the click event.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)