### PR TITLE
Feature 732

### DIFF
--- a/projects/systelab-components/README.md
+++ b/projects/systelab-components/README.md
@@ -37,7 +37,7 @@ After, you must add the following styles, stylePreprocessorOptions and scripts i
       ],
 ```
 
-> Be careful because you will not probably need all fontawesome 5.x. Instead you can add:
+> Be careful because you will not probably need all fontawesome 5.x. Instead, you can add:
 > - brands.css
 > - fontawesome.css
 > - regular.css
@@ -55,13 +55,15 @@ NgModule({
         SystelabTranslateModule,
         SystelabPreferencesModule,
         SystelabLoginModule,
-        SystelabComponentsModule,
+        SystelabComponentsModule.forRoot({productionMode: false}),
         AgGridModule.withComponents([
             GridContextMenuCellRendererComponent,
             GridHeaderContextMenuComponent
         ]),
     ...
 ```
+
+You can config the productionMode for the library to true or false using the forRoot method.
 
 Finally, you must import the systelab-components sass file in the general styles file in src/styles.scss.
 

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.0",
+  "version": "15.4.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/config.ts
+++ b/projects/systelab-components/src/lib/config.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export const APP_CONFIG = new InjectionToken<AppConfig>('APP_CONFIG_PARAMS');
+
+export interface AppConfig{
+    productionMode: boolean;
+}

--- a/projects/systelab-components/src/lib/directives/README.md
+++ b/projects/systelab-components/src/lib/directives/README.md
@@ -46,3 +46,15 @@ i.e: when locale is spanish, if we click the '.' key it translates the '.' to ',
 ```html
 <input type="text" id="ID_DOSE"  systelabNumPadDecimalNumericDirective/>
 ```
+
+## testId
+
+This directives adds a HTML data-test-id attribute if the configuration is not set to production. This data field can be used
+to select the element for testing purpose.
+
+This directive also avoid to have non needed code when the
+application is in production.
+
+```html
+<div systelabTestId="people"></div>
+```

--- a/projects/systelab-components/src/lib/directives/README.md
+++ b/projects/systelab-components/src/lib/directives/README.md
@@ -49,10 +49,10 @@ i.e: when locale is spanish, if we click the '.' key it translates the '.' to ',
 
 ## testId
 
-This directives adds a HTML data-test-id attribute if the configuration is not set to production. This data field can be used
+This directive adds an HTML data-test-id attribute if the configuration is not set to production. This data field can be used
 to select the element for testing purpose.
 
-This directive also avoid to have non needed code when the
+This directive also avoids to have non needed code when the
 application is in production.
 
 ```html

--- a/projects/systelab-components/src/lib/directives/keyup-debounce.directive.ts
+++ b/projects/systelab-components/src/lib/directives/keyup-debounce.directive.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, AfterViewInit, Directive, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -7,7 +7,7 @@ import { debounceTime } from 'rxjs/operators';
 })
 export class KeyupDebounceDirective implements OnInit, OnDestroy {
 
-	@Input() public keyupDebounceTime:number = 350;
+	@Input() public keyupDebounceTime = 350;
 	@Output() public keyupDebounced = new EventEmitter();
 	private debouncer = new Subject();
 	private subscription: Subscription;

--- a/projects/systelab-components/src/lib/directives/numpad-decimal-numeric-point.directive.spec.ts
+++ b/projects/systelab-components/src/lib/directives/numpad-decimal-numeric-point.directive.spec.ts
@@ -30,11 +30,11 @@ const englishNumPadScenarios = [
 	{description: 'Use Number not processed', code: 'Digit8', key: '8', expected: ''},
 ];
 
-function setup() {
+const setup = () => {
 	const fixture = TestBed.createComponent(TestComponent);
 	fixture.detectChanges();
 	return {fixture};
-}
+};
 
 describe('Verify numPadDecimalNumericDirective english', () => {
 

--- a/projects/systelab-components/src/lib/directives/test-id.directive.spec.ts
+++ b/projects/systelab-components/src/lib/directives/test-id.directive.spec.ts
@@ -1,0 +1,27 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TestIdDirective } from './test-id.directive';
+
+@Component({
+  template: `
+    <div systelabTestId='test'></div>
+  `
+})
+class TestComponent {}
+
+describe('SystelabTestId Directive', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [ TestComponent, TestIdDirective ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+    }).createComponent(TestComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create an instance', () => {
+    const div: HTMLElement = fixture.nativeElement.query(By.css('div[data-test-is="test"]'));
+    expect(div).toBeTruthy();
+  });
+});

--- a/projects/systelab-components/src/lib/directives/test-id.directive.spec.ts
+++ b/projects/systelab-components/src/lib/directives/test-id.directive.spec.ts
@@ -1,6 +1,6 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { BrowserModule, By } from '@angular/platform-browser';
 import { TestIdDirective } from './test-id.directive';
 
 @Component({
@@ -8,20 +8,23 @@ import { TestIdDirective } from './test-id.directive';
     <div systelabTestId='test'></div>
   `
 })
