### PR TITLE
fix: Change font color in ag-checkbox-input-wrapper class to transparent

### DIFF
--- a/projects/systelab-components/sass/modern/_checkBox.scss
+++ b/projects/systelab-components/sass/modern/_checkBox.scss
@@ -90,6 +90,9 @@ input[type="checkbox"]:not(.slab-checkbox-not-show):disabled + label {
     }
   }
 
+  .ag-checkbox-input-wrapper::after {
+    color: transparent !important;
+  }
 
   .ag-checkbox-input-wrapper.ag-checked::after {
     content: '\f00c' !important;


### PR DESCRIPTION
# PR Details
Change font color in ag-checkbox-input-wrapper class to transparent to remove strange fonts in unchecked checkboxes. This change does not affect any other browser.

## Related Issue
Issue **#545**
