### PR TITLE
New tooltip directive and component. Avoid using jQuery.

### DIFF
--- a/projects/showcase/src/app/components/dialog/showcase-dialog.component.html
+++ b/projects/showcase/src/app/components/dialog/showcase-dialog.component.html
@@ -1,5 +1,5 @@
 <div class="container-fluid">
-    <systelab-button class="mt-2 mr-1" (action)="showStandardDialog()">Horizontal form
+    <systelab-button class="mt-2 mr-1" (action)="showStandardDialog()" systelabTooltip="Tooltip on right" systelabTooltipPlacement="right">Horizontal form
     </systelab-button>
     <systelab-button class="mt-2 mr-1" (action)="showVerticalDialog()">Vertical form
     </systelab-button>

--- a/projects/showcase/src/app/components/tooltip/showcase-tooltip.component.html
+++ b/projects/showcase/src/app/components/tooltip/showcase-tooltip.component.html
@@ -5,4 +5,6 @@
     <systelab-button class="mt-2 mr-1" systelabTooltip="Tooltip on left" systelabTooltipPlacement="left">Tooltip on left</systelab-button>
     <systelab-button class="mt-2 mr-1" systelabTooltip="Tooltip delay 100 ms" systelabTooltipDelay="100" systelabTooltipHideDelay="0">Tooltip delay 100 ms</systelab-button>
     <systelab-button class="mt-2 mr-1" systelabTooltip="Tooltip delay 100 ms and 0 ms to hide" systelabTooltipDelay="100" systelabTooltipHideDelay="0">Tooltip delay</systelab-button>
+    <systelab-button class="mt-2 mr-1" systelabTooltipHtml="This is an <strong>HTML</strong> tooltip" systelabTooltipDelay="100" systelabTooltipHideDelay="0">HTML Tooltip</systelab-button>
+
 </div>

