### PR TITLE
Improve datepicker component

### DIFF
--- a/projects/showcase/src/app/components/datepicker/showcase-datepicker.component.html
+++ b/projects/showcase/src/app/components/datepicker/showcase-datepicker.component.html
@@ -17,6 +17,15 @@
         </div>
     </div>
     <div class="row mt-1">
+        <label class="col-md-3 col-form-label" for="form-h-s">Datepicker Time (Time integrated)</label>
+        <div class="col-md-9">
+            <systelab-date-time
+                    [(currentDate)]="myNewDate"
+                    [withIntegratedTime]="true"
+            ></systelab-date-time>
+        </div>
+    </div>
+    <div class="row mt-1">
         <label class="col-md-3 col-form-label" for="form-h-s">Datepicker Time (Disabled)</label>
         <div class="col-md-9">
             <systelab-date-time [disabled]="true"
@@ -41,6 +50,17 @@
             <systelab-date-time
                     [showCalendar]="false"
                     [(currentDate)]="myDate"></systelab-date-time>
+        </div>
+    </div>
+    <div class="row mt-1">
+        <label class="col-md-3 col-form-label" for="form-h-s">Datepicker Time without calendar (time only mode)</label>
+        <div class="col-md-9">
+            <systelab-date-time
+                    [showCalendar]="false"
+                    [(currentDate)]="myNewDate"
+                    [withIntegratedTime]="true"
+                    [onlyTime]="true"
+            ></systelab-date-time>
         </div>
     </div>
     <div class="row mt-1">

