### PR TITLE
bugfix-554: Added modern styles for two-list buttons

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.3.5",
+  "version": "13.3.6",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/modern/_two-list.scss
+++ b/projects/systelab-components/sass/modern/_two-list.scss
@@ -56,7 +56,9 @@ systelab-two-list {
         padding: 0;
         border-radius: 30px;
         border: 1px solid $primary;
-
+        &:hover {
+          color:white;
+        }
         &:disabled {
           opacity: 0.4 !important;
         }

--- a/projects/systelab-components/sass/modern/_two-list.scss
+++ b/projects/systelab-components/sass/modern/_two-list.scss
@@ -58,6 +58,7 @@ systelab-two-list {
         border: 1px solid $primary;
         &:hover {
           color:white;
+          background-color: $primary;
         }
         &:disabled {
           opacity: 0.4 !important;

--- a/projects/systelab-components/src/lib/twolist/two-list.component.html
+++ b/projects/systelab-components/src/lib/twolist/two-list.component.html
@@ -16,16 +16,16 @@
         </div>
     </div>
     <div class="slab-twolistbuttondiv  d-flex flex-column flex-nowrap justify-content-center">
-        <button type="button" class="btn icon-angle-double-right" (click)="addAll()" title="{{'COMMON_ADD_ALL' | translate | async }}"
+        <button type="button" class="btn btn-outline-primary icon-angle-double-right" (click)="addAll()" title="{{'COMMON_ADD_ALL' | translate | async }}"
             [disabled]="available.length == 0">
         </button>
-        <button type="button" class="btn icon-angle-right" (click)="add()" title="{{'COMMON_ADD_SELECTED' | translate | async }}"
+        <button type="button" class="btn btn-outline-primary icon-angle-right" (click)="add()" title="{{'COMMON_ADD_SELECTED' | translate | async }}"
             [disabled]="currentSelectionStatus.available.length == 0">
         </button>
-        <button type="button" class="btn icon-angle-left" (click)="remove()" title="{{'COMMON_REMOVE_SELECTED' | translate | async }}"
+        <button type="button" class="btn btn-outline-primary icon-angle-left" (click)="remove()" title="{{'COMMON_REMOVE_SELECTED' | translate | async }}"
             [disabled]="currentSelectionStatus.visible.length == 0">
         </button>
-        <button type="button" class="btn icon-angle-double-left" (click)="removeAll()" title="{{'COMMON_REMOVE_ALL' | translate | async }}"
+        <button type="button" class="btn btn-outline-primary icon-angle-double-left" (click)="removeAll()" title="{{'COMMON_REMOVE_ALL' | translate | async }}"
             [disabled]="visible.length == 0">
         </button>
     </div>

--- a/projects/systelab-components/src/lib/twolist/two-list.component.html
+++ b/projects/systelab-components/src/lib/twolist/two-list.component.html
@@ -15,17 +15,17 @@
             </div>
         </div>
     </div>
-    <div class="slab-twolistbuttondiv  d-flex flex-column flex-nowrap justify-content-center">
-        <button type="button" class="btn btn-outline-primary icon-angle-double-right" (click)="addAll()" title="{{'COMMON_ADD_ALL' | translate | async }}"
+    <div class="slab-twolistbuttondiv d-flex flex-column flex-nowrap justify-content-center">
+        <button type="button" class="btn icon-angle-double-right" (click)="addAll()" title="{{'COMMON_ADD_ALL' | translate | async }}"
             [disabled]="available.length == 0">
         </button>
-        <button type="button" class="btn btn-outline-primary icon-angle-right" (click)="add()" title="{{'COMMON_ADD_SELECTED' | translate | async }}"
+        <button type="button" class="btn icon-angle-right" (click)="add()" title="{{'COMMON_ADD_SELECTED' | translate | async }}"
             [disabled]="currentSelectionStatus.available.length == 0">
         </button>
-        <button type="button" class="btn btn-outline-primary icon-angle-left" (click)="remove()" title="{{'COMMON_REMOVE_SELECTED' | translate | async }}"
+        <button type="button" class="btn icon-angle-left" (click)="remove()" title="{{'COMMON_REMOVE_SELECTED' | translate | async }}"
             [disabled]="currentSelectionStatus.visible.length == 0">
         </button>
-        <button type="button" class="btn btn-outline-primary icon-angle-double-left" (click)="removeAll()" title="{{'COMMON_REMOVE_ALL' | translate | async }}"
+        <button type="button" class="btn icon-angle-double-left" (click)="removeAll()" title="{{'COMMON_REMOVE_ALL' | translate | async }}"
             [disabled]="visible.length == 0">
         </button>
     </div>


### PR DESCRIPTION
# PR Details

Modified modern > _two-list.scss to achieve desired styles
![image](https://user-images.githubusercontent.com/5593621/151526494-52a4b709-b972-452c-8900-8f3b5aa5eb65.png)

## Related Issue

#554 

## How Has This Been Tested

Cosmetic changes

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
