### PR TITLE
Fix AOT error with keyUpBounce directive

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.2.2",
+  "version": "13.2.3",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -90,6 +90,7 @@ import { AutoCompleteModule } from 'primeng/autocomplete';
 import { SpyMenuComponent } from './spy-menu/spy-menu.component';
 import { ScrollSpyDirective } from './spy-menu/scroll-spy.directive';
 import { ToastComponent } from './toast/toast.component';
+import { KeyupDebounceDirective } from './directives/keyup-debounce.directive';
 
 @NgModule({
 	imports:      [
@@ -182,6 +183,7 @@ import { ToastComponent } from './toast/toast.component';
 		SpyMenuComponent,
 		ScrollSpyDirective,
 		ToastComponent,
+		KeyupDebounceDirective
 	],
 	exports:      [
 		SliderComponent,
@@ -258,7 +260,8 @@ import { ToastComponent } from './toast/toast.component';
 		ChipsComponent,
 		SpyMenuComponent,
 		ScrollSpyDirective,
-		ToastComponent
+		ToastComponent,
+		KeyupDebounceDirective,
 	],
 	providers:    [
 		StylesUtilService,


### PR DESCRIPTION
Fix AOT error with keyUpBounce directive
Publish 13.2.3 patch version

## Related Issue

#175 

## Motivation and Context

This issues contained an error when compiling with AOT using the library 



## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
