### PR TITLE
638 add property to prevent parent selection in abstractapitreelistbox

### DIFF
--- a/projects/showcase/src/app/components/listbox/showcase-listbox.component.html
+++ b/projects/showcase/src/app/components/listbox/showcase-listbox.component.html
@@ -15,6 +15,8 @@
 <div class="container-fluid mt-2">
     <form class="position-relative" style="height: 200px;">
         <showcase-inner-tree-listbox [(selectedTreeItem)]="selectedTreeItem"
+                                     [isParentSelectable]="false"
+                                     [multipleSelection]="true"
                                      (selectedTreeItemChange)="onSelectedItemChange($event)"></showcase-inner-tree-listbox>
     </form>
 </div>

--- a/projects/showcase/src/app/components/listbox/showcase-listbox.component.html
+++ b/projects/showcase/src/app/components/listbox/showcase-listbox.component.html
@@ -16,7 +16,6 @@
     <form class="position-relative" style="height: 200px;">
         <showcase-inner-tree-listbox [(selectedTreeItem)]="selectedTreeItem"
                                      [isParentSelectable]="false"
-                                     [multipleSelection]="true"
                                      (selectedTreeItemChange)="onSelectedItemChange($event)"></showcase-inner-tree-listbox>
     </form>
 </div>

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "13.10.0",
+  "version": "13.11.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/listbox/README.md
+++ b/projects/systelab-components/src/lib/listbox/README.md
@@ -226,16 +226,17 @@ Once you have your component, you can use it in your templates.
 
 ## Properties AbstractListBox&lt;T&gt; and AbstractApiListBox&lt;T&gt;
 
-| Name | Type | Default | Description |
-| ---- |:----:|:-------:| ----------- |
-| **selectedItem** | T | | Element selected. Only when multipleSelection=false |
-| **multipleSelectedItemList** | Array&lt;T&gt; | | Array with elements selected. Only when multipleSelection=true |
-| isDisabled | boolean | false | If true the listbox is disabled  |
-| multipleSelection | boolean | false | Enable to select multiple elements. A checkbox will be rendered in front of each element. |
-| hideChecks | boolean | false | Enable to use multiple selection without checkboxes. Selection will be done with ctrl and click.
-| selectFirstItem | boolean | false | If true first item of the list is selected if there are not selected items. Only when multipleSelection=false |
-| showAll | boolean | false | If true adds all element at the beginning of the list |
-| rowDrag | boolean | false | If true list can be reordered by dragging rows. Only applied to non paginated listbox. |
+| Name                         | Type | Default | Description                                                                                                   |
+|------------------------------|:----:|:-------:|---------------------------------------------------------------------------------------------------------------|
+| **selectedItem**             | T |         | Element selected. Only when multipleSelection=false                                                           |
+| **multipleSelectedItemList** | Array&lt;T&gt; |         | Array with elements selected. Only when multipleSelection=true                                                |
+| isParentSelectable           | boolean |  true   | If true the parent item is selectable **ONLY WORKS WITH SINGLE SELECTION**                                    |                                                                                      |
+| isDisabled                   | boolean |  false  | If true the listbox is disabled                                                                               |
+| multipleSelection            | boolean |  false  | Enable to select multiple elements. A checkbox will be rendered in front of each element.                     |
+| hideChecks                   | boolean |  false  | Enable to use multiple selection without checkboxes. Selection will be done with ctrl and click.              
+| selectFirstItem              | boolean |  false  | If true first item of the list is selected if there are not selected items. Only when multipleSelection=false |
+| showAll                      | boolean |  false  | If true adds all element at the beginning of the list                                                         |
+| rowDrag                      | boolean |  false  | If true list can be reordered by dragging rows. Only applied to non paginated listbox.                        |
 
 In black the Two-Way Data Binding properties.
 

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -31,16 +31,16 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	public paddingSingleSelection = 0;
 
 	@Input()