--- a/projects/showcase/src/app/components/datepicker/showcase-datepicker.component.ts
+++ b/projects/showcase/src/app/components/datepicker/showcase-datepicker.component.ts
@@ -9,6 +9,7 @@ import { I18nService } from 'systelab-translate';
 export class ShowcaseDatepickerComponent {
 
 	public myDate;
+	public myNewDate;
 	public myDateWithReset;
 	public maxDate: Date;
 	public minDate: Date;
@@ -24,6 +25,7 @@ export class ShowcaseDatepickerComponent {
 
 	constructor(public i18nService: I18nService, protected readonly zone: NgZone) {
 		this.myDate = new Date(2018, 9, 20, 14, 5, 30, 0);
+		this.myNewDate = new Date(2022, 9, 20, 14, 5, 30, 0);
 		this.maxDate = new Date(2018, 9, 20);	// October 20, 2018
 		this.minDate = new Date(2017, 0, 20);	// January 20, 2017
 		this.myDateWithReset = new Date(2018, 9, 20, 14, 5, 30, 0);
@@ -33,6 +35,7 @@ export class ShowcaseDatepickerComponent {
 
 	public resetDateAndTime(): void {
 		this.myDate = new Date();
+		this.myNewDate = new Date();
 		this.myDateWithReset = new Date();
 	}
 

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.9.1",
+  "version": "13.9.2",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/_datepicker.scss
+++ b/projects/systelab-components/sass/_datepicker.scss
@@ -16,6 +16,10 @@ p-calendar {
       height: 100%;
     }
 
+    .icon-clock {
+      height: 100%;
+    }
+
   }
 
   &.input-expand-height {

--- a/projects/systelab-components/sass/modern/_datepicker.scss
+++ b/projects/systelab-components/sass/modern/_datepicker.scss
@@ -18,6 +18,12 @@ p-calendar {
       cursor: pointer;
     }
 
+    .icon-clock {
+      height: 100%;
+      color: black;
+      cursor: pointer;
+    }
+
   }
 
   &.input-expand-height {

--- a/projects/systelab-components/src/lib/datepicker/README.md
+++ b/projects/systelab-components/src/lib/datepicker/README.md
@@ -10,23 +10,25 @@ All the input parameters are optional.
 
 ## Properties
 
-| Name | Type | Default | Description |
-| ---- |:----:|:-------:| ----------- |
-| **currentDate** | Date | | Date selected in the component |
-| disabled | boolean | false | If true the component is shown disabled |
-| error | boolean | false | If true the components shows the Date selected in red indicating an erroneous date |
-| required | boolean | false | If true and currentDate is not set the components shows the input border in red |
-| markPreviousAfterDate | boolean | false | (Deprecated, use warnDaysBefore with a value of 1 instead) If true and currentDate previous than today then the input background color is red |
-| inputExpandHeight | boolean | false | If true the component expands to parent height |
-| fontSize | number | | Font size in pixels |
-| showTodayButton | boolean | false | Show Today button |
-| inline | boolean | false | When enabled, displays the calendar as inline. Default is false for popup mode |
-| minDate | Date | | The minimum selectable date |
-| maxDate | Date | | The maximum selectable date |
-| warnDaysBefore | number | | If set, when a date is selected the input background is set to red when that date happens before or it is exactly the same than the system's current date minus the number of days specified. |
-| warnDaysAfter | number | | If set, when a date is selected the input background is set to red when that date happens after than the system's current date plus the number of days specified. |
-| autofocus | boolean | false | If true the input is automatically focused |
-| fromDateForRelativeDates | date | undefined | Date to be used as from date to calculate the new date when using the shortcuts (ie. 3d)
+| Name |  Type   |  Default  | Description |
+| --- |:-------:|:---------:| ----------- |
+| **currentDate** |  Date   |           | Date selected in the component |
+| disabled | boolean |   false   | If true the component is shown disabled |
+| error | boolean |   false   | If true the components shows the Date selected in red indicating an erroneous date |
+| required | boolean |   false   | If true and currentDate is not set the components shows the input border in red |
+| markPreviousAfterDate | boolean |   false   | (Deprecated, use warnDaysBefore with a value of 1 instead) If true and currentDate previous than today then the input background color is red |
+| inputExpandHeight | boolean |   false   | If true the component expands to parent height |
+| fontSize | number  |           | Font size in pixels |
+| showTodayButton | boolean |   false   | Show Today button |
+| inline | boolean |   false   | When enabled, displays the calendar as inline. Default is false for popup mode |
+| minDate |  Date   |           | The minimum selectable date |
+| maxDate |  Date   |           | The maximum selectable date |
+| warnDaysBefore | number  |           | If set, when a date is selected the input background is set to red when that date happens before or it is exactly the same than the system's current date minus the number of days specified. |
+| warnDaysAfter | number  |           | If set, when a date is selected the input background is set to red when that date happens after than the system's current date plus the number of days specified. |
+| autofocus | boolean |   false   | If true the input is automatically focused |
+| fromDateForRelativeDates |  date   | undefined | Date to be used as from date to calculate the new date when using the shortcuts (ie. 3d)
+| withIntegratedTime | boolean |   false   | If true, it will be used the time component integrated in calendar instead of the spinner components
+| onlyTime | boolean |   false   | If true, only the timepicker integrated is shown instead of calendar, else is shown the calendar with the time
 
 In black the Two-Way Data Binding properties.
 

--- a/projects/systelab-components/src/lib/datepicker/datepicker-time.component.html
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-time.component.html
@@ -1,40 +1,44 @@
 <div class="d-flex">
-    <ng-container *ngIf="showCalendar">
+    <ng-container *ngIf="showCalendar || withIntegratedTime">
         <systelab-datepicker
-                            [(currentDate)]="currentDate"
-                             (currentDateChange)="currentDateChange.emit($event)"
-                             [disabled]="disabled"
-                             [error]="error"
-                             [markPreviousAfterDate]="markPreviousAfterDate"
-                             [required]="required"
-                             [inputExpandHeight]="inputExpandHeight"
-                             [inputFontSize]="inputFontSize"
-                             [showTodayButton]="showTodayButton"
-                             [tabindex]="tabindex"
-                             [maxDate]="maxDate"
-                             [minDate]="minDate"
-                             [warnDaysAfter]="warnDaysAfter"
-                             [warnDaysBefore]="warnDaysBefore"
-                             [autofocus]="autofocus"
-                             [inline]="inline"></systelab-datepicker>
+                [(currentDate)]="currentDate"
+                (currentDateChange)="currentDateChange.emit($event)"
+                [disabled]="disabled"
+                [error]="error"
+                [markPreviousAfterDate]="markPreviousAfterDate"
+                [required]="required"
+                [inputExpandHeight]="inputExpandHeight"
+                [inputFontSize]="inputFontSize"
+                [showTodayButton]="showTodayButton"
+                [tabindex]="tabindex"
+                [maxDate]="maxDate"
+                [minDate]="minDate"
+                [warnDaysAfter]="warnDaysAfter"
+                [warnDaysBefore]="warnDaysBefore"
+                [autofocus]="autofocus"
+                [onlyTime]="!showCalendar"
+                [withIntegratedTime]="withIntegratedTime"
+                [inline]="inline"></systelab-datepicker>
 
     </ng-container>
 
-    <systelab-spinner class="d-flex h-100" id="hours"
-                      [spinValues]="touchSpinHourValues"
-                      [fillUnitsWithZero]="true"
-                      [(value)]="touchSpinHourValues.value"
-                      [disabled]="disabled"
-                      [error]="error"
-                      [tabindex]="tabindex"
-                      (valueChange)="currentHoursChanged($event)"></systelab-spinner>
-    <label class="mx-1 my-0" [class.text-danger]="error">:</label>
-    <systelab-spinner class="d-flex h-100" id="minutes"
-                      [spinValues]="touchSpinMinutesValues"
-                      [fillUnitsWithZero]="true"
-                      [tabindex]="tabindex"
-                      [(value)]="touchSpinMinutesValues.value"
-                      [disabled]="disabled"
-                      [error]="error"
-                      (valueChange)="currentMinutesChanged($event)"></systelab-spinner>
+    <ng-container *ngIf="!withIntegratedTime">
+        <systelab-spinner class="d-flex h-100" id="hours"
+                          [spinValues]="touchSpinHourValues"
+                          [fillUnitsWithZero]="true"
+                          [(value)]="touchSpinHourValues.value"
+                          [disabled]="disabled"
+                          [error]="error"
+                          [tabindex]="tabindex"
+                          (valueChange)="currentHoursChanged($event)"></systelab-spinner>
+        <label class="mx-1 my-0" [class.text-danger]="error">:</label>
+        <systelab-spinner class="d-flex h-100" id="minutes"
+                          [spinValues]="touchSpinMinutesValues"
+                          [fillUnitsWithZero]="true"
+                          [tabindex]="tabindex"
+                          [(value)]="touchSpinMinutesValues.value"
+                          [disabled]="disabled"
+                          [error]="error"
+                          (valueChange)="currentMinutesChanged($event)"></systelab-spinner>
+    </ng-container>
 </div>

--- a/projects/systelab-components/src/lib/datepicker/datepicker-time.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-time.component.ts
@@ -30,7 +30,9 @@ export class DatepickerTimeComponent extends Datepicker {
 
 	override set currentDate(value: Date) {
 		this._currentDate = value;
-		if (this._currentDate) {
+		if(this.withIntegratedTime){
+			this.currentDateChange.emit(this._currentDate);
+		} else if (this._currentDate) {
 			if (this.resetTimeWhenChangingCurrentDate) {
 				this.touchSpinHourValues.value = this._currentDate.getHours();
 				this.touchSpinMinutesValues.value = this._currentDate.getMinutes();

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.html
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.html
@@ -14,11 +14,13 @@
             [disabled]="disabled"
             [readonlyInput]="isTablet"
             [style.font-size.px]="inputFontSize"
+            [showTime]="withIntegratedTime"
+            [timeOnly]="onlyTime"
             [showTransitionOptions]="'1ms linear'"
             [hideTransitionOptions]="'1ms linear'"
             appendTo="body"
             [ngClass]="{'date-error': formatError || error || (required && !currentDate), 'is-disabled': disabled, 'warning-date': tooFarDate || previousAfterDate, 'input-expand-height':inputExpandHeight}">
-    <ng-template pTemplate="header">
+    <ng-template pTemplate="header" *ngIf="!onlyTime">
         <div id="{{datepickerId}}" class="slab-datepicker-header">
             <a id="previousYear" class="icon-angle-double-left slab-icon-medium" (click)="prevYear()"></a>
             <a id="previousMonth" class="icon-angle-left slab-icon-medium" (click)="prevMonth()"></a>

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
@@ -90,6 +90,29 @@ export class AuxFunctionClass {
 		button.click();
 		fixture.detectChanges();
 	}
+
+	public static isSameDate(dateOne: Date, dateTwo: Date): boolean {
+		if(!dateOne || !dateTwo){
+			return false;
+		}
+		if (dateOne.getDate() !== dateTwo.getDate()) {
+			return false;
+		}
+		if (dateOne.getMonth() !== dateTwo.getMonth()) {
+			return false;
+		}
+		return dateOne.getFullYear() === dateTwo.getFullYear();
+	}
+
+	public static isSameHourAndMinute(dateOne: Date, dateTwo: Date): boolean {
+		if(!dateOne || !dateTwo){
+			return false;
+		}
+		if (dateOne.getHours() !== dateTwo.getHours()) {
+			return false;
+		}
+		return dateOne.getMinutes() === dateTwo.getMinutes();
+	}
 }
 
 describe('Systelab DatepickerComponent', () => {
@@ -254,6 +277,89 @@ describe('Systelab DatepickerComponent', () => {
 		expect(fixture2.componentInstance.formatError)
 			.toBeFalsy();
 		fixture2.destroy();
+	});
+
+	describe('Set of specs for datepicker with inputs withIntegratedTime and timeOnly active', () => {
+		function setup(isTimeOnly?: boolean){
+			const fixtureDatepicker = TestBed.createComponent(Datepicker);
+			const datepickerComponent = fixtureDatepicker.componentInstance;
+			datepickerComponent.withIntegratedTime = true;
+			datepickerComponent.onlyTime = isTimeOnly;
+			fixtureDatepicker.detectChanges();
+
+
+			return {fixtureDatepicker, datepickerComponent};
+		}
+
+		it('Datepicker component parse date and hour', () => {
+			const {datepickerComponent} = setup();
+			let dateString = '3/30/2020 21:20';
+			const expectedDate = new Date(dateString);
+			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = dateString;
+			datepickerComponent.inputChanged = true;
+			datepickerComponent.changeDate();
+			const isSameDateAndHour = AuxFunctionClass.isSameDate(expectedDate, datepickerComponent.currentDate) &&
+				AuxFunctionClass.isSameHourAndMinute(expectedDate, datepickerComponent.currentDate);
+			expect(datepickerComponent.formatError).toBeFalsy();
+			expect(isSameDateAndHour).toBeTruthy();
+
+		});
+
+		it('Datepicker component parse only date', () => {
+			const {datepickerComponent} = setup();
+			let dateString = '3/30/2020';
+			const expectedDate = new Date(dateString);
+			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = dateString;
+			datepickerComponent.inputChanged = true;
+			datepickerComponent.changeDate();
+			const isSameDate = AuxFunctionClass.isSameDate(expectedDate, datepickerComponent.currentDate);
+			expect(datepickerComponent.formatError).toBeFalsy();
+			expect(isSameDate).toBeTruthy();
+
+		});
+
+		it('Datepicker parsing incorrect format, format error', () => {
+			const {datepickerComponent} = setup();
+			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = '3/30/2020 : 5:11';
+			datepickerComponent.inputChanged = true;
+			datepickerComponent.changeDate();
+			expect(datepickerComponent.formatError).toBeTruthy();
+
+		});
+
+		it('Datepicker only time, parsing incorrect hour, format error', () => {
+			const {datepickerComponent} = setup(true);
+			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = '24:11';
+			datepickerComponent.inputChanged = true;
+			datepickerComponent.changeDate();
+			expect(datepickerComponent.formatError).toBeTruthy();
+
+		});
+
+		it('Datepicker only time, parsing incorrect minute, format error', () => {
+			const {datepickerComponent} = setup(true);
+			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = '4:66';
+			datepickerComponent.inputChanged = true;
+			datepickerComponent.changeDate();
+			expect(datepickerComponent.formatError).toBeTruthy();
+
+		});
+
+		it('Datepicker only time, parsing correct time', () => {
+			const {datepickerComponent} = setup(true);
+			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = '4:6';
+			datepickerComponent.inputChanged = true;
+			datepickerComponent.changeDate();
+			const expectedDate = new Date();
+			expectedDate.setHours(4, 6);
+			const isSameDate = AuxFunctionClass.isSameHourAndMinute(expectedDate, datepickerComponent.currentDate);
+			expect(isSameDate).toBeTruthy();
+			expect(datepickerComponent.formatError).toBeFalsy();
+
+		});
+
+
+
 	});
 });
 

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
@@ -280,7 +280,7 @@ describe('Systelab DatepickerComponent', () => {
 	});
 
 	describe('Set of specs for datepicker with inputs withIntegratedTime and timeOnly active', () => {
-		function setup(isTimeOnly?: boolean){
+		const setup = (isTimeOnly?: boolean) => {
 			const fixtureDatepicker = TestBed.createComponent(Datepicker);
 			const datepickerComponent = fixtureDatepicker.componentInstance;
 			datepickerComponent.withIntegratedTime = true;
@@ -289,11 +289,11 @@ describe('Systelab DatepickerComponent', () => {
 
 
 			return {fixtureDatepicker, datepickerComponent};
-		}
+		};
 
 		it('Datepicker component parse date and hour', () => {
 			const {datepickerComponent} = setup();
-			let dateString = '3/30/2020 21:20';
+			const dateString = '3/30/2020 21:20';
 			const expectedDate = new Date(dateString);
 			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = dateString;
 			datepickerComponent.inputChanged = true;
@@ -307,7 +307,7 @@ describe('Systelab DatepickerComponent', () => {
 
 		it('Datepicker component parse only date', () => {
 			const {datepickerComponent} = setup();
-			let dateString = '3/30/2020';
+			const dateString = '3/30/2020';
 			const expectedDate = new Date(dateString);
 			datepickerComponent.currentCalendar.inputfieldViewChild.nativeElement.value = dateString;
 			datepickerComponent.inputChanged = true;

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -27,13 +27,13 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 	@Input() public autofocus = false;
 	@Input() public fromDateForRelativeDates;
 	@Input() public tabindex: number;
+	@Input() public withIntegratedTime = false;
+	@Input() public onlyTime = false;
+
 	@Input()
 	get currentDate(): Date {
 		return this._currentDate;
 	}
-
-	@Input() public withIntegratedTime = false;
-	@Input() public onlyTime = false;
 
 	set currentDate(value: Date) {
 		this._currentDate = value;
@@ -151,14 +151,14 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 						this.currentDate = transformedDate;
 					} else {
 						if (this.onlyTime || this.withIntegratedTime) {
-							let splitDateByHours = dateStr.split(':');
+							const splitDateByHours = dateStr.split(':');
 							if (!this.onlyTime) {
 								switch (splitDateByHours.length) {
 									case 1:
 										this.infereDate(dateStr);
 										break;
 									case 2:
-										let hourPosition = splitDateByHours[0].length-2;
+										const hourPosition = splitDateByHours[0].length-2;
 										const dateString = splitDateByHours[0].substring(0, hourPosition);
 										this.infereDate(dateString);
 										this.parseTime(+splitDateByHours[0].substring(hourPosition), +splitDateByHours[1]);
@@ -195,7 +195,7 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 		}
 	}
 
-	private infereDate(dateStr: string) : void {
+	private infereDate(dateStr: string): void {
 		const inferedDate = this.dataTransformerService.infereDate(dateStr, this.i18nService.getDateFormatForDatePicker());
 		if (inferedDate) {
 			this.currentDate = inferedDate;

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -32,6 +32,9 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 		return this._currentDate;
 	}
 
+	@Input() public withIntegratedTime = false;
+	@Input() public onlyTime = false;
+
 	set currentDate(value: Date) {
 		this._currentDate = value;
 		if (this.markPreviousAfterDate || (this.warnDaysBefore && this.warnDaysBefore > 0)) {
@@ -89,7 +92,7 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 	public ngAfterViewInit() {
 		const newElement = document.createElement('i');
 		if (!this.inline) {
-			newElement.className = 'icon-calendar';
+			newElement.className = this.onlyTime ? 'icon-clock' : 'icon-calendar';
 			if (this.currentCalendar) {
 				if (this.autofocus) {
 					this.currentCalendar.el.nativeElement.querySelector('input')
@@ -99,7 +102,7 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 				this.currentCalendar.el.nativeElement.childNodes[0].appendChild(newElement);
 			}
 		}
-		if(this.tabindex) {
+		if (this.tabindex) {
 			this.currentCalendar.el.nativeElement.querySelector('input')
 				.setAttribute('tabindex', this.tabindex);
 		}
@@ -147,18 +150,57 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 					if (transformedDate) {
 						this.currentDate = transformedDate;
 					} else {
-						const inferedDate = this.dataTransformerService.infereDate(dateStr, this.i18nService.getDateFormatForDatePicker());
-						if (inferedDate) {
-							this.currentDate = inferedDate;
-						}
-						else {
-							this.formatError = true;
+						if (this.onlyTime || this.withIntegratedTime) {
+							let splitDateByHours = dateStr.split(':');
+							if (!this.onlyTime) {
+								switch (splitDateByHours.length) {
+									case 1:
+										this.infereDate(dateStr);
+										break;
+									case 2:
+										let hourPosition = splitDateByHours[0].length-2;
+										const dateString = splitDateByHours[0].substring(0, hourPosition);
+										this.infereDate(dateString);
+										this.parseTime(+splitDateByHours[0].substring(hourPosition), +splitDateByHours[1]);
+										break;
+									default:
+										this.formatError = true;
+										break;
+								}
+							} else {
+								const hour = +splitDateByHours[0];
+								const minute = +splitDateByHours[1];
+								this.currentDate = new Date();
+								this.parseTime(hour, minute);
+
+							}
+						} else {
+							this.infereDate(dateStr);
 						}
 					}
 				}
 				this.currentDateChange.emit(this.currentDate);
 				this.inputChanged = false;
 			}
+		}
+	}
+
+	private parseTime(hour: number, minute: number): void {
+		const isValidHour = hour >= 0 && hour <= 23;
+		const isValidMinute = minute >= 0 && minute <= 59;
+		if (!isValidHour || !isValidMinute) {
+			this.formatError = true;
+		} else {
+			this.currentDate.setHours(hour, minute);
+		}
+	}
+
+	private infereDate(dateStr: string) : void {
+		const inferedDate = this.dataTransformerService.infereDate(dateStr, this.i18nService.getDateFormatForDatePicker());
+		if (inferedDate) {
+			this.currentDate = inferedDate;
+		} else {
+			this.formatError = true;
 		}
 	}
 
@@ -317,7 +359,8 @@ export class Datepicker implements OnInit, AfterViewInit, DoCheck, OnDestroy {
 				dayNamesMin:     weekDaysNamesShort,
 				monthNames:      monthNames,
 				monthNamesShort: monthNamesShort
-		}};
+			}
+		};
 
 		this.language.firstDayOfWeek = this.i18nService.getFirstDayOfWeek();
 		this.language.dateFormatValue = this.i18nService.getDateFormatForDatePicker(true);


### PR DESCRIPTION
# PR Details

The datepicker component nowadays have an spinner to set the time. As is described in the #629 this is not pretty for the final users. It's required to improve this component to provide a better solution than the current

## Description

It has been added two new inputs that allows to use the time component used by p-calendar of PrimeNG instead of the spinner components to set the time. With this solution, is used only one input text with the date and time result.
It's possible to be configured to use only the calendar (as usual) or use only the time component.

All the previous functionality works as usual

## Related Issue

#629 

## Motivation and Context

The change provide to the final user a different look & feel and more space in screen to the dessigners 

## How Has This Been Tested

It has been added unit test and a new show showcase of the DatePicker component to ensure the functionality

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
