### PR TITLE
Feature 534

### DIFF
--- a/projects/showcase/src/app/components/message-popup/showcase-message-popup.component.html
+++ b/projects/showcase/src/app/components/message-popup/showcase-message-popup.component.html
@@ -9,8 +9,26 @@
             class="icon-info-circle mr-1"></i>Information
     </systelab-button>
     <systelab-button class="mt-2 mr-1" (action)="showQuestionYN()"><i
-            class="icon-question-circle mr-1"></i>Question YN
+            class="icon-question-circle mr-1"></i>Question YN No template
     </systelab-button>
+    <systelab-button class="mt-2 mr-1" (action)="showQuestionYN('primary')"><i
+        class="icon-question-circle mr-1"></i>Question YN Primary
+	</systelab-button>
+	<systelab-button class="mt-2mr-1" (action)="showQuestionYN('outline-primary')"><i
+        class="icon-question-circle mr-1"></i>Question YN Outline Primary
+	</systelab-button>
+	<systelab-button class="mt-2mr-1" (action)="showQuestionYN('warning')"><i
+        class="icon-question-circle mr-1"></i>Question YN Warning
+	</systelab-button>
+	<systelab-button class="mt-2mr-1" (action)="showQuestionYN('outline-warning')"><i
+        class="icon-question-circle mr-1"></i>Question YN Outline Warning
+	</systelab-button>
+	<systelab-button class="mt-2mr-1" (action)="showQuestionYN('danger')"><i
+        class="icon-question-circle mr-1"></i>Question YN Danger
+	</systelab-button>
+	<systelab-button class="mt-2mr-1" (action)="showQuestionYN('outline-danger')"><i
+        class="icon-question-circle mr-1"></i>Question YN Outline Danger
+	</systelab-button>
     <systelab-button class="mt-2 mr-1" (action)="showCustomized()">Custom
     </systelab-button>
 

