### PR TITLE
Emit event in abstract-sortable-list when remove or drop

### DIFF
--- a/projects/systelab-components/src/lib/sortable-list/abstract-sortable-list.component.ts
+++ b/projects/systelab-components/src/lib/sortable-list/abstract-sortable-list.component.ts
@@ -1,6 +1,6 @@
-import { Directive, Input } from '@angular/core';
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Directive, EventEmitter, Input, Output } from '@angular/core';
 import { polyfill } from 'mobile-drag-drop';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 
 @Directive()
 export abstract class AbstractSortableListComponent<T> {
@@ -8,6 +8,8 @@ export abstract class AbstractSortableListComponent<T> {
 	@Input() public elementsList: Array<T> = [];
 	@Input() public secondListSearch: string;
 	@Input() public dragAndDropEnabled = true;
+
+	@Output() elementsListChange = new EventEmitter<Array<T>>();
 
 	public deleteWithSupr = false;
 	public showIcon = false;
@@ -70,10 +72,12 @@ export abstract class AbstractSortableListComponent<T> {
 	public removeElement(element: T, event: KeyboardEvent): void {
 		if (this.deleteWithSupr && event.code === 'Delete') {
 			this.elementsList.splice(this.elementsList.indexOf(element), 1);
+			this.elementsListChange.emit(this.elementsList);
 		}
 	}
 
 	public dropped(event: CdkDragDrop<string[]>) {
 		moveItemInArray(this.elementsList, event.previousIndex, event.currentIndex);
+		this.elementsListChange.emit(this.elementsList);
 	}
 }


### PR DESCRIPTION
# PR Details

With this PR abstract-sortable-list emits and even when remove or drop.

## Description

See details

## Related Issue

#696 Emit changes in abstract sortable list

## Motivation and Context

In compoments using abstract-sortable-list sometimes it is needed to know when the order of the list has changed

## How Has This Been Tested

Tested in application using two-list component.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
