### PR TITLE
systelab-combobox: Navigate through the values using the arrows of the keyboard #86

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.7.1",
+  "version": "13.7.2",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.7.2",
+  "version": "13.7.3",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Directive, Input, Renderer2 } from '@angular/core';
 import { AgRendererComponent } from 'ag-grid-angular';
-import { IGetRowsParams } from 'ag-grid-community';
+import {IGetRowsParams, KeyName} from 'ag-grid-community';
 import { AbstractApiComboBox } from '../abstract-api-combobox.component';
 import { AbstractComboBox } from '../abstract-combobox.component';
 import { PreferencesService } from 'systelab-preferences';
@@ -25,7 +25,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 		if (event.shiftKey || event.ctrlKey) {
 			return;
 		}
-		if (event.key === 'Escape' || event.key === 'Enter' || event.key === 'Tab') {
+		if (event.key === KeyName.ESCAPE || event.key === KeyName.ENTER || event.key === KeyName.TAB) {
 			if (this.isDropDownOpen()) {
 				this.closeDropDown();
 			}
@@ -68,11 +68,11 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 
 	// Overrides
 	public override onCellKeyDown(e: any) {
-		if (e.event.key === 'Enter') {
+		if (e.event.key === KeyName.ENTER) {
 			this.gridOptions.api.selectNode(e.node);
 			this.closeDropDown();
 			this.inputElement.nativeElement.focus();
-		} else if (e.event.key === 'Backspace') {
+		} else if (e.event.key === KeyName.BACKSPACE) {
 			this.inputElement.nativeElement.value = this.inputElement.nativeElement.value.slice(0, -1);
 			this.inputElement.nativeElement.focus();
 		} else if (e.event.key.length === 1 && e.event.key.match(/^[a-zA-Z]+|[0-9]/g)) {

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -25,7 +25,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 		if (event.shiftKey || event.ctrlKey) {
 			return;
 		}
-		if (event.keyCode === 27) {
+		if (event.key === 'Escape' || event.key === 'Enter' || event.key === 'Tab') {
 			if (this.isDropDownOpen()) {
 				this.closeDropDown();
 			}
@@ -46,14 +46,40 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 		event.stopPropagation();
 		if (!this.isDisabled) {
 			if (!this.isDropDownOpen()) {
-				this.showDropDown();
-				jQuery('#' + this.comboId)
-					.dropdown('toggle');
-				this.isDropdownOpened = true;
+				this.openDropDown();
 				this.doSearchText(this.description);
 			}
 			this.inputElement.nativeElement.focus();
 		}
+	}
+
+	public onInputNavigate(event: KeyboardEvent) {
+		if (!this.isDisabled) {
+			if (!this.isDropDownOpen()) {
+				this.openDropDown();
+				this.doSearchText(this.description);
+			}
+			this.chref.detectChanges();
+			// sets focus into the first grid cell
+			const firstCol = this.gridOptions.columnApi.getAllDisplayedColumns()[0];
+			this.gridOptions.api.setFocusedCell(0, firstCol);
+		}
+	}
+
+	// Overrides
+	public override onCellKeyDown(e: any) {
+		if (e.event.key === 'Enter') {
+			this.gridOptions.api.selectNode(e.node);
+			this.closeDropDown();
+			this.inputElement.nativeElement.focus();
+		} else if (e.event.key === 'Backspace') {
+			this.inputElement.nativeElement.value = this.inputElement.nativeElement.value.slice(0, -1);
+			this.inputElement.nativeElement.focus();
+		} else if (e.event.key.length === 1 && e.event.key.match(/^[a-zA-Z]+|[0-9]/g)) {
+			this.inputElement.nativeElement.value += e.event.key;
+			this.inputElement.nativeElement.focus();
+		}
+		e.event.preventDefault();
 	}
 
 	// Overrides
@@ -97,6 +123,9 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	}
 
 	protected doSearchText(text: string): void {
+		if (!this.isDropDownOpen()) {
+			this.openDropDown();
+		}
 		this.startsWith = text;
 		if (!this.startsWith || this.startsWith.length < 1) {
 			this.resetComboSelection();
@@ -113,6 +142,13 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 			this.gridOptions.api.deselectAll();
 		}
 		this.selectedItemChange.emit(undefined);
+	}
+
+	private openDropDown(): void {
+		this.showDropDown();
+		jQuery('#' + this.comboId)
+			.dropdown('toggle');
+		this.isDropdownOpened = true;
 	}
 
 }

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -53,7 +53,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 		}
 	}
 
-	public onInputNavigate(event: KeyboardEvent) {
+	public onInputNavigate(): void {
 		if (!this.isDisabled) {
 			if (!this.isDropDownOpen()) {
 				this.openDropDown();
@@ -67,7 +67,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	}
 
 	// Overrides
-	public override onCellKeyDown(e: any) {
+	public override onCellKeyDown(e: any): void {
 		if (e.event.key === KeyName.ENTER) {
 			this.gridOptions.api.selectNode(e.node);
 			this.closeDropDown();

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -13,7 +13,8 @@
                [style.font-style]="fontStyle"
                [tabindex]="tabindex"
                (keydown.Tab)="closeDropDown()"
-               (keydown.arrowDown)="onInputClicked($event)"
+               (keydown.arrowDown)="onInputNavigate($event)"
+               (keydown.arrowUp)="onInputNavigate($event)"
                 (click)="onInputClicked($event)"/>
         <button type="button" *ngIf="withFavourites && id" #favouriteButton class="slab-combo-button slab-combo-star border-right-0 rounded-0 text-primary"
                 [ngClass]="{'icon-star': isFavourite, 'icon-star-o': !isFavourite}" (click)="doToggleFavourite($event)" tabindex="-1"></button>
@@ -33,7 +34,7 @@
                              [gridOptions]="gridOptions"
                              (selectionChanged)="onSelectionChanged($event)"
                              (rowSelected)="onRowSelected($event)"
-                             (modelUpdated)="onModelUpdated()">
+                             (modelUpdated)="onModelUpdated()" (cellKeyDown)="onCellKeyDown($event)">
             </ag-grid-angular>
         </div>
 

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -13,8 +13,8 @@
                [style.font-style]="fontStyle"
                [tabindex]="tabindex"
                (keydown.Tab)="closeDropDown()"
-               (keydown.arrowDown)="onInputNavigate($event)"
-               (keydown.arrowUp)="onInputNavigate($event)"
+               (keydown.arrowDown)="onInputNavigate()"
+               (keydown.arrowUp)="onInputNavigate()"
                 (click)="onInputClicked($event)"/>
         <button type="button" *ngIf="withFavourites && id" #favouriteButton class="slab-combo-button slab-combo-star border-right-0 rounded-0 text-primary"
                 [ngClass]="{'icon-star': isFavourite, 'icon-star-o': !isFavourite}" (click)="doToggleFavourite($event)" tabindex="-1"></button>


### PR DESCRIPTION
# PR Details

Added in autocomplete comboboxes the functionality of navigating through the values using the arrow keys, and the enter to select an option.

## Description

Auto complete comboboxes where keeping the focus on the input field, which was preventing the ag grid from capturing the corresponding navigation events. 
The changes consist of delegating the focus to the ag grid, but interacting with the input field so that it stores the text entered by the user and triggers the corresponding search.

## Related Issue

https://github.com/systelab/systelab-components/issues/86

## Motivation and Context

The navigation with the keyboard was not working in autocomplete comboboxes.

## How Has This Been Tested

The fix has been tested in Chrome, Firefox and Opera browsers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [X] All new and existing tests passed
- [X] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
