### PR TITLE
#433 Add email, url and phone custom validations to use in forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng serve",
     "build-showcase": "ng build showcase --configuration production",
     "build-lib": "ng build systelab-components --configuration production",
     "postbuild-lib": "npm run copytemplates",

--- a/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.html
+++ b/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.html
@@ -1,0 +1,41 @@
+
+  <div class="container-fluid">
+    <form [formGroup]="inputValidationForm" (ngSubmit)="onFormSubmit()">
+        <div class="row mt-1">
+            <label class="col-md-3 col-form-label" for="full-width-input">Email validation</label>
+            <div class="col-md-9">
+                <input formControlName="email" class="form-control" 
+                placeholder="Email" id="full-width-input">
+                <div *ngIf="email?.errors?.email"> 
+                    Email not valid.
+                </div>	
+            </div>
+        </div>
+        <div class="row mt-1">
+            <label class="col-md-3 col-form-label" for="full-width-input">Phone validation</label>
+            <div class="col-md-9">
+              <input formControlName="phone" class="form-control" 
+                placeholder="Phone" id="full-width-input">
+                <div [hidden]="phone.valid || phone.pristine"> 
+                    Phone not valid.
+                </div>	
+            </div>
+        </div>
+        <div class="row mt-1">
+            <label class="col-md-3 col-form-label" for="third-width-input">Url validation</label>
+            <div class="col-md-9">
+              <input formControlName="url" class="form-control" 
+                placeholder="Url" id="full-width-input">
+              <div *ngIf="url?.errors?.url">  
+                    Url not valid.
+                </div>
+            </div>
+        </div>
+        <div class="row mt-1">
+            <button type="submit" [disabled]="!inputValidationForm.valid">Submit</button>
+        </div>        
+      </form>
+</div>
+
+
+  

--- a/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { AbstractControl, FormBuilder } from '@angular/forms';
 import { emailValidator, phoneValidator, urlValidator } from 'systelab-components';
 
 @Component({
@@ -13,19 +13,19 @@ export class ShowcaseInputReactiveFormsValidationsComponent implements OnInit {
     phone :['', phoneValidator],
     url :['', urlValidator],
 
-  })
+  });
   constructor(private formBuilder: FormBuilder) { }
 
   ngOnInit(): void {
   }
 