-class TestComponent {}
+class SystelabTestIdDirectiveTestComponent {}
 
 describe('SystelabTestId Directive', () => {
-  let fixture: ComponentFixture<TestComponent>;
-  beforeEach(() => {
-    fixture = TestBed.configureTestingModule({
-      declarations: [ TestComponent, TestIdDirective ],
+  let fixture: ComponentFixture<SystelabTestIdDirectiveTestComponent>;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BrowserModule],
+      declarations: [ SystelabTestIdDirectiveTestComponent, TestIdDirective ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
-    }).createComponent(TestComponent);
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SystelabTestIdDirectiveTestComponent);
     fixture.detectChanges();
   });
 
-  it('should create an instance', () => {
-    const div: HTMLElement = fixture.nativeElement.query(By.css('div[data-test-is="test"]'));
+  it('should create an instance', fakeAsync(() => {
+    const div: DebugElement = fixture.debugElement.query(By.css('div[data-test-id="test"]'));
     expect(div).toBeTruthy();
-  });
+  }));
 });

--- a/projects/systelab-components/src/lib/directives/test-id.directive.spec.ts
+++ b/projects/systelab-components/src/lib/directives/test-id.directive.spec.ts
@@ -2,6 +2,7 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { TestIdDirective } from './test-id.directive';
+import { APP_CONFIG } from '../config';
 
 @Component({
   template: `
@@ -10,12 +11,58 @@ import { TestIdDirective } from './test-id.directive';
 })
 class SystelabTestIdDirectiveTestComponent {}
 
-describe('SystelabTestId Directive', () => {
+describe('SystelabTestId Directive without module configuration', () => {
+    let fixture: ComponentFixture<SystelabTestIdDirectiveTestComponent>;
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [BrowserModule],
+        declarations: [ SystelabTestIdDirectiveTestComponent, TestIdDirective ],
+        schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SystelabTestIdDirectiveTestComponent);
+      fixture.detectChanges();
+    });
+
+    it('shouldn\'t add "data-test-id" attribute with defined label into DOM element because of productionMode ' +
+       'hasn\'t been set', fakeAsync(() => {
+      const div: DebugElement = fixture.debugElement.query(By.css('div[data-test-id="test"]'));
+      expect(div).toBeFalsy();
+    }));
+});
+
+describe('SystelabTestId Directive with productionMode to true', () => {
+    let fixture: ComponentFixture<SystelabTestIdDirectiveTestComponent>;
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [BrowserModule],
+        declarations: [ SystelabTestIdDirectiveTestComponent, TestIdDirective ],
+        providers: [{
+          provide: APP_CONFIG, useValue: {productionMode: true},
+        }],
+        schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SystelabTestIdDirectiveTestComponent);
+      fixture.detectChanges();
+    });
+
+      it('shouldn\'t add "data-test-id" attribute with defined label into DOM element because of productionMode ' +
+          'has been set as true', fakeAsync(() => {
+        const div: DebugElement = fixture.debugElement.query(By.css('div[data-test-id="test"]'));
+        expect(div).toBeFalsy();
+      }));
+});
+
+describe('SystelabTestId Directive with productionMode to false', () => {
   let fixture: ComponentFixture<SystelabTestIdDirectiveTestComponent>;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [BrowserModule],
       declarations: [ SystelabTestIdDirectiveTestComponent, TestIdDirective ],
+      providers: [{
+        provide: APP_CONFIG, useValue: {productionMode: false},
+      }],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
     }).compileComponents();
 
@@ -23,7 +70,7 @@ describe('SystelabTestId Directive', () => {
     fixture.detectChanges();
   });
 
-  it('should create an instance', fakeAsync(() => {
+  it('should add "data-test-id" attribute with defined label into DOM element', fakeAsync(() => {
     const div: DebugElement = fixture.debugElement.query(By.css('div[data-test-id="test"]'));
     expect(div).toBeTruthy();
   }));

--- a/projects/systelab-components/src/lib/directives/test-id.directive.ts
+++ b/projects/systelab-components/src/lib/directives/test-id.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, ElementRef, Inject, Input, OnInit, Optional, Renderer2 } from '@angular/core';
 import { APP_CONFIG } from '../config';
 
+const DEFAULT_PRODUCTION_MODE = true;
 @Directive({
   selector: '[systelabTestId]'
 })
@@ -9,7 +10,7 @@ export class TestIdDirective implements OnInit {
   private readonly productionMode: boolean;
 
   constructor(@Optional() @Inject(APP_CONFIG) private config, private renderer: Renderer2, private el: ElementRef) {
-    this.productionMode = (config) ? config.productionMode : false;
+    this.productionMode = (config) ? config.productionMode : DEFAULT_PRODUCTION_MODE;
   }
 
   ngOnInit() {

--- a/projects/systelab-components/src/lib/directives/test-id.directive.ts
+++ b/projects/systelab-components/src/lib/directives/test-id.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, ElementRef, Inject, Input, OnInit, Optional, Renderer2 } from '@angular/core';
+import { APP_CONFIG } from '../config';
+
+@Directive({
+  selector: '[systelabTestId]'
+})
+export class TestIdDirective implements OnInit {
+  @Input('systelabTestId') label: string;
+  private readonly productionMode: boolean;
+
+  constructor(@Optional() @Inject(APP_CONFIG) private config, private renderer: Renderer2, private el: ElementRef) {
+    this.productionMode = (config) ? config.productionMode : false;
+  }
+
+  ngOnInit() {
+    if (!this.productionMode) {
+      this.addE2EAttribute();
+    }
+  }
+
+  private addE2EAttribute() {
+    this.renderer.setAttribute(this.el.nativeElement, 'data-test-id', this.label);
+  }
+
+}

--- a/projects/systelab-components/src/lib/systelab-components.module.spec.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.spec.ts
@@ -1,0 +1,15 @@
+import { SystelabComponentsModule } from './systelab-components.module';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+
+describe('Systelab Components', () => {
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [SystelabComponentsModule],
+        });
+    });
+
+    it('module should be loaded', fakeAsync(() => {
+        const module = TestBed.inject(SystelabComponentsModule);
+        expect(module).toBeTruthy();
+    }));
+});

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SliderComponent } from './slider/slider.component';
 import { SwitchComponent } from './switch/switch.component';
@@ -97,8 +97,10 @@ import { SliderDoubleRangeComponent } from './slider-double-range/slider-double-
 import { ButtonComponent } from './button/button.component';
 import { DraggableDirective } from './directives/draggable.directive';
 import { ResizableDirective } from './directives/resizable.directive';
-import {ImageViewerComponent} from './image-viewer/image-viewer.component';
+import { ImageViewerComponent } from './image-viewer/image-viewer.component';
 import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numeric.directive';
+import { APP_CONFIG, AppConfig } from './config';
+import { TestIdDirective } from './directives/test-id.directive';
 
 @NgModule({
 	imports:      [
@@ -200,7 +202,8 @@ import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numer
 		DraggableDirective,
 		ResizableDirective,
 		ImageViewerComponent,
-		NumpadDecimalNumericDirective
+		NumpadDecimalNumericDirective,
+  TestIdDirective
 	],
 	exports:      [
 		SliderComponent,
@@ -294,4 +297,21 @@ import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numer
 	]
 })
 export class SystelabComponentsModule {
+
+	constructor(@Optional() @SkipSelf() parentModule: SystelabComponentsModule) {
+		if(parentModule) {
+			throw new Error('SystelabComponentsModule is already loaded. Please add it in AppModule only.');
+		}
+	}
+
+	public static forRoot(conf?: AppConfig): ModuleWithProviders<SystelabComponentsModule> {
+		return {
+			ngModule: SystelabComponentsModule,
+			providers: [
+				{
+					provide: APP_CONFIG, useValue: conf
+				}
+			]
+		};
+	}
 }

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -203,7 +203,7 @@ import { TestIdDirective } from './directives/test-id.directive';
 		ResizableDirective,
 		ImageViewerComponent,
 		NumpadDecimalNumericDirective,
-  TestIdDirective
+  		TestIdDirective,
 	],
 	exports:      [
 		SliderComponent,
@@ -288,7 +288,8 @@ import { TestIdDirective } from './directives/test-id.directive';
 		DraggableDirective,
 		ResizableDirective,
 		ImageViewerComponent,
-		NumpadDecimalNumericDirective
+		NumpadDecimalNumericDirective,
+		TestIdDirective,
 	],
 	providers:    [
 		StylesUtilService,

--- a/projects/systelab-components/src/public-api.ts
+++ b/projects/systelab-components/src/public-api.ts
@@ -109,6 +109,7 @@ export * from './lib/directives/keyup-debounce.directive';
 export * from './lib/directives/draggable.directive';
 export * from './lib/directives/resizable.directive';
 export * from './lib/directives/numpad-decimal-numeric.directive';
+export * from './lib/directives/test-id.directive';
 
 
 export * from './lib/listbox/renderer/abstract-tree-listbox-renderer.component';


### PR DESCRIPTION
# PR Details

A new directive for testing purpose has been added. Furthermore a new config method for the library has been added to be able to config if the productionMode is enabled or not.

## Related Issue

#732  
https://github.com/systelab/systelab-components-wdio-test/issues/37

## Motivation and Context

The idea is to be able to enable or disable the 'data-test-id' HTML attributes depending on whether the production mode is enabled or not. Furthermore adds a common to work with frontend test.

## How Has This Been Tested

A new test file has been added to the library.

## Types of changes

- [ x ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x ] I have read the **CONTRIBUTING** document
- [ x ] My code follows the code style of this project
- [ x ] My change requires a change to the documentation 
- [ x ] I have updated the documentation accordingly (README.md for each UI component)
- [ x ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ x  ] All new and existing tests passed
- [ x ] A new branch needs to be created from master to evolve previous versions
- [ x ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ x ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ x ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