--- a/projects/showcase/src/app/components/message-popup/showcase-message-popup.component.ts
+++ b/projects/showcase/src/app/components/message-popup/showcase-message-popup.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
-import { MessagePopupService, MessagePopupButton } from 'systelab-components';
-import { MessagePopupIcon } from 'systelab-components';
+import { MessagePopupButton, MessagePopupIcon, MessagePopupService } from 'systelab-components';
 
 @Component({
 	selector: 'showcase-message-popup',
@@ -29,8 +28,8 @@ export class ShowcaseMessagePopupComponent {
 
 	}
 
-	public showQuestionYN() {
-		this.messagePopupService.showYesNoQuestionPopup('Test', 'Error message popup example', null, 800, 600)
+	public showQuestionYN(template?:string) {
+		this.messagePopupService.showYesNoQuestionPopup('Test', 'Error message popup example', null, 800, 600, template)
 			.subscribe((v) => {
 				console.log('Observable returned to showcase', v);
 			});

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.3.3",
+  "version": "13.3.4",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/modal/message-popup/README.md
+++ b/projects/systelab-components/src/lib/modal/message-popup/README.md
@@ -41,8 +41,19 @@ public showInformationPopup(titleDescription: string, messageDescription: string
 Use showYesNoQuestionPopup to show a yes/no popup with a question icon.
 
 ```javascript
-public showYesNoQuestionPopup(titleDescription: string, messageDescription: string, modalClass?: string, width?: number, height?: number): Observable<any>
+public showYesNoQuestionPopup(titleDescription: string, messageDescription: string, modalClass?: string, width?: number, height?: number, template?: string): Observable<any>
 ```
+Current available templates are the following:
+
+| Template | String value | Example |
+| ---- |:----------:| ------------|
+| No template | ```null``` | ![image](https://user-images.githubusercontent.com/5593621/148924691-09aed4e2-ae37-4a07-95a8-a03bfbf479b9.png) |
+| Primary | ```primary``` | ![image](https://user-images.githubusercontent.com/5593621/148924854-bdf0765c-7f55-4782-bad6-9094bf722a6e.png) |
+| Outline primary | ```outline-primary``` | ![image](https://user-images.githubusercontent.com/5593621/148924973-e221d2ca-438d-406c-818d-4d4116092767.png) |
+| Warning | ```warning``` | ![image](https://user-images.githubusercontent.com/5593621/148925148-abb303d1-174a-49d6-a8a0-523151c5e0b0.png) |
+| Outline warning | ```outline-warning```  | ![image](https://user-images.githubusercontent.com/5593621/148925187-87e0be42-4a37-483c-819b-438ca2cef24b.png) |
+| Danger | ```danger``` | ![image](https://user-images.githubusercontent.com/5593621/148925237-7af6c3a0-9769-4bdf-8d28-0affa801587a.png) |
+| Outline Danger | ```outline-danger``` | ![image](https://user-images.githubusercontent.com/5593621/148925269-b9a80e61-acc4-41f8-b9dc-e91ce656dda1.png) |
 
 Use showCustomQuestionPopup to show a popup with custom buttons and a question icon.
 

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.spec.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.spec.ts
@@ -1,0 +1,83 @@
+import { OverlayModule } from '@angular/cdk/overlay';
+import { HttpClientModule } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { DialogRef, DialogService } from "systelab-components";
+import { I18nService, SystelabTranslateModule } from 'systelab-translate';
+import { MessagePopupButton, MessagePopupService } from './message-popup.service';
+import { MessageWithIconComponent } from './message-with-icon.component';
+
+const yesNoNoTemplate = {
+    titleDescription: 'Test',
+    messageDescription: 'Yes/No message popup example',
+    modalClass: null,
+    width: 600,
+    height: 500,
+    template: null,
+}
+
+const yesNoNoOutlineWarningTemplate = {
+    titleDescription: 'Test',
+    messageDescription: 'Yes/No message popup example',
+    modalClass: null,
+    width: 600,
+    height: 500,
+    template: 'outline-warning',
+}
+
+const expectedButtonsWithNoTemplate = [
+    new MessagePopupButton('COMMON_NO', false, 'btn-link'),
+    new MessagePopupButton('COMMON_YES', true, 'btn-outline-primary')
+];
+
+const expectedButtonsWithWarningTemplate = [
+    new MessagePopupButton('COMMON_NO', false, 'btn-link'),
+    new MessagePopupButton('COMMON_YES', true, 'btn-outline-warning')
+];
+
+describe('MessagePopupService', () => {
+    let service: MessagePopupService;
+    let spyDialogRef: jasmine.SpyObj<MessagePopupService>;
+    beforeEach(() => {
+        spyDialogRef = jasmine.createSpyObj('MessagePopupService', ['showYesNoQuestionPopup']);
+		TestBed.configureTestingModule({
+            imports: [
+                OverlayModule,
+				HttpClientModule,
+				SystelabTranslateModule
+			],
+			providers: [
+                DialogService,
+                {provide: DialogRef, useValue: spyDialogRef},
+                {provide: I18nService, useClass: I18nService}
+			]
+		});
+		service = TestBed.inject(MessagePopupService);
+	});
+
+    it('should be created', () => {
+		expect(service).toBeTruthy();
+	});
+
+    it('should return buttons with template when getButtonsTemplate is called', ()=>{
+        expect(service['getButtonsTemplate'](yesNoNoTemplate.template)).toEqual(expectedButtonsWithNoTemplate);
+    });
+
+    it('should return buttons with template when getButtonsTemplate is called', ()=>{
+        expect(service['getButtonsTemplate'](yesNoNoOutlineWarningTemplate.template)).toEqual(expectedButtonsWithWarningTemplate);
+    });
+
+    it('it should show a YesNo dialog',()=>{
+        spyOn<any>(service, 'showPopup').and.callThrough();
+        service.showYesNoQuestionPopup(yesNoNoTemplate.titleDescription, yesNoNoTemplate.messageDescription, yesNoNoTemplate.modalClass, yesNoNoTemplate.width , yesNoNoTemplate.height, yesNoNoTemplate.template)
+        const buttons: MessagePopupButton[] = service['getButtonsTemplate'](yesNoNoTemplate.template);
+        expect(service['showPopup']).toHaveBeenCalledWith(
+            yesNoNoTemplate.titleDescription,
+            MessageWithIconComponent.MESSAGE_QUESTION,
+            yesNoNoTemplate.messageDescription,
+            yesNoNoTemplate.modalClass,
+            yesNoNoTemplate.width,
+            yesNoNoTemplate.height,
+            buttons
+        );
+    });
+});

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.ts
@@ -69,31 +69,16 @@ export class MessagePopupService {
 
 	private getButtonsTemplate(template:string): MessagePopupButton[] {
 		const buttons: MessagePopupButton[] = [];
-		let classTemplate: string;
-		switch (template) {
-			case 'outline-danger':
-				classTemplate = 'btn-outline-danger';
-				break;
-			case 'danger':
-				classTemplate = 'btn-danger';
-				break;
-			case 'outline-warning':
-				classTemplate = 'btn-outline-warning';
-				break;
-			case 'warning':
-				classTemplate = 'btn-warning';
-				break;
-			case 'outline-primary':
-				classTemplate = 'btn-outline-primary';
-				break;
-			case 'primary':
-				classTemplate = 'btn-primary';
-				break;
-			case 'default':
-			default:
-				classTemplate = 'btn-outline-primary';
-				break;
+		const availableTemplates = {
+			'outline-danger': 'btn-outline-danger',
+			'danger': 'btn-danger',
+			'outline-warning': 'btn-outline-warning',
+			'warning': 'btn-warning',
+			'primary':'btn-primary',
+			'outline-primary': 'btn-outline-primary',
 		}
+		const classTemplate: string = availableTemplates[template] || 'btn-outline-primary';
+
 		buttons.push(new MessagePopupButton(this.i18nService.instant('COMMON_NO'), false, 'btn-link'));
 		buttons.push(new MessagePopupButton(this.i18nService.instant('COMMON_YES'), true, classTemplate));
 		return buttons;

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.ts
@@ -69,7 +69,7 @@ export class MessagePopupService {
 
 	private getButtonsTemplate(template:string): MessagePopupButton[] {
 		const buttons: MessagePopupButton[] = [];
-		const availableTemplates = {
+		const availableTemplates: any = {
 			'outline-danger': 'btn-outline-danger',
 			'danger': 'btn-danger',
 			'outline-warning': 'btn-outline-warning',

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
-import { I18nService } from 'systelab-translate';
-import { MessagePopupViewComponent } from './message-popup-view.component';
 import { Observable } from 'rxjs';
-import { MessagePopupIcon, MessageWithIconComponent } from './message-with-icon.component';
+import { I18nService } from 'systelab-translate';
 import { DialogService } from '../dialog/dialog.service';
+import { MessagePopupViewComponent } from './message-popup-view.component';
+import { MessagePopupIcon, MessageWithIconComponent } from './message-with-icon.component';
 
 export class MessagePopupButton {
 	constructor(public title: string, public returnValue: any, public cssClass?: string, public focus: boolean = false) {
@@ -30,10 +30,8 @@ export class MessagePopupService {
 		return this.showPopup(titleDescription, MessageWithIconComponent.MESSAGE_INFO, messageDescription, modalClass, width, height, []);
 	}
 
-	public showYesNoQuestionPopup(titleDescription: string, messageDescription: string, modalClass?: string, width?: number, height?: number): Observable<any> {
-		const buttons: MessagePopupButton[] = [];
-		buttons.push(new MessagePopupButton(this.i18nService.instant('COMMON_NO'), false, 'btn-link'));
-		buttons.push(new MessagePopupButton(this.i18nService.instant('COMMON_YES'), true, 'btn-primary'));
+	public showYesNoQuestionPopup(titleDescription: string, messageDescription: string, modalClass?: string, width?: number, height?: number, template?: string): Observable<any> {
+		const buttons: MessagePopupButton[] = this.getButtonsTemplate(template);
 		return this.showPopup(titleDescription, MessageWithIconComponent.MESSAGE_QUESTION, messageDescription, modalClass, width, height, buttons);
 	}
 
@@ -67,6 +65,38 @@ export class MessagePopupService {
 		parameters.icon = icon;
 
 		return this.dialogService.showDialog(MessagePopupViewComponent, parameters);
+	}
+
+	private getButtonsTemplate(template:string): MessagePopupButton[] {
+		const buttons: MessagePopupButton[] = [];
+		let classTemplate: string;
+		switch (template) {
+			case 'outline-danger':
+				classTemplate = 'btn-outline-danger';
+				break;
+			case 'danger':
+				classTemplate = 'btn-danger';
+				break;
+			case 'outline-warning':
+				classTemplate = 'btn-outline-warning';
+				break;
+			case 'warning':
+				classTemplate = 'btn-warning';
+				break;
+			case 'outline-primary':
+				classTemplate = 'btn-outline-primary';
+				break;
+			case 'primary':
+				classTemplate = 'btn-primary';
+				break;
+			case 'default':
+			default:
+				classTemplate = 'btn-outline-primary';
+				break;
+		}
+		buttons.push(new MessagePopupButton(this.i18nService.instant('COMMON_NO'), false, 'btn-link'));
+		buttons.push(new MessagePopupButton(this.i18nService.instant('COMMON_YES'), true, classTemplate));
+		return buttons;
 	}
 
 }


### PR DESCRIPTION
# PR Details

Added templates to Yes/No Popup

## Description

With no template parameter
![image](https://user-images.githubusercontent.com/5593621/148924691-09aed4e2-ae37-4a07-95a8-a03bfbf479b9.png)

With 'primary' template
![image](https://user-images.githubusercontent.com/5593621/148924854-bdf0765c-7f55-4782-bad6-9094bf722a6e.png)

With 'outline-primary' template
![image](https://user-images.githubusercontent.com/5593621/148924973-e221d2ca-438d-406c-818d-4d4116092767.png)

With 'warning' template
![image](https://user-images.githubusercontent.com/5593621/148925148-abb303d1-174a-49d6-a8a0-523151c5e0b0.png)

With 'outline-warning' template
![image](https://user-images.githubusercontent.com/5593621/148925187-87e0be42-4a37-483c-819b-438ca2cef24b.png)

With 'danger' template
![image](https://user-images.githubusercontent.com/5593621/148925237-7af6c3a0-9769-4bdf-8d28-0affa801587a.png)

With 'outline-danger' template
![image](https://user-images.githubusercontent.com/5593621/148925269-b9a80e61-acc4-41f8-b9dc-e91ce656dda1.png)


## Related Issue

#534 

## How Has This Been Tested

Only cosmetic changes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