-  get email() {
+  get email(): AbstractControl {
     return this.inputValidationForm.get('email');
   }
-  get phone() {
+  get phone(): AbstractControl {
     return this.inputValidationForm.get('phone');
-  }  
-  get url() {
+  }
+  get url(): AbstractControl {
     return this.inputValidationForm.get('url');
   }    
 

--- a/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
@@ -27,7 +27,7 @@ export class ShowcaseInputReactiveFormsValidationsComponent implements OnInit {
   }
   get url(): AbstractControl {
     return this.inputValidationForm.get('url');
-  }    
+  }
 
   onFormSubmit(): void{
     if (this.inputValidationForm.invalid) {

--- a/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { emailValidator, phoneValidator, urlValidator } from 'systelab-preferences';
+import { emailValidator, phoneValidator, urlValidator } from 'systelab-components';
 
 @Component({
   selector: 'showcase-input-reactive-forms-validations',

--- a/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-reactive-forms-validations.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { emailValidator, phoneValidator, urlValidator } from 'systelab-preferences';
+
+@Component({
+  selector: 'showcase-input-reactive-forms-validations',
+  templateUrl: './showcase-input-reactive-forms-validations.component.html'
+})
+export class ShowcaseInputReactiveFormsValidationsComponent implements OnInit {
+
+  inputValidationForm = this.formBuilder.group({
+    email :['', emailValidator],
+    phone :['', phoneValidator],
+    url :['', urlValidator],
+
+  })
+  constructor(private formBuilder: FormBuilder) { }
+
+  ngOnInit(): void {
+  }
+
+  get email() {
+    return this.inputValidationForm.get('email');
+  }
+  get phone() {
+    return this.inputValidationForm.get('phone');
+  }  
+  get url() {
+    return this.inputValidationForm.get('url');
+  }    
+
+  onFormSubmit(): void{
+    if (this.inputValidationForm.invalid) {
+      return;
+    }
+    this.inputValidationForm.reset();
+  }
+}

--- a/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.html
+++ b/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.html
@@ -1,0 +1,38 @@
+<div class="container-fluid">
+    <form #inputValidationsForm="ngForm" (ngSubmit)="onFormSubmit(inputValidationsForm)">
+        <div class="row mt-1">
+            <label class="col-md-3 col-form-label" for="full-width-input">Email validation</label>
+            <div class="col-md-9">
+                <input [(ngModel)]="info.email" name='email' emailValidator
+                    #emailInput="ngModel" class="form-control" placeholder="Email" id="full-width-input">
+                <div *ngIf="emailInput.errors?.email"> 
+                    Email not valid.
+                </div>	
+            </div>
+        </div>
+        <div class="row mt-1">
+            <label class="col-md-3 col-form-label" for="full-width-input">Phone validation</label>
+            <div class="col-md-9">
+                <input [(ngModel)]="info.phone" name='phone' phoneValidator
+                    #phoneInput="ngModel" class="form-control" placeholder="Phone" id="full-width-input">
+                <div [hidden]="phoneInput.valid || phoneInput.pristine"> 
+                    Phone not valid.
+                </div>	
+            </div>
+        </div>
+        <div class="row mt-1">
+            <label class="col-md-3 col-form-label" for="third-width-input">Url validation</label>
+            <div class="col-md-9">
+                <input [(ngModel)]="info.url" name='url' urlValidator
+                    #urlInput="ngModel" class="form-control" placeholder="Url" id="full-width-input">
+                <div *ngIf="urlInput.errors?.url"> 
+                    Url not valid.
+                </div>
+            </div>
+        </div>
+        <div class="row mt-1">
+            <button type="submit" [disabled]="!inputValidationsForm.form.valid">Submit</button>
+        </div>        
+      </form>
+</div>
+

--- a/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.html
+++ b/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.html
@@ -3,7 +3,7 @@
         <div class="row mt-1">
             <label class="col-md-3 col-form-label" for="full-width-input">Email validation</label>
             <div class="col-md-9">
-                <input [(ngModel)]="info.email" name='email' emailValidator
+                <input [(ngModel)]="info.email" name='email' systelab-emailValidator
                     #emailInput="ngModel" class="form-control" placeholder="Email" id="full-width-input">
                 <div *ngIf="emailInput.errors?.email"> 
                     Email not valid.
@@ -13,7 +13,7 @@
         <div class="row mt-1">
             <label class="col-md-3 col-form-label" for="full-width-input">Phone validation</label>
             <div class="col-md-9">
-                <input [(ngModel)]="info.phone" name='phone' phoneValidator
+                <input [(ngModel)]="info.phone" name='phone' systelab-phoneValidator
                     #phoneInput="ngModel" class="form-control" placeholder="Phone" id="full-width-input">
                 <div [hidden]="phoneInput.valid || phoneInput.pristine"> 
                     Phone not valid.
@@ -23,7 +23,7 @@
         <div class="row mt-1">
             <label class="col-md-3 col-form-label" for="third-width-input">Url validation</label>
             <div class="col-md-9">
-                <input [(ngModel)]="info.url" name='url' urlValidator
+                <input [(ngModel)]="info.url" name='url' systelab-urlValidator
                     #urlInput="ngModel" class="form-control" placeholder="Url" id="full-width-input">
                 <div *ngIf="urlInput.errors?.url"> 
                     Url not valid.

--- a/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { NgForm } from '@angular/forms';
+
+@Component({
+	selector:    'showcase-input-template-driven-form-validations',
+	templateUrl: 'showcase-input-template-driven-form-validations.component.html'
+})
+export class ShowcaseInputTemplateDrivenFormValidationsComponent {
+
+   public info = new Info('','','');
+   public submitted = false;
+
+	constructor() {		
+	}
+
+	onFormSubmit(form: NgForm) {
+        this.submitted = false;
+
+        if (form.invalid) {
+           return;
+        }
+        this.submitted = true;
+        form.resetForm();
+     }
+}
+
+export class Info {
+   constructor(public email: string, public phone: string, public url: string) { }
+}

--- a/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.ts
@@ -1,6 +1,10 @@
 import { Component } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
+class Info {
+   constructor(public email: string, public phone: string, public url: string) { }
+}
+
 @Component({
 	selector:    'showcase-input-template-driven-form-validations',
 	templateUrl: 'showcase-input-template-driven-form-validations.component.html'
@@ -13,7 +17,7 @@ export class ShowcaseInputTemplateDrivenFormValidationsComponent {
 	constructor() {
 	}
 
-	onFormSubmit(form: NgForm) : void{
+	onFormSubmit(form: NgForm): void{
         this.submitted = false;
 
         if (form.invalid) {
@@ -24,6 +28,3 @@ export class ShowcaseInputTemplateDrivenFormValidationsComponent {
      }
 }
 
-export class Info {
-   constructor(public email: string, public phone: string, public url: string) { }
-}

--- a/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.ts
+++ b/projects/showcase/src/app/components/input/showcase-input-template-driven-form-validations.component.ts
@@ -10,10 +10,10 @@ export class ShowcaseInputTemplateDrivenFormValidationsComponent {
    public info = new Info('','','');
    public submitted = false;
 
-	constructor() {		
+	constructor() {
 	}
 
-	onFormSubmit(form: NgForm) {
+	onFormSubmit(form: NgForm) : void{
         this.submitted = false;
 
         if (form.invalid) {

--- a/projects/showcase/src/app/components/showcase-components.component.html
+++ b/projects/showcase/src/app/components/showcase-components.component.html
@@ -2,6 +2,12 @@
     <showcase-title>Input</showcase-title>
     <showcase-input></showcase-input>
 
+    <showcase-title>Template driven forms input Validation</showcase-title>
+    <showcase-input-template-driven-form-validations></showcase-input-template-driven-form-validations>
+    
+    <showcase-title>Reactive forms input Validation</showcase-title>
+    <showcase-input-reactive-forms-validations></showcase-input-reactive-forms-validations>
+
     <showcase-title [href]="'file-selector'">File Selector</showcase-title>
     <showcase-file-selector></showcase-file-selector>
 

--- a/projects/showcase/src/app/showcase.module.ts
+++ b/projects/showcase/src/app/showcase.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { ShowcaseComponent } from './showcase.component';
 import { GridContextMenuCellRendererComponent, GridHeaderContextMenuComponent, SystelabComponentsModule } from 'systelab-components';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SystelabTranslateModule } from 'systelab-translate';
 import { SystelabPreferencesModule } from 'systelab-preferences';
 import { HttpClientModule } from '@angular/common/http';
@@ -31,6 +31,8 @@ import { ShowcaseTextareaComponent } from './components/textarea/showcase-textar
 import { ShowcaseDatepickerComponent } from './components/datepicker/showcase-datepicker.component';
 import { ShowcaseComboboxComponent } from './components/combobox/showcase-combobox.component';
 import { ShowcaseInputComponent } from './components/input/showcase-input.component';
+import { ShowcaseInputTemplateDrivenFormValidationsComponent } from './components/input/showcase-input-template-driven-form-validations.component';
+import { ShowcaseInputReactiveFormsValidationsComponent } from './components/input/showcase-input-reactive-forms-validations.component';
 import { ShowcaseTableComponent } from './components/table/showcase-table.component';
 import { ShowcaseGridComponent } from './components/grid/showcase-grid.component';
 import { ShowcaseInnerApiGridComponent } from './components/grid/showcase-inner-api-grid.component';
@@ -96,6 +98,7 @@ import { ShowcaseButtonComponent } from './components/button/showcase-button.com
 		BrowserModule,
 		BrowserAnimationsModule,
 		FormsModule,
+		ReactiveFormsModule,
 		DragDropModule,
 		OverlayModule,
 		TreeModule,
@@ -123,6 +126,8 @@ import { ShowcaseButtonComponent } from './components/button/showcase-button.com
 		ShowcaseSliderComponent,
 		ShowcaseTooltipComponent,
 		ShowcaseInputComponent,
+		ShowcaseInputTemplateDrivenFormValidationsComponent,
+		ShowcaseInputReactiveFormsValidationsComponent,
 		ShowcaseButtonStylesComponent,
 		ShowcaseButtonComponent,
 		ShowcaseIconComponent,

--- a/projects/showcase/src/app/showcase.module.ts
+++ b/projects/showcase/src/app/showcase.module.ts
@@ -31,7 +31,7 @@ import { ShowcaseTextareaComponent } from './components/textarea/showcase-textar
 import { ShowcaseDatepickerComponent } from './components/datepicker/showcase-datepicker.component';
 import { ShowcaseComboboxComponent } from './components/combobox/showcase-combobox.component';
 import { ShowcaseInputComponent } from './components/input/showcase-input.component';
-import { ShowcaseInputTemplateDrivenFormValidationsComponent } 
+import { ShowcaseInputTemplateDrivenFormValidationsComponent }
 	from './components/input/showcase-input-template-driven-form-validations.component';
 import { ShowcaseInputReactiveFormsValidationsComponent } from './components/input/showcase-input-reactive-forms-validations.component';
 import { ShowcaseTableComponent } from './components/table/showcase-table.component';

--- a/projects/showcase/src/app/showcase.module.ts
+++ b/projects/showcase/src/app/showcase.module.ts
@@ -31,7 +31,8 @@ import { ShowcaseTextareaComponent } from './components/textarea/showcase-textar
 import { ShowcaseDatepickerComponent } from './components/datepicker/showcase-datepicker.component';
 import { ShowcaseComboboxComponent } from './components/combobox/showcase-combobox.component';
 import { ShowcaseInputComponent } from './components/input/showcase-input.component';
-import { ShowcaseInputTemplateDrivenFormValidationsComponent } from './components/input/showcase-input-template-driven-form-validations.component';
+import { ShowcaseInputTemplateDrivenFormValidationsComponent } 
+	from './components/input/showcase-input-template-driven-form-validations.component';
 import { ShowcaseInputReactiveFormsValidationsComponent } from './components/input/showcase-input-reactive-forms-validations.component';
 import { ShowcaseTableComponent } from './components/table/showcase-table.component';
 import { ShowcaseGridComponent } from './components/grid/showcase-grid.component';

--- a/projects/showcase/src/app/showcase.module.ts
+++ b/projects/showcase/src/app/showcase.module.ts
@@ -92,6 +92,9 @@ import { KeyupDebounceDirective } from '../../../systelab-components/src/lib/dir
 import { ShowcaseInnerGroupColumnsGridComponent } from './components/grid/showcase-inner-group-columns-grid.component';
 import { ShowcaseToggleSelectorComponent } from './components/toggle-selector/showcase-toggle-selector.component';
 import { ShowcaseButtonComponent } from './components/button/showcase-button.component';
+import { EmailValidatorDirective } from 'projects/systelab-components/src/lib/forms/validators/email-validator.directive';
+import { UrlValidatorDirective } from 'projects/systelab-components/src/lib/forms/validators/url-validator.directive';
+import { PhoneValidatorDirective } from 'projects/systelab-components/src/lib/forms/validators/phone-validator.directive';
 
 @NgModule({
 	imports:      [
@@ -192,7 +195,10 @@ import { ShowcaseButtonComponent } from './components/button/showcase-button.com
 		ShowcaseVerticaldDialog,
 		ShowcaseToastComponent,
 		ShowcaseToggleSelectorComponent,
-		KeyupDebounceDirective
+		KeyupDebounceDirective,
+		EmailValidatorDirective,
+		PhoneValidatorDirective,
+		UrlValidatorDirective
 	],
 	bootstrap:    [ShowcaseComponent]
 })

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.3.0",
+  "version": "13.3.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/forms/README.md
+++ b/projects/systelab-components/src/lib/forms/README.md
@@ -116,4 +116,3 @@ For the moment, but this is something that will be improved, you can indicate in
 To validate for email, phone or url inputs you can use the custom validators created:
 
 [validators](validators) 
-

--- a/projects/systelab-components/src/lib/forms/README.md
+++ b/projects/systelab-components/src/lib/forms/README.md
@@ -113,3 +113,7 @@ The styles for the forms are defined in the forms.scss Saas file.
 
 For the moment, but this is something that will be improved, you can indicate invalid and valid form fields with .is-invalid and .is-valid classes.
 
+To validate for email, phone or url inputs you can use the custom validators created:
+
+[validators](validators) 
+

--- a/projects/systelab-components/src/lib/forms/validators/README.md
+++ b/projects/systelab-components/src/lib/forms/validators/README.md
@@ -1,0 +1,66 @@
+# Validators
+
+Custom validators to validate inputs. Available validators are for email, phone and url. 
+The validators can be used with Reactive Forms and Template-driven Forms.
+
+## Using validators on Templete-driven form
+
+You can use validation on the template using any of the directives available: emailValidator, phoneValidator or urlValidator.
+
+```Html
+<input [(ngModel)]="info.email" name='email' emailValidator
+     #emailInput="ngModel" class="form-control" placeholder="Email" id="full-width-input">
+<div *ngIf="emailInput.errors?.email"> 
+     Email not valid.
+</div>	
+```
+
+```Html
+<input [(ngModel)]="info.phone" name='phone' phoneValidator
+    #phoneInput="ngModel" class="form-control" placeholder="Phone" id="full-width-input">
+<div [hidden]="phoneInput.valid || phoneInput.pristine"> 
+    Phone not valid.
+</div>	
+```
+
+```Html
+<input [(ngModel)]="info.url" name='url' urlValidator
+    #urlInput="ngModel" class="form-control" placeholder="Url" id="full-width-input">
+<div *ngIf="urlInput.errors?.url"> 
+    Url not valid.
+</div>
+```
+
+## Using validators on Reactive forms
+You can use validation on the reactive forms by setting the validator function when construct the form
+
+```typescript
+inputValidationForm = this.formBuilder.group({
+    email :['', emailValidator],
+    phone :['', phoneValidator],
+    url :['', urlValidator],
+  })
+  ```
+```Html
+<input formControlName="email" class="form-control" 
+    placeholder="Email" id="full-width-input">
+<div *ngIf="email?.errors?.email"> 
+    Email not valid.
+</div>	
+```
+
+```Html
+<input formControlName="phone" class="form-control" 
+    placeholder="Phone" id="full-width-input">
+<div [hidden]="phone.valid || phone.pristine"> 
+    Phone not valid.
+</div>
+```
+
+```Html
+<input formControlName="url" class="form-control" 
+    placeholder="Url" id="full-width-input">
+<div *ngIf="url?.errors?.url">  
+    Url not valid.
+</div>
+```

--- a/projects/systelab-components/src/lib/forms/validators/README.md
+++ b/projects/systelab-components/src/lib/forms/validators/README.md
@@ -3,12 +3,12 @@
 Custom validators to validate inputs. Available validators are for email, phone and url. 
 The validators can be used with Reactive Forms and Template-driven Forms.
 
-## Using validators on Templete-driven form
+## Using validators on Template-driven form
 
 You can use validation on the template using any of the directives available: emailValidator, phoneValidator or urlValidator.
 
 ```Html
-<input [(ngModel)]="info.email" name='email' emailValidator
+<input [(ngModel)]="info.email" name='email' systelab-emailValidator
      #emailInput="ngModel" class="form-control" placeholder="Email" id="full-width-input">
 <div *ngIf="emailInput.errors?.email"> 
      Email not valid.
@@ -16,7 +16,7 @@ You can use validation on the template using any of the directives available: em
 ```
 
 ```Html
-<input [(ngModel)]="info.phone" name='phone' phoneValidator
+<input [(ngModel)]="info.phone" name='phone' systelab-phoneValidator
     #phoneInput="ngModel" class="form-control" placeholder="Phone" id="full-width-input">
 <div [hidden]="phoneInput.valid || phoneInput.pristine"> 
     Phone not valid.
@@ -24,7 +24,7 @@ You can use validation on the template using any of the directives available: em
 ```
 
 ```Html
-<input [(ngModel)]="info.url" name='url' urlValidator
+<input [(ngModel)]="info.url" name='url' systelab-urlValidator
     #urlInput="ngModel" class="form-control" placeholder="Url" id="full-width-input">
 <div *ngIf="urlInput.errors?.url"> 
     Url not valid.

--- a/projects/systelab-components/src/lib/forms/validators/email-validator.directive.spec.ts
+++ b/projects/systelab-components/src/lib/forms/validators/email-validator.directive.spec.ts
@@ -41,9 +41,6 @@ describe('Email validation', () => {
 	].forEach((email) => {
 		it('Check that ' + email + ' is not valid', () => {
 			expect(emailValidator(new FormControl(email))).toEqual({email});
-			var a = true;
-			jasmine.addMatchers
-			expect(a).toBeFalse
 		});
 	});
 });

--- a/projects/systelab-components/src/lib/forms/validators/email-validator.directive.spec.ts
+++ b/projects/systelab-components/src/lib/forms/validators/email-validator.directive.spec.ts
@@ -1,0 +1,49 @@
+import { FormControl } from '@angular/forms';
+import { emailValidator } from './email-validator.directive';
+
+describe('Email validation', () => {
+	beforeEach(() => {
+	});
+
+	[	'valid@email.com',
+		'valid@email.c',
+		'v@email.com',
+		'valid@l.com',
+		'valid@email.com',
+		'v@email.com',
+		'firstname.lastname@example.com',
+		'email@subdomain.example.com',
+		'firstname+lastname@example.com',
+		'1234567890@example.com',
+		'email@example-one.com',
+		'_______@example.com',
+		'email@example.name',
+		'email@example.museum',
+		'email@example.co.jp',
+		'firstname-lastname@example.com'
+	].forEach((email) => {
+		it('Check that ' + email + ' is valid', () => {
+			expect(emailValidator(new FormControl(email))).toEqual(null);
+		});
+	});
+
+	[	'plainaddress',
+		'#@%^%#$@#$@#.com',
+		'@example.com',
+		'Joe Smith <email@example.com>',
+		'email.example.com',
+		'email@example@example.com',
+		'あいうえお@example.com',
+		'email@example.com (Joe Smith)',
+		'email@example',
+		'email@-example.com',
+		'email@example..com',
+	].forEach((email) => {
+		it('Check that ' + email + ' is not valid', () => {
+			expect(emailValidator(new FormControl(email))).toEqual({email});
+			var a = true;
+			jasmine.addMatchers
+			expect(a).toBeFalse
+		});
+	});
+});

--- a/projects/systelab-components/src/lib/forms/validators/email-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/email-validator.directive.ts
@@ -10,7 +10,7 @@ export const emailValidator = (control: FormControl): ValidationErrors | null =>
 };
 
 @Directive({
-  selector: '[emailValidator]',
+  selector: '[systelab-emailValidator]',
   providers: [{
       provide: NG_VALIDATORS,
       useExisting: EmailValidatorDirective,

--- a/projects/systelab-components/src/lib/forms/validators/email-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/email-validator.directive.ts
@@ -1,0 +1,27 @@
+import {FormControl, NG_VALIDATORS,ValidationErrors, Validator} from '@angular/forms';
+import {Directive} from '@angular/core';
+
+export const emailValidator = (control: FormControl): ValidationErrors | null => {
+  const regExp = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+  return regExp.test(control.value) ? null : {
+    email: control.value
+  };
+};
+
+@Directive({
+  selector: '[emailValidator]',
+  providers: [{
+      provide: NG_VALIDATORS,
+      useExisting: EmailValidatorDirective,
+      multi: true
+  }]
+})
+export class EmailValidatorDirective implements Validator {
+  validate(control: FormControl): ValidationErrors | null {
+      return emailValidator(control);
+  }
+}
+
+
+

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.spec.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.spec.ts
@@ -5,7 +5,9 @@ describe('Phone validation', () => {
 	beforeEach(() => {
 	});
 
-	[	'900 703 030',
+	[	'93.885.05.00',
+		'(0034) 886708865',
+		'900703030',
 		'111111111111111111111111',
 		'938550500',
 		'886787654',
@@ -16,13 +18,12 @@ describe('Phone validation', () => {
 		});
 	});
 
-	[	'93.885.05.00',
-		'(0034) 886708865',
+	[	'900 703 030',
 		'textphone',
 		'888sometext888',
 		'a12332e323',
 	].forEach((phone) => {
-		it('Check that ' + phone + ' is valid', () => {
+		it('Check that ' + phone + ' is invalid', () => {
 			expect(phoneValidator(new FormControl(phone))).toEqual({
 				phone
 			  });

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.spec.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.spec.ts
@@ -5,28 +5,51 @@ describe('Phone validation', () => {
 	beforeEach(() => {
 	});
 
-	[	'93.885.05.00',
-		'(0034) 886708865',
-		'900703030',
-		'111111111111111111111111',
-		'938550500',
-		'886787654',
-		'+34 888888888',
-	].forEach((phone) => {
-		it('Check that ' + phone + ' is valid', () => {
-			expect(phoneValidator(new FormControl(phone))).toEqual(null);
+	[	{description: 'Number with 9 digits', text: '939999999', expected: true},
+		{description: 'International prefix with 00', text: '0034939999999', expected: true},
+		{description: 'International prefix with 00 and spaces', text: '0034 93 999 99 99', expected: true},
+		{description: 'International prefix with ()', text: '(34)939999999', expected: true},
+		{description: 'International prefix with () and space after )', text: '(34) 939999999', expected: true},
+		{description: 'International prefix with () and 00', text: '(0034)939999999', expected: true},
+		{description: 'International prefix with () and 00 and separator after )', text: '(0034)-939999999', expected: true},
+		{description: 'International prefix with +', text: '+34939999999', expected: true},
+		{description: 'Number with - separator', text: '93-9999999', expected: true},
+		{description: 'Number with . separator', text: '93.9999999', expected: true},
+		{description: 'Number with more than one . separator', text: '93.999.99.99', expected: true},
+		{description: 'Number with space separator', text: '93 9999999', expected: true},
+		{description: 'Number with more than one space separator', text: '93 999 99 99', expected: true},
+		{description: 'Italian short number', text: '0225221', expected: true},
+		{description: 'Italian international short number', text: '+39 0225221', expected: true},
+		{description: 'Italian mobile number', text: '335 784 5058', expected: true},
+		{description: 'Italian international mobile number', text: '+39 335 784 5058', expected: true},
+		{description: 'Spanish mobile number with spaces', text: '695 21 81 54', expected: true},
+		{description: 'Spanish mobile number groups of three', text: '695 218 154', expected: true},
+		{description: 'Spanish mobile number no spaces', text: '695218154', expected: true},
+		{description: 'Eight digit number', text: '69521815', expected: true},
+		{description: 'International with just one number and no parentesis', text: '1-800-955-9525', expected: true},
+		{description: 'International with just one number and +', text: '+1 800 955 9525', expected: true},
+		{description: 'International with just one number and 00', text: '001 800 955 9525', expected: true},
+		{description: 'International with just one number and separators', text: '+1 858-586-9900', expected: true},
+		{description: 'International with three number', text: '(351) 93 393 66 26', expected: true},
+		{description: 'International with three number and +', text: '+351 93 393 66 26', expected: true},
+		{description: 'International with three number and 00', text: '00351 93 393 66 26', expected: true},
+		,//
+		
+	].forEach((test) => {
+		it(test.description + ' "' + test.text + '" is valid', () => {
+			expect(phoneValidator(new FormControl(test.text))).toBeNull();
 		});
 	});
 
-	[	'900 703 030',
-		'textphone',
-		'888sometext888',
-		'a12332e323',
-	].forEach((phone) => {
-		it('Check that ' + phone + ' is invalid', () => {
-			expect(phoneValidator(new FormControl(phone))).toEqual({
-				phone
-			  });
+	[	{description: 'International prefix with () and +', text: '(+34)939999999', expected: false},
+		{description: 'Strange characters number', text: '@/()*345678', expected: false},
+		{description: 'Separators for each number', text: '93 3 9 3 6 6 2 6', expected: false},
+		{description: 'Group with only one number', text: '93 393 66 2 6', expected: false},
+		{description: 'Alphabetical phone', text: 'textphone', expected: false},
+		{description: 'Alphanumeric phone', text: '888sometext888', expected: false},
+	].forEach((test) => {
+		it(test.description + '"' + test.text + '" is not valid', () => {
+			expect(phoneValidator(new FormControl(test.text))).not.toBeNull();
 		});
 	});
 });

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.spec.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.spec.ts
@@ -1,0 +1,31 @@
+import { FormControl } from '@angular/forms';
+import { phoneValidator } from './phone-validator.directive';
+
+describe('Phone validation', () => {
+	beforeEach(() => {
+	});
+
+	[	'900 703 030',
+		'111111111111111111111111',
+		'938550500',
+		'886787654',
+		'+34 888888888',
+	].forEach((phone) => {
+		it('Check that ' + phone + ' is valid', () => {
+			expect(phoneValidator(new FormControl(phone))).toEqual(null);
+		});
+	});
+
+	[	'93.885.05.00',
+		'(0034) 886708865',
+		'textphone',
+		'888sometext888',
+		'a12332e323',
+	].forEach((phone) => {
+		it('Check that ' + phone + ' is valid', () => {
+			expect(phoneValidator(new FormControl(phone))).toEqual({
+				phone
+			  });
+		});
+	});
+});

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
@@ -2,8 +2,11 @@ import {FormControl, NG_VALIDATORS,ValidationErrors, Validator} from '@angular/f
 import {Directive} from '@angular/core';
 
 export const phoneValidator = (control: FormControl): ValidationErrors | null => {
-  const regExp = /^(\+{1}\d{2,3}\s?[(]{1}\d{1,3}[)]{1}\s?\d+|\+\d{2,3}\s{1}\d+|\d+){1}[\s|-]?\d+([\s|-]?\d+){1,2}$/;
-
+  const phonePattern: string = '(([+][(]?[0-9]{1,3}[)]?)|([(]?([0]{2})?[0-9]{1,3}[)]?)|\s*)\s*[)]?[-\s\.]?[(]?[0-9]{0,4}[)]' + 
+    '?([-\s\.]?[0-9]{2,3})([-\s\.]?[0-9]{2,3})([-\s\.]?[0-9]{2,3})';
+  
+  const regExp = new RegExp(phonePattern);
+    
   return regExp.test(control.value) ? null : {
     phone: control.value
   };

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
@@ -2,12 +2,9 @@ import {FormControl, NG_VALIDATORS,ValidationErrors, Validator} from '@angular/f
 import {Directive} from '@angular/core';
 
 export const phoneValidator = (control: FormControl): ValidationErrors | null => {
-  const phonePattern: string = '(([+][(]?[0-9]{1,3}[)]?)|([(]?([0]{2})?[0-9]{1,3}[)]?)|\s*)\s*[)]?[-\s\.]?[(]?[0-9]{0,4}[)]' + 
-    '?([-\s\.]?[0-9]{2,3})([-\s\.]?[0-9]{2,3})([-\s\.]?[0-9]{2,3})';
+  const phoneRegex: RegExp =/^(([+][(]?[0-9]{1,3}[)]?)|([(]?([0]{2})?[0-9]{1,3}[)]?)|\s*)\s*[)]?[-\s\.]?[(]?[0-9]{0,4}[)]?([-\s\.]?[0-9]{2,3})([-\s\.]?[0-9]{2,3})([-\s\.]?[0-9]{2,3})$/;
   
-  const regExp = new RegExp(phonePattern);
-    
-  return regExp.test(control.value) ? null : {
+  return  phoneRegex.test(control.value) ? null : {
     phone: control.value
   };
 };

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
@@ -1,0 +1,27 @@
+import {FormControl, NG_VALIDATORS,ValidationErrors, Validator} from '@angular/forms';
+import {Directive} from '@angular/core';
+
+export const phoneValidator = (control: FormControl): ValidationErrors | null => {
+  const regExp = /^(\+{1}\d{2,3}\s?[(]{1}\d{1,3}[)]{1}\s?\d+|\+\d{2,3}\s{1}\d+|\d+){1}[\s|-]?\d+([\s|-]?\d+){1,2}$/;
+
+  return regExp.test(control.value) ? null : {
+    phone: control.value
+  };
+};
+
+@Directive({
+  selector: '[phoneValidator]',
+  providers: [{
+      provide: NG_VALIDATORS,
+      useExisting: PhoneValidatorDirective,
+      multi: true
+  }]
+})
+export class PhoneValidatorDirective implements Validator {
+  validate(control: FormControl): ValidationErrors | null {
+      return phoneValidator(control);
+  }
+}
+
+
+

--- a/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/phone-validator.directive.ts
@@ -10,7 +10,7 @@ export const phoneValidator = (control: FormControl): ValidationErrors | null =>
 };
 
 @Directive({
-  selector: '[phoneValidator]',
+  selector: '[systelab-phoneValidator]',
   providers: [{
       provide: NG_VALIDATORS,
       useExisting: PhoneValidatorDirective,

--- a/projects/systelab-components/src/lib/forms/validators/url-validator.directive.spec.ts
+++ b/projects/systelab-components/src/lib/forms/validators/url-validator.directive.spec.ts
@@ -1,0 +1,48 @@
+import { FormControl } from '@angular/forms';
+import { urlValidator } from './url-validator.directive';
+
+describe('Url validation', () => {
+	beforeEach(() => {
+	});
+
+	[	'plainUrl',
+		'https://myDomain.com',
+		'http://myDomain.cat',
+		'https://www.myDomain.com',
+		'http://www.myDomain.cat',
+		'https://www.myDomain.com:80',
+		'http://www.myDomain.cat:80',
+		'myDomain.com',
+		'www.myDomain.com',
+		'ftp://foo:host.com/',
+		'ftp://host.com/',
+		'ftp://foo:host.com:21',
+	].forEach((url) => {
+		it('Check that ' + url + ' is valid', () => {
+			expect(urlValidator(new FormControl(url))).toEqual(null);
+		});
+	});
+
+	[	'htt://myDomain.com',
+		'http:///myDomain.com',
+		'https:///myDomain.com',
+		'http:/www.myDomain.com',
+		'https:/www.myDomain.cat',
+		'http:/www.myDomain.com:81',
+		'https:/www.myDomain.cat:81',
+		'http://.com',
+		'https://.com',
+		'http://www.urlWithLargeDomainExtension@domain.LargeExtension',
+		'https://www.urlWithLargeDomainExtension@domain.LargeExtension',
+		'.com',
+		'myDomain.',
+		'urlWithLargeDomainExtension@domain.LargeExtension',
+		'ftp:/foo:host.com',
+	].forEach((url) => {
+		it('Check that ' + url + ' is not valid', () => {
+			expect(urlValidator(new FormControl(url))).toEqual({
+				url
+			  });
+		});
+	});
+});

--- a/projects/systelab-components/src/lib/forms/validators/url-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/url-validator.directive.ts
@@ -1,0 +1,39 @@
+import {FormControl, NG_VALIDATORS,ValidationErrors, Validator} from '@angular/forms';
+import {Directive} from '@angular/core';
+
+export const urlValidator = (control: FormControl): ValidationErrors | null => {
+  const urlPattern: string = '^((https|http|ftp|rtsp|mms)?://)'
+    + '?(([0-9a-z_!~*\'().&=+$%-]+: )?[0-9a-z_!~*\'().&=+$%-]+@)?' //ftp user@
+    + '(([0-9]{1,3}\.){3}[0-9]{1,3}" // IP URL- 199.194.52.184'
+    + '|'
+    + '([0-9a-z_!~*\'()-]+\.)*' // - www.
+    + '([0-9a-z][0-9a-z-]{0,61})?[0-9a-z]\.'
+    + '[a-z]{2,6})' // first level domain- .com or .museum
+    + '(:[0-9]{1,4})?' //- :80
+    + '((/?)|' // a slash isn't required if there is no file name
+    + '(/[0-9a-z_!~*\'().;?:@&=+$,%#-]+)+/?)$';
+
+    const regExp = new RegExp(urlPattern);
+
+    return regExp.test(control.value) ? null : {
+      url: control.value
+  };
+};
+
+@Directive({
+  selector: '[urlValidator]',
+  providers: [{
+      provide: NG_VALIDATORS,
+      useExisting: UrlValidatorDirective,
+      multi: true
+  }]
+})
+export class UrlValidatorDirective implements Validator {
+
+  validate(control: FormControl): ValidationErrors | null {
+      return urlValidator(control);
+  }
+}
+
+
+

--- a/projects/systelab-components/src/lib/forms/validators/url-validator.directive.ts
+++ b/projects/systelab-components/src/lib/forms/validators/url-validator.directive.ts
@@ -21,7 +21,7 @@ export const urlValidator = (control: FormControl): ValidationErrors | null => {
 };
 
 @Directive({
-  selector: '[urlValidator]',
+  selector: '[systelab-urlValidator]',
   providers: [{
       provide: NG_VALIDATORS,
       useExisting: UrlValidatorDirective,

--- a/projects/systelab-components/src/public-api.ts
+++ b/projects/systelab-components/src/public-api.ts
@@ -124,3 +124,7 @@ export * from './lib/spy-menu/spy-menu.component';
 export * from './lib/spy-menu/scroll-spy.directive';
 
 export * from './lib/toggle-selector/toggle-selector.component';
+
+export * from './lib/forms/validators/email-validator.directive';
+export * from './lib/forms/validators/phone-validator.directive';
+export * from './lib/forms/validators/url-validator.directive';


### PR DESCRIPTION
# PR Details

Add validators for email, phone and url inputs in forms

## Description

Added three custom validators (email, phone and url) to use for validating forms. It can be used in template-driven forms as a directive or in Reactive forms

## Related Issue

#433, #532

## Motivation and Context

To use the same way to validate email, phone and url form inputs through systelab angular projects

## How Has This Been Tested

I created a showcase example of using the validators and tested entering valid and invalid inputs and viewing if invalid messages are showing when invalid input.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
