### PR TITLE
Click event on autocomplete combos & datepicker

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.8.0",
+  "version": "13.8.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/modern/_datepicker.scss
+++ b/projects/systelab-components/sass/modern/_datepicker.scss
@@ -15,7 +15,6 @@ p-calendar {
     .icon-calendar {
       height: 100%;
       color: black;
-      pointer-events: auto;
       cursor: pointer;
     }
 

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -33,7 +33,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 			return;
 		}
 		if (event.key === KeyName.escape || event.key === KeyName.enter || event.key === KeyName.tab) {
-			if (this.isDropDownOpen()) {
+			if (this.isDropdownOpened) {
 				this.closeDropDown();
 			}
 		} else {
@@ -52,7 +52,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	public onInputClicked(event: MouseEvent): void {
 		event.stopPropagation();
 		if (!this.isDisabled) {
-			if (!this.isDropDownOpen()) {
+			if (!this.isDropdownOpened) {
 				this.openDropDown();
 				this.doSearchText(this.description);
 			}
@@ -62,7 +62,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 
 	public onInputNavigate(): void {
 		if (!this.isDisabled) {
-			if (!this.isDropDownOpen()) {
+			if (!this.isDropdownOpened) {
 				this.openDropDown();
 				this.doSearchText(this.description);
 			}
@@ -131,7 +131,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	}
 
 	protected doSearchText(text: string): void {
-		if (!this.isDropDownOpen()) {
+		if (!this.isDropdownOpened) {
 			this.openDropDown();
 		}
 		this.startsWith = text;


### PR DESCRIPTION
# PR Details

Fix both bugs described in the issue

## Description

Click events on both icons now open the corresponding elements. The list of options in the combo and the calendar in the datepicker.
In the combo the problem was caused by a bad checking of the dropdown state (opened or closed).
In the calendar the problem was caused by the a css property that prevented the click event to be triggered.

## Related Issue

https://github.com/systelab/systelab-components/issues/603

## Motivation and Context

Fix the problems described in the issue

## How Has This Been Tested

The fix has been tested in Chrome, Firefox and Opera browsers.
It also has been tested in modulab platform projects.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [X] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