--- a/projects/systelab-components/sass/_tooltip.scss
+++ b/projects/systelab-components/sass/_tooltip.scss
@@ -1,3 +1,81 @@
-.tooltip{
-  z-index:1000000;
+$slab-tooltip-background-color: black !default;
+$slab-tooltip-foreground-color: white !default;
+$slab-tooltip-font-size: 13px !default;
+
+.slab-tooltip {
+  z-index: 1000000;
+  position: fixed;
+  background-color: $slab-tooltip-background-color;
+  border-radius: 4px;
+  color: $slab-tooltip-foreground-color;
+  padding: 3px 6px;
+  font-size: $slab-tooltip-font-size;
+  opacity: 0;
+
+  &::before {
+    border: 5px solid $slab-tooltip-background-color;
+  }
+
+  &::before {
+    content: '';
+    width: 0;
+    height: 0;
+    position: absolute;
+  }
+
+  &--visible {
+    opacity: 1;
+    transition: opacity 300ms;
+  }
+
+  &--bottom {
+    transform: translateX(-50%);
+    margin-top: 7px;
+
+    &::before {
+      border-left-color: transparent;
+      border-right-color: transparent;
+      border-top: none;
+      left: calc(50% - 5px);
+      top: -5px;
+    }
+  }
+
+  &--top {
+    transform: translate(-50%, -100%);
+    margin-bottom: 7px;
+
+    &::before {
+      border-left-color: transparent;
+      border-right-color: transparent;
+      border-bottom: none;
+      left: calc(50% - 5px);
+      bottom: -5px;
+    }
+  }
+
+  &--left {
+    transform: translate(calc(-100% - 7px), -50%);
+
+    &::before {
+      border-top-color: transparent;
+      border-bottom-color: transparent;
+      border-right: none;
+      right: -5px;
+      top: calc(50% - 5px);
+    }
+  }
+
+  &--right {
+    transform: translateY(-50%);
+    margin-left: 7px;
+
+    &::before {
+      border-top-color: transparent;
+      border-bottom-color: transparent;
+      border-left: none;
+      left: -5px;
+      top: calc(50% - 5px);
+    }
+  }
 }

--- a/projects/systelab-components/sass/modern/_tooltip.scss
+++ b/projects/systelab-components/sass/modern/_tooltip.scss
@@ -1,3 +1,81 @@
-.tooltip{
-  z-index:1000000;
+$slab-tooltip-background-color: black !default;
+$slab-tooltip-foreground-color: white !default;
+$slab-tooltip-font-size: 13px !default;
+
+.slab-tooltip {
+  z-index: 1000000;
+  position: fixed;
+  background-color: $slab-tooltip-background-color;
+  border-radius: 4px;
+  color: $slab-tooltip-foreground-color;
+  padding: 3px 6px;
+  font-size: $slab-tooltip-font-size;
+  opacity: 0;
+
+  &::before {
+    border: 5px solid $slab-tooltip-background-color;
+  }
+
+  &::before {
+    content: '';
+    width: 0;
+    height: 0;
+    position: absolute;
+  }
+
+  &--visible {
+    opacity: 1;
+    transition: opacity 300ms;
+  }
+
+  &--bottom {
+    transform: translateX(-50%);
+    margin-top: 7px;
+
+    &::before {
+      border-left-color: transparent;
+      border-right-color: transparent;
+      border-top: none;
+      left: calc(50% - 5px);
+      top: -5px;
+    }
+  }
+
+  &--top {
+    transform: translate(-50%, -100%);
+    margin-bottom: 7px;
+
+    &::before {
+      border-left-color: transparent;
+      border-right-color: transparent;
+      border-bottom: none;
+      left: calc(50% - 5px);
+      bottom: -5px;
+    }
+  }
+
+  &--left {
+    transform: translate(calc(-100% - 7px), -50%);
+
+    &::before {
+      border-top-color: transparent;
+      border-bottom-color: transparent;
+      border-right: none;
+      right: -5px;
+      top: calc(50% - 5px);
+    }
+  }
+
+  &--right {
+    transform: translateY(-50%);
+    margin-left: 7px;
+
+    &::before {
+      border-top-color: transparent;
+      border-bottom-color: transparent;
+      border-left: none;
+      left: -5px;
+      top: calc(50% - 5px);
+    }
+  }
 }

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -99,6 +99,7 @@ import { DraggableDirective } from './directives/draggable.directive';
 import { ResizableDirective } from './directives/resizable.directive';
 import {ImageViewerComponent} from './image-viewer/image-viewer.component';
 import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numeric.directive';
+import { TooltipComponent } from './tooltip/tooltip.component';
 
 @NgModule({
 	imports:      [
@@ -200,7 +201,8 @@ import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numer
 		DraggableDirective,
 		ResizableDirective,
 		ImageViewerComponent,
-		NumpadDecimalNumericDirective
+		NumpadDecimalNumericDirective,
+		TooltipComponent
 	],
 	exports:      [
 		SliderComponent,

--- a/projects/systelab-components/src/lib/tooltip/README.md
+++ b/projects/systelab-components/src/lib/tooltip/README.md
@@ -23,5 +23,3 @@ Use systelabTooltipDelay to indicate delay showing the combo in ms. Default is 1
 
 Use systelabTooltipHideDelay to indicate delay hiding the combo in ms. Default is 1000 ms.
 
-Use systelabTooltipOnFocus to indicate that the tooltip must be opened only with the hover event. By default the trigger value is with hover and focus. By default, the variable value is true.
-

--- a/projects/systelab-components/src/lib/tooltip/tooltip.component.html
+++ b/projects/systelab-components/src/lib/tooltip/tooltip.component.html
@@ -1,0 +1,6 @@
+<div class="slab-tooltip"
+     [ngClass]="['slab-tooltip--'+position]"
+     [class.slab-tooltip--visible]="visible"
+     [style.left]="left + 'px'"
+     [style.top]="top + 'px'" [innerHTML]="tooltip">
+</div>

--- a/projects/systelab-components/src/lib/tooltip/tooltip.component.ts
+++ b/projects/systelab-components/src/lib/tooltip/tooltip.component.ts
@@ -1,0 +1,15 @@
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+	selector: 'tooltip',
+	templateUrl: 'tooltip.component.html'
+})
+export class TooltipComponent {
+
+	public position = 'top';
+	public tooltip = '';
+	public left = 0;
+	public top = 0;
+	public visible = false;
+
+}


### PR DESCRIPTION
# PR Details

Implement tooltips without using jQuery. Keep the same directive.

## Related Issue

#691 

## Motivation and Context

There are few components with the jQuery dependency and we want to remove it.

## How Has This Been Tested

Manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation 
- [X] I have updated the documentation accordingly (README.md for each UI component)
- [X] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [X] All new and existing tests passed
- [X] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [X] All UI components must be added into the showcase (at least 1 component with the default settings)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
