### PR TITLE
Add ComboboxOption interface

### DIFF
--- a/projects/showcase/src/app/components/combobox/showcase-autocomplete-combobox.component.ts
+++ b/projects/showcase/src/app/components/combobox/showcase-autocomplete-combobox.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectorRef, Component, Renderer2 } from '@angular/core';
 import { AutocompleteApiComboBox } from 'systelab-components';
 import { Observable, of } from 'rxjs';
+import { ComboboxOption } from "../../../../../systelab-components/src/lib/combobox/combobox-option.interface";
 
 export class ShowcaseCities {
 	public id: string;
@@ -15,7 +16,7 @@ export class ShowcaseCities {
 
 export class ShowcaseAutocomplete extends AutocompleteApiComboBox<ShowcaseCities> {
 
-	public defaultValues = [
+	public defaultValues: ComboboxOption<string>[] = [
 		{description: 'New York', id: '1'},
 		{description: 'Rome', id: '2'},
 		{description: 'London', id: '3'},

--- a/projects/showcase/src/app/components/combobox/showcase-combobox.component.html
+++ b/projects/showcase/src/app/components/combobox/showcase-combobox.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid">
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Sin buscador</label>
+        <label class="col-md-3 col-form-label">Sin buscador</label>
         <div class="col-md-9">
             <systelab-select
                     [values]="comboOptionList"
@@ -9,7 +9,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">With restore default option</label>
+        <label class="col-md-3 col-form-label">With restore default option</label>
         <div class="col-md-9">
             <systelab-select
                     [values]="comboOptionList"
@@ -19,7 +19,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">With restore default option (rubbish icon instead of X) and empty element in the list</label>
+        <label class="col-md-3 col-form-label">With restore default option (rubbish icon instead of X) and empty element in the list</label>
         <div class="col-md-9">
             <systelab-select
                     [withEmptyValue]="true"
@@ -31,14 +31,14 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Autocomplete</label>
+        <label class="col-md-3 col-form-label">Autocomplete</label>
         <div class="col-md-9">
             <showcase-autocomplete (selectedItemChange)="comboChangeEvent($event)">
             </showcase-autocomplete>
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Editable input</label>
+        <label class="col-md-3 col-form-label">Editable input</label>
         <div class="col-md-9">
             <systelab-select
                     [allowEditInput]="true"
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Combo with Icon and color</label>
+        <label class="col-md-3 col-form-label">Combo with Icon and color</label>
         <div class="col-md-9">
             <systelab-select
                     [withIcon]="true"
@@ -61,7 +61,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Favoritos</label>
+        <label class="col-md-3 col-form-label">Favoritos</label>
         <div class="col-md-9">
             <systelab-select
                     [values]="comboOptionList"
@@ -72,7 +72,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Disabled</label>
+        <label class="col-md-3 col-form-label">Disabled</label>
         <div class="col-md-9">
             <systelab-select
                     [values]="comboOptionList"
@@ -82,7 +82,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Con valor asignado</label>
+        <label class="col-md-3 col-form-label">Con valor asignado</label>
         <div class="col-md-9">
             <systelab-select
                     [id]="1"
@@ -92,7 +92,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Con buscador</label>
+        <label class="col-md-3 col-form-label">Con buscador</label>
         <div class="col-md-9">
             <systelab-select
                     [values]="comboOptionList" [filter]="true"
@@ -101,7 +101,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Color Picker</label>
+        <label class="col-md-3 col-form-label">Color Picker</label>
         <div class="col-md-9">
             <systelab-colorpicker
                     [(id)]="colorId">
@@ -109,28 +109,28 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">All Yes-No</label>
+        <label class="col-md-3 col-form-label">All Yes-No</label>
         <div class="col-md-9">
             <systelab-all-yes-no-select>
             </systelab-all-yes-no-select>
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Gender</label>
+        <label class="col-md-3 col-form-label">Gender</label>
         <div class="col-md-9">
             <systelab-gender-select>
             </systelab-gender-select>
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Time unit</label>
+        <label class="col-md-3 col-form-label">Time unit</label>
         <div class="col-md-9">
             <systelab-time-unit-select>
             </systelab-time-unit-select>
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Multiple Selection</label>
+        <label class="col-md-3 col-form-label">Multiple Selection</label>
         <div class="col-md-9">
             <systelab-select
                     [multipleSelection]="multiple"
@@ -144,7 +144,7 @@
         </div>
     </div>
     <div class="row mt-1">
-        <label class="col-md-3 col-form-label" for="form-h-s">Tree Combobox with favourites</label>
+        <label class="col-md-3 col-form-label">Tree Combobox with favourites</label>
         <div class="col-md-9">
             <showcase-inner-tree-combobox [withFavourites]="true"
                                           [preferenceName]="'favourites.section-laboratory-combobox'"></showcase-inner-tree-combobox>

--- a/projects/showcase/src/app/components/combobox/showcase-combobox.component.ts
+++ b/projects/showcase/src/app/components/combobox/showcase-combobox.component.ts
@@ -1,4 +1,5 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
+import { ComboboxOption } from "../../../../../systelab-components/src/lib/combobox/combobox-option.interface";
 
 @Component({
 	selector: 'showcase-combobox',
@@ -11,9 +12,9 @@ export class ShowcaseComboboxComponent {
 	public listSelectedValues = true;
 	public multiple = true;
 
-	public comboOptionList: Array<Object> = [];
+	public comboOptionList: ComboboxOption<number>[] = [];
 
-	public selectedComboOptionList: Array<Object> = [];
+	public selectedComboOptionList: ComboboxOption<number>[] = [];
 
 	constructor() {
 

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/README.md
+++ b/projects/systelab-components/src/lib/combobox/README.md
@@ -24,8 +24,12 @@ For example:
 
 ```
 class MaritalStatus {
-    constructor(public id: string, public description: string) {
-    }
+    public static getOption<T>(id: T, description: string): ComboboxOption<T> {
+		return {
+			id,
+			description,
+		};
+	}
 }
 
 @Component({
@@ -33,21 +37,21 @@ class MaritalStatus {
     templateUrl: '../../../../../node_modules/systelab-components/html/abstract-combobox.component.html'
 })
 
-export class MaritalStatusComboBox extends AbstractComboBox<MaritalStatus> {
+export class MaritalStatusComboBox extends AbstractComboBox<ComboboxOption<string>> {
 
     constructor(myRenderer: Renderer2, public chRef: ChangeDetectorRef, public i18nService: I18nService) {
         super(myRenderer, chRef);
-        this.values = new Array<MaritalStatus>();
-        this.values.push(new MaritalStatus('1', 'Single'));
-        this.values.push(new MaritalStatus('2', 'Married'));
-        this.values.push(new MaritalStatus('3', 'Widowed'));
-        this.values.push(new MaritalStatus('4', 'Divorced'));
-        this.values.push(new MaritalStatus('5', 'Separated'));
-        this.values.push(new MaritalStatus('6', 'Registered partnership'));
+        this.values: ComboboxOption<string>[] = [];
+        this.values.push(MaritalStatus.getOption<string>('1', 'Single'));
+        this.values.push(MaritalStatus.getOption<string>('2', 'Married'));
+        this.values.push(MaritalStatus.getOption<string>('3', 'Widowed'));
+        this.values.push(MaritalStatus.getOption<string>('4', 'Divorced'));
+        this.values.push(MaritalStatus.getOption<string>('5', 'Separated'));
+        this.values.push(MaritalStatus.getOption<string>('6', 'Registered partnership'));
     }
 
-    getInstance(): MaritalStatus {
-        return new MaritalStatus('0', 'Unknown');
+    getInstance(): ComboboxOption<string> {
+        return MaritalStatus.getOption<string>('0', 'Unknown');
     }
 
     getDescriptionField(): string {
@@ -83,8 +87,12 @@ For example:
 
 ```
 class Laboratory {
-    constructor(public id: string, public description: string) {
-    }
+    public static getOption<T>(id: T, description: string): ComboboxOption<T> {
+		return {
+			id,
+			description,
+		};
+	}
 }
 
 @Component({
@@ -92,7 +100,7 @@ class Laboratory {
     templateUrl: '../../../../../node_modules/systelab-components/html/abstract-combobox.component.html'
 })
 
-export class LaboratoryComboBox extends AbstractApiComboBox<Laboratory> {
+export class LaboratoryComboBox extends AbstractApiComboBox<ComboboxOption<string>> {
 
     private totalItems=0;
 
@@ -101,7 +109,7 @@ export class LaboratoryComboBox extends AbstractApiComboBox<Laboratory> {
     }
 
     public getInstance() {
-        return new Laboratory('','');
+        return Laboratory.getOption<string>('','');
     }
 
     public getDescriptionField(): string {
@@ -116,7 +124,7 @@ export class LaboratoryComboBox extends AbstractApiComboBox<Laboratory> {
         return 'id';
     }
 
-    public getData(page: number, itemsPerPage: number): Observable<Array<Laboratory>> {
+    public getData(page: number, itemsPerPage: number): Observable<Array<Combobox<string | number>>> {
         return this.api.getLaboratoryList(page,itemsPerPage).pipe(map((value) => {
             this.totalItems = value.totalElements;
             return value.content;
@@ -194,35 +202,35 @@ Once you have your component, you can use it in your templates.
 
 ## Properties
 
-| Name | Type | Default | Description |
-| ---- |:----:|:-------:| ----------- |
-| **id** | string | | Identifier |
-| **description** | string | | Description or name that will be shown in the combobox |
-| **code** | string | | Short code |
-| **fieldToShow** | string | | Description or name for autocomplete combobox|
-| **multipleSelectedItemList** | Array<T> | | Array with selected elements for comboboxes with selection multiple|
-| startsWith| string | | Look up the item in the combo that starts with the entered text
-| customInputRenderer | any | | Class of the component with a custom renderer for the combo input field. This class must extend ComboBoxInputRenderer class|
-| initialParams | any | | Class with the initial params of the component defined in customInputRender property |
-| filter | boolean | false | If true adds an input field inside dropdown to search elements. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos|
-| multipleSelection | boolean | false | Enable to select multiple elements. A checkbox will be rendered in front of each element. |
-| selectDeselectAll | boolean | false | For a multiple selection combobox, set if a 'Select All' and 'Un-select all' should be shown inside the dropdown of the combo. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos|
-| listSelectedValues | boolean | false | Shows the selected values at the bottom of the combobox. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos|
-| fontFamily | string | | Font Family |
-| fontSize | string | | Font size in pixels |
-| fontWeight | string | | normal, bold, bolder, lighter, number, initial or inherit |
-| fontStyle | string | | normal, italic, oblique, initial or inherit |
-| values | Array<any> | | Array with the elements of the combobox. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos|
-| isDisabled | boolean | false | If true the combo is disabled|
-| expandToParentContainerHeight | boolean | false | If true the combo expands its height to parent container height|
-| emptyElement | boolean | false | If true adds and emtpy element at the first position of the elements list in the dropdown. Use it only in combos that extends from AbstractApiComboBox or AbstractApiTreeComboBox. Never use it with multipleSelection property|
-| allElement | boolean | false | If true adds an element that represents the "all" element at the first position of the elements list in the dropdown (the second if the emptyElement is also set to true). Use it only in combos that extends from AbstractComboBox or AbstractApiComboBox. It can be used with multipleSelection property. In this last case, if the "all" element is selected no other option will remain selected. Reversely, if the "all" element is selected and the user select any other option, then the "all" element is deselected. |																																																																																																																																								
-| withFavourites | boolean | false | Used to activate and deactivate the favourites |
-| withDeleteOption | boolean | false | Used to activate and deactivate the reset combo option |
-| defaultIdValue | string | | Used to define the default id of the combo |
-| defaultDescription | string | | Used to define the default description selected of the combo |
-| defaultCode | string | | Used to define the default code selected of the combo |
-| preferencesName | string | '' | Preference name over will be saved the preferences |
+| Name                          |                     Type                     |                                                                Default                                                                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|-------------------------------|:--------------------------------------------:|:-------------------------------------------------------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **id**                        |                    string                    |                                                                                                                                       | Identifier                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **description**               |                    string                    |                                                                                                                                       | Description or name that will be shown in the combobox                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| **code**                      |                    string                    |                                                                                                                                       | Short code                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **fieldToShow**               |                    string                    |                                                                                                                                       | Description or name for autocomplete combobox                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **multipleSelectedItemList**  |                   Array<T>                   |                                                                                                                                       | Array with selected elements for comboboxes with selection multiple                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| startsWith                    |                    string                    |                                                                                                                                       | Look up the item in the combo that starts with the entered text                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| customInputRenderer           |                     any                      |                                                                                                                                       | Class of the component with a custom renderer for the combo input field. This class must extend ComboBoxInputRenderer class                                                                                                                                                                                                                                                                                                                                                                                                   |
+| initialParams                 |                     any                      |                                                                                                                                       | Class with the initial params of the component defined in customInputRender property                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| filter                        |                   boolean                    |                                                                 false                                                                 | If true adds an input field inside dropdown to search elements. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos                                                                                                                                                                                                                                                                                                                                                                  |
+| multipleSelection             |                   boolean                    |                                                                 false                                                                 | Enable to select multiple elements. A checkbox will be rendered in front of each element.                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| selectDeselectAll             |                   boolean                    |                                                                 false                                                                 | For a multiple selection combobox, set if a 'Select All' and 'Un-select all' should be shown inside the dropdown of the combo. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos                                                                                                                                                                                                                                                                                                   |
+| listSelectedValues            |                   boolean                    |                                                                 false                                                                 | Shows the selected values at the bottom of the combobox. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos                                                                                                                                                                                                                                                                                                                                                                         |
+| fontFamily                    |                    string                    |                                                                                                                                       | Font Family                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| fontSize                      |                    string                    |                                                                                                                                       | Font size in pixels                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| fontWeight                    |                    string                    |                                                                                                                                       | normal, bold, bolder, lighter, number, initial or inherit                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| fontStyle                     |                    string                    |                                                                                                                                       | normal, italic, oblique, initial or inherit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| values                        | `Array<ComboboxOption<string &vert; number>` | Array with the elements of the combobox. Use it only in combos that extends from AbstractComboBox. Do not use with AbstractApi combos |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| isDisabled                    |                   boolean                    |                                                                 false                                                                 | If true the combo is disabled                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| expandToParentContainerHeight |                   boolean                    |                                                                 false                                                                 | If true the combo expands its height to parent container height                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| emptyElement                  |                   boolean                    |                                                                 false                                                                 | If true adds and emtpy element at the first position of the elements list in the dropdown. Use it only in combos that extends from AbstractApiComboBox or AbstractApiTreeComboBox. Never use it with multipleSelection property                                                                                                                                                                                                                                                                                               |
+| allElement                    |                   boolean                    |                                                                 false                                                                 | If true adds an element that represents the "all" element at the first position of the elements list in the dropdown (the second if the emptyElement is also set to true). Use it only in combos that extends from AbstractComboBox or AbstractApiComboBox. It can be used with multipleSelection property. In this last case, if the "all" element is selected no other option will remain selected. Reversely, if the "all" element is selected and the user select any other option, then the "all" element is deselected. |																																																																																																																																								
+| withFavourites                |                   boolean                    |                                                                 false                                                                 | Used to activate and deactivate the favourites                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| withDeleteOption              |                   boolean                    |                                                                 false                                                                 | Used to activate and deactivate the reset combo option                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| defaultIdValue                |                    string                    |                                                                                                                                       | Used to define the default id of the combo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| defaultDescription            |                    string                    |                                                                                                                                       | Used to define the default description selected of the combo                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| defaultCode                   |                    string                    |                                                                                                                                       | Used to define the default code selected of the combo                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| preferencesName               |                    string                    |                                                                  ''                                                                   | Preference name over will be saved the preferences                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 In black the Two-Way Data Binding properties.
 

--- a/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.spec.ts
@@ -14,9 +14,14 @@ import { AbstractApiComboBox } from './abstract-api-combobox.component';
 import { GridHeaderContextMenuComponent } from '../grid/contextmenu/grid-header-context-menu-renderer.component';
 import { GridContextMenuCellRendererComponent } from '../grid/contextmenu/grid-context-menu-cell-renderer.component';
 import { ComboBoxInputRendererComponent } from './renderer/combobox-input-renderer.component';
+import { ComboboxOption } from './combobox-option.interface';
 
-export class TestData {
-	constructor(public id: string | number, public description: string) {
+class TestData {
+	public static getOption<T>(id: T, description: string): ComboboxOption<T> {
+		return {
+			id,
+			description,
+		};
 	}
 }
 
@@ -32,8 +37,8 @@ export class SystelabComboboxComponent extends AbstractApiComboBox<TestData> {
 		super(myRenderer, chref);
 	}
 
-	public getInstance() {
-		return new TestData('', '');
+	public getInstance(): ComboboxOption<string> {
+		return TestData.getOption<string>('', '');
 	}
 
 	public getDescriptionField(): string {
@@ -49,11 +54,11 @@ export class SystelabComboboxComponent extends AbstractApiComboBox<TestData> {
 	}
 
 	public getData(): Observable<Array<TestData>> {
-		const values: TestData[] = [];
-		values.push(new TestData('1', 'Description 1'));
-		values.push(new TestData('2', 'Description 2'));
-		values.push(new TestData('3', 'Description 3'));
-		values.push(new TestData(4, 'Description 4'));
+		const values: ComboboxOption<number | string>[] = [];
+		values.push(TestData.getOption<string>('1', 'Description 1'));
+		values.push(TestData.getOption<string>('2', 'Description 2'));
+		values.push(TestData.getOption<string>('3', 'Description 3'));
+		values.push(TestData.getOption<number>(4, 'Description 4'));
 		this.totalItems = values.length;
 		return of(values);
 	}
@@ -84,9 +89,9 @@ export class ComboboxTestComponent {
 	public id = '1';
 	public description = 'Description 2';
 	public multipleSelection = false;
-	public multipleSelectedItemList = [
-		new TestData('3', 'Description 3'),
-		new TestData(4, 'Description 4')
+	public multipleSelectedItemList: ComboboxOption<number | string>[] = [
+		TestData.getOption<string>('3', 'Description 3'),
+		TestData.getOption<number>(4, 'Description 4')
 	];
 }
 

--- a/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.ts
@@ -14,31 +14,10 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 
 	public totalItemsLoaded = false;
 
-	constructor(public override myRenderer: Renderer2, public chref: ChangeDetectorRef, public override preferencesService?: PreferencesService) {
+	protected constructor(public override myRenderer: Renderer2, public chref: ChangeDetectorRef,
+						  public override preferencesService?: PreferencesService) {
 		super(myRenderer, chref, preferencesService);
 	}
-
-	// override
-	protected override configGrid() {
-
-		super.configGrid();
-		this.gridOptions.rowModelType = 'infinite';
-		this.gridOptions.paginationPageSize = 20;
-		this.gridOptions.cacheBlockSize = 20;
-		this.gridOptions.cacheOverflowSize = 2;
-		this.gridOptions.maxConcurrentDatasourceRequests = 1;
-		this.gridOptions.infiniteInitialRowCount = 0;
-		this.gridOptions.maxBlocksInCache = 100;
-
-	}
-
-	protected override configGridData() {
-		this.gridOptions.datasource = null;
-	}
-
-	public abstract getData(page: number, itemsPerPage: number, startsWithParameter: string): Observable<Array<T>>;
-
-	public abstract getTotalItems(): number;
 
 	public override refresh(params: any): boolean {
 		if (this.gridOptions && this.gridOptions.api) {
@@ -70,11 +49,6 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 		}
 	}
 
-	//override
-	protected override getTotalItemsInCombo(): number {
-		return this.getTotalItems();
-	}
-
 	public override doSearch(event: any) {
 		if (event.shiftKey || event.ctrlKey) {
 			return;
@@ -104,7 +78,7 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 				.subscribe({
 						next:  (previousPage: Array<T>) => {
 							const itemArray: Array<T> = new Array<T>();
-							const totItems: number = Number(this.getTotalItems() + emptyElemNumber + allNumber);
+							const totItems = Number(this.getTotalItems() + emptyElemNumber + allNumber);
 							if (this.emptyElement === true && this.allElement === true) {
 								const lastButOneItemFromPreviousPage = previousPage[this.gridOptions.paginationPageSize - 2];
 								itemArray.push(lastButOneItemFromPreviousPage);
@@ -128,13 +102,36 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 		}
 	}
 
+	// override
+	protected override configGrid() {
+
+		super.configGrid();
+		this.gridOptions.rowModelType = 'infinite';
+		this.gridOptions.paginationPageSize = 20;
+		this.gridOptions.cacheBlockSize = 20;
+		this.gridOptions.cacheOverflowSize = 2;
+		this.gridOptions.maxConcurrentDatasourceRequests = 1;
+		this.gridOptions.infiniteInitialRowCount = 0;
+		this.gridOptions.maxBlocksInCache = 100;
+
+	}
+
+	protected override configGridData() {
+		this.gridOptions.datasource = null;
+	}
+
+	//override
+	protected override getTotalItemsInCombo(): number {
+		return this.getTotalItems();
+	}
+
 	private getElements(page: number, pageSize: number, emptyElemNumber: number, allNumber: number, params: IGetRowsParams) {
 		this.totalItemsLoaded = false;
 		this.getData(page, pageSize, this.startsWith)
 			.subscribe({
 					next:  (v: Array<T>) => {
 						const itemArray: Array<T> = new Array<T>();
-						const totalItems: number = Number(this.getTotalItems() + emptyElemNumber + allNumber);
+						const totalItems = Number(this.getTotalItems() + emptyElemNumber + allNumber);
 
 						if (this.emptyElement === true || this.allElement === true) {
 
@@ -158,30 +155,29 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 							} else {
 								this.getData(page - 1, this.gridOptions.paginationPageSize, this.startsWith)
 									.subscribe({
-											next:  (previousPage: Array<T>) => {
+										next:  (previousPage: Array<T>) => {
 
-												if (this.emptyElement === true && this.allElement === true) {
-													const lastButOneItemFromPreviousPage = previousPage[this.gridOptions.paginationPageSize - 2];
-													itemArray.push(lastButOneItemFromPreviousPage);
+											if (this.emptyElement === true && this.allElement === true) {
+												const lastButOneItemFromPrevPage = previousPage[this.gridOptions.paginationPageSize - 2];
+												itemArray.push(lastButOneItemFromPrevPage);
 
-													const lastItemFromPreviousPage = previousPage[this.gridOptions.paginationPageSize - 1];
-													itemArray.push(lastItemFromPreviousPage);
-												} else {
-													const lastItemFromPreviousPage = previousPage[this.gridOptions.paginationPageSize - 1];
-													itemArray.push(lastItemFromPreviousPage);
-												}
-
-												for (const originalElement of v) {
-													itemArray.push(originalElement);
-												}
-												this.totalItemsLoaded = true;
-												params.successCallback(itemArray, totalItems);
-											},
-											error: () => {
-												params.failCallback();
+												const lastItemFromPreviousPage = previousPage[this.gridOptions.paginationPageSize - 1];
+												itemArray.push(lastItemFromPreviousPage);
+											} else {
+												const lastItemFromPreviousPage = previousPage[this.gridOptions.paginationPageSize - 1];
+												itemArray.push(lastItemFromPreviousPage);
 											}
+
+											for (const originalElement of v) {
+												itemArray.push(originalElement);
+											}
+											this.totalItemsLoaded = true;
+											params.successCallback(itemArray, totalItems);
+										},
+										error: () => {
+											params.failCallback();
 										}
-									);
+									});
 							}
 						} else {
 
@@ -198,5 +194,9 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 				}
 			);
 	}
+
+	public abstract getData(page: number, itemsPerPage: number, startsWithParameter: string): Observable<Array<T>>;
+
+	public abstract getTotalItems(): number;
 
 }

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -13,9 +13,14 @@ import { GridHeaderContextMenuComponent } from '../grid/contextmenu/grid-header-
 import { GridContextMenuCellRendererComponent } from '../grid/contextmenu/grid-context-menu-cell-renderer.component';
 import { ComboBoxInputRendererComponent } from './renderer/combobox-input-renderer.component';
 import { ModulabSelect } from '../select/select.component';
+import { ComboboxOption } from './combobox-option.interface';
 
-export class TestData {
-	constructor(public id: string | number, public description: string) {
+class TestData {
+	public static getOption<T>(id: T, description: string): ComboboxOption<T> {
+		return {
+			id,
+			description,
+		};
 	}
 }
 
@@ -41,7 +46,10 @@ export class TestData {
 export class ComboboxTestComponent {
 	@ViewChild('combobox') public combobox: ModulabSelect;
 	public filter = false;
-	public valuesList: TestData[] = [new TestData('1', 'Description 1'), new TestData('2', 'Description 2')];
+	public valuesList: ComboboxOption<string>[] = [
+		TestData.getOption<string>('1', 'Description 1'),
+		TestData.getOption<string>('2', 'Description 2')
+	];
 	public withEmptyValue = false;
 	public deleteIconClass = 'icon-close';
 	public defaultIdValue = undefined;

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -1,11 +1,23 @@
-import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+	ChangeDetectorRef,
+	Directive,
+	ElementRef,
+	EventEmitter,
+	HostListener,
+	Input,
+	OnDestroy,
+	OnInit,
+	Output,
+	Renderer2,
+	ViewChild
+} from '@angular/core';
 import { AgRendererComponent } from 'ag-grid-angular';
 import { GetRowIdParams, GridOptions } from 'ag-grid-community';
 import { StylesUtilService } from '../utilities/styles.util.service';
 import { ComboboxFavouriteRendererComponent } from './renderer/combobox-favourite-renderer.component';
 import { PreferencesService } from 'systelab-preferences';
 
-declare var jQuery: any;
+declare let jQuery: any;
 
 @Directive()
 export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit, OnDestroy {
@@ -346,7 +358,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	public getInputHeight() {
-		return this.expandToParentContainerHeight ? {'height': '100%'} : undefined;
+		return this.expandToParentContainerHeight ? {height: '100%'} : undefined;
 	}
 
 	protected getComboPreferencesPrefix(): string {
@@ -642,9 +654,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		if (!this.multipleSelection) {
 		} else if (event.node && event.node.data && event.node.data[this.getIdField()] !== undefined) {
 			if (this.multipleSelectedItemList) {
-				const elementIndexInSelectedList: number = this.multipleSelectedItemList.findIndex((item) => {
-					return item[this.getIdField()] === event.node.data[this.getIdField()];
-				});
+				const elementIndexInSelectedList: number = this.multipleSelectedItemList.findIndex((item) => item[this.getIdField()] === event.node.data[this.getIdField()]);
 				if (event.node.selected) {
 					if (elementIndexInSelectedList < 0) {
 						if (this.allElement) {
@@ -654,9 +664,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 								this.unselectAllNodesInGridOptions();
 							} else {
 								// the selectedNode is NOT "all: was "all" node already selected?
-								const elementAllInSelectedList: number = this.multipleSelectedItemList.findIndex((item) => {
-									return item[this.getIdField()] === this.getAllFieldIDValue();
-								});
+								const elementAllInSelectedList: number = this.multipleSelectedItemList.findIndex((item) => item[this.getIdField()] === this.getAllFieldIDValue());
 								// yes, it was => unselect "all" node and empty the multipleSelectedItemList
 								if (elementAllInSelectedList !== -1) {
 									this.multipleSelectedItemList = [];

--- a/projects/systelab-components/src/lib/combobox/combobox-option.interface.ts
+++ b/projects/systelab-components/src/lib/combobox/combobox-option.interface.ts
@@ -1,0 +1,4 @@
+export interface ComboboxOption<T> {
+    id: T;
+    description: string;
+}

--- a/projects/systelab-components/src/public-api.ts
+++ b/projects/systelab-components/src/public-api.ts
@@ -69,6 +69,7 @@ export * from './lib/image-viewer/image-viewer.component';
 export * from './lib/percentage-circle/percentage-circle.component';
 export * from './lib/combobox/abstract-combobox.component';
 export * from './lib/combobox/abstract-api-combobox.component';
+export * from './lib/combobox/combobox-option.interface';
 export * from './lib/combobox/autocomplete/autocomplete-api-combobox.component';
 export * from './lib/combobox/renderer/combobox-favourite-renderer.component';
 export * from './lib/combobox/renderer/combobox-input-renderer.component';


### PR DESCRIPTION
# PR Details

A new ComboboxOption interface has been added.

## Description

To be able to assure the consistency of the data passed to the combobox, a new interface has been added to be used to type data in the options array.

## Related Issue

https://github.com/systelab/systelab-components/issues/715

## Motivation and Context

Reinforce type driven development

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
