### PR TITLE
Bugfix #487 Fix Grids row context menu is displayed in the wrong position

### DIFF
--- a/projects/systelab-components/src/lib/contextmenu/abstract-context.component.ts
+++ b/projects/systelab-components/src/lib/contextmenu/abstract-context.component.ts
@@ -50,6 +50,9 @@ export abstract class AbstractContextComponent<T> implements OnInit, OnDestroy {
 	protected loop(x: number, y: number): void {
 		if (this.isDropDownOpened()) {
 			this.myRenderer.setStyle(this.dropdownMenuElement.nativeElement, 'position', 'fixed');
+			if (this.isEmbedded) {
+				this.myRenderer.setStyle(this.dropdownMenuElement.nativeElement, 'transform', 'unset');
+			}
 			this.myRenderer.setStyle(this.dropdownElement.nativeElement, 'position', 'absolute');
 			y = y - this.dropdownParent.nativeElement.offsetHeight;
 			if (y + this.dropdownElement.nativeElement.offsetHeight > window.innerHeight) {


### PR DESCRIPTION
Fix Grids row context menu is displayed in the wrong position

Context menus are using bootstrap dropdowns and when viewport is scrolled bootstrap is applying a transformation. When this context-menu are embedded in grids this transformation is wrong relative to the scroll, since the position calculation the library applies is already ok, we can remove the transformation.

Related Issue: #487


## How Has This Been Tested

Manually testing context-menus in grids, and in non embedded way.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