-	public set selectedTreeItem(value: TreeListBoxElement<T>) {
+	set selectedTreeItem(value: TreeListBoxElement<T>) {
 		this._selectedTreeItem = value;
 		this.selectTreeItemInGrid();
 	}
-	public get selectedTreeItem(): TreeListBoxElement<T> {
+	get selectedTreeItem(): TreeListBoxElement<T> {
 		return this._selectedTreeItem;
 	}
 
 	@Input()
-	public set selectedIDList(value: string) {
+	set selectedIDList(value: string) {
 		this._selectedIDList = value;
 		if (!value) {
 			this.initSelectionList();
@@ -84,6 +84,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		}
 	}
 
+	// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 	public override doClick(row: any): void {
 		if (!this.multipleSelection && !this.isDisabled) {
 			const selectionLevel = row.node.data.level;
@@ -94,6 +95,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		}
 	}
 
+	// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 	public changeValues(event: any): void {
 		if (this.multipleSelection) {
 			this.addRemoveToMultipleSelectedItem(event);
@@ -147,6 +149,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		return false;
 	}
 
+	// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 	public override onModelUpdated(pEvent: any): void {
 	}
 

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -18,35 +18,35 @@ export class TreeListBoxElement<T> {
 
 @Directive()
 export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeListBoxElement<T>> implements OnInit, AfterViewInit {
+	@ViewChild('hidden', {static: true}) public override hiddenElement: ElementRef;
+
 	@Input() public isParentSelectable = true;
 	@Input() public updateHierarchy = true;
-	@Input() set selectedTreeItem(value: TreeListBoxElement<T>) {
-		this._selectedTreeItem = value;
-		this.selectTreeItemInGrid();
-	}
-	@Input() set selectedIDList(value: string) {
-		this._selectedIDList = value;
-		if (!value) {
-			this.initSelectionList();
-		}
-		this.selectedIDListChange.emit(this._selectedIDList);
-	}
-	@Output() selectedTreeItemChange = new EventEmitter<TreeListBoxElement<T>>();
-	@Output() public selectedIDListChange = new EventEmitter<string>();
 
-	@ViewChild('hidden', {static: true}) public override hiddenElement: ElementRef;
+	protected _selectedIDList: string;
 
 	public columnDefs: Array<any>;
 	public treeValues: Array<TreeListBoxElement<T>> = [];
 	public _selectedTreeItem: TreeListBoxElement<T>;
 	public paddingSingleSelection = 0;
 
-	protected _selectedIDList: string;
-
-	get selectedTreeItem() {
+	@Input()
+	public set selectedTreeItem(value: TreeListBoxElement<T>) {
+		this._selectedTreeItem = value;
+		this.selectTreeItemInGrid();
+	}
+	public get selectedTreeItem() {
 		return this._selectedTreeItem;
 	}
 
+	@Input()
+	public set selectedIDList(value: string) {
+		this._selectedIDList = value;
+		if (!value) {
+			this.initSelectionList();
+		}
+		this.selectedIDListChange.emit(this._selectedIDList);
+	}
 	get selectedIDList() {
 		this._selectedIDList = '';
 		for (const selectedItem of this.multipleSelectedItemList) {
@@ -58,6 +58,9 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		}
 		return this._selectedIDList;
 	}
+
+	@Output() public selectedTreeItemChange = new EventEmitter<TreeListBoxElement<T>>();
+	@Output() public selectedIDListChange = new EventEmitter<string>();
 
 	protected constructor() {
 		super();

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -18,37 +18,33 @@ export class TreeListBoxElement<T> {
 
 @Directive()
 export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeListBoxElement<T>> implements OnInit, AfterViewInit {
-	public columnDefs: Array<any>;
-	public treeValues: Array<TreeListBoxElement<T>> = [];
 	@Input() public isParentSelectable = true;
-
-	@ViewChild('hidden', {static: true}) public override hiddenElement: ElementRef;
-
 	@Input() public updateHierarchy = true;
-
-	public _selectedTreeItem: TreeListBoxElement<T>;
-
-	@Input()
-	set selectedTreeItem(value: TreeListBoxElement<T>) {
+	@Input() set selectedTreeItem(value: TreeListBoxElement<T>) {
 		this._selectedTreeItem = value;
 		this.selectTreeItemInGrid();
 	}
-
-	get selectedTreeItem() {
-		return this._selectedTreeItem;
-	}
-
-	@Output() selectedTreeItemChange = new EventEmitter<TreeListBoxElement<T>>();
-
-	protected _selectedIDList: string;
-
-	@Input()
-	set selectedIDList(value: string) {
+	@Input() set selectedIDList(value: string) {
 		this._selectedIDList = value;
 		if (!value) {
 			this.initSelectionList();
 		}
 		this.selectedIDListChange.emit(this._selectedIDList);
+	}
+	@Output() selectedTreeItemChange = new EventEmitter<TreeListBoxElement<T>>();
+	@Output() public selectedIDListChange = new EventEmitter<string>();
+
+	@ViewChild('hidden', {static: true}) public override hiddenElement: ElementRef;
+
+	public columnDefs: Array<any>;
+	public treeValues: Array<TreeListBoxElement<T>> = [];
+	public _selectedTreeItem: TreeListBoxElement<T>;
+	public paddingSingleSelection = 0;
+
+	protected _selectedIDList: string;
+
+	get selectedTreeItem() {
+		return this._selectedTreeItem;
 	}
 
 	get selectedIDList() {
@@ -62,10 +58,6 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		}
 		return this._selectedIDList;
 	}
-
-	@Output() public selectedIDListChange = new EventEmitter<string>();
-
-	public paddingSingleSelection = 0;
 
 	protected constructor() {
 		super();
@@ -272,7 +264,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	}
 
 	private addRemoveToMultipleSelectedItem(event: any) {
-		if (this.multipleSelectedItemList && this.multipleSelectedItemList !== undefined) {
+		if (this.multipleSelectedItemList) {
 			const elementIndexInSelectedList: number = this.multipleSelectedItemList.findIndex((item) => {
 				return (item.nodeData[this.getIdField(1)] === event.nodeData[this.getIdField(1)] && item['level'] === event['level']);
 			});

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -23,8 +23,6 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	@Input() public isParentSelectable = true;
 	@Input() public updateHierarchy = true;
 
-	protected _selectedIDList: string;
-
 	public columnDefs: Array<any>;
 	public treeValues: Array<TreeListBoxElement<T>> = [];
 	public _selectedTreeItem: TreeListBoxElement<T>;
@@ -35,7 +33,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		this._selectedTreeItem = value;
 		this.selectTreeItemInGrid();
 	}
-	public get selectedTreeItem() {
+	public get selectedTreeItem(): TreeListBoxElement<T> {
 		return this._selectedTreeItem;
 	}
 
@@ -47,7 +45,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		}
 		this.selectedIDListChange.emit(this._selectedIDList);
 	}
-	get selectedIDList() {
+	get selectedIDList(): string {
 		this._selectedIDList = '';
 		for (const selectedItem of this.multipleSelectedItemList) {
 			if (this._selectedIDList && this._selectedIDList !== '') {
@@ -61,6 +59,8 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 
 	@Output() public selectedTreeItemChange = new EventEmitter<TreeListBoxElement<T>>();
 	@Output() public selectedIDListChange = new EventEmitter<string>();
+
+	protected _selectedIDList: string;
 
 	protected constructor() {
 		super();

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -18,9 +18,10 @@ export class TreeListBoxElement<T> {
 
 @Directive()
 export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeListBoxElement<T>> implements OnInit, AfterViewInit {
-
 	public columnDefs: Array<any>;
 	public treeValues: Array<TreeListBoxElement<T>> = [];
+	@Input() public isParentSelectable = true;
+
 	@ViewChild('hidden', {static: true}) public override hiddenElement: ElementRef;
 
 	@Input() public updateHierarchy = true;
@@ -213,8 +214,11 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 
 	public override doClick(row: any) {
 		if (!this.multipleSelection && !this.isDisabled) {
-			this.selectedTreeItem = row.node.data;
-			this.selectedTreeItemChange.emit(row.node.data);
+			const selectionLevel = row.node.data.level;
+			if((selectionLevel === 0 && this.isParentSelectable) || selectionLevel > 0){
+				this.selectedTreeItem = row.node.data;
+				this.selectedTreeItemChange.emit(row.node.data);
+			}
 		}
 	}
 


### PR DESCRIPTION
# PR Details

Added property isParentSelectable in AbstractApiTreeListBox

## Description

Added the posibility to prevent parent item selection via component input data

## Related Issue
#638 

## How Has This Been Tested

Manual test in showcase

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
