### PR TITLE
Modified the return value when we are using the AskAgain popup

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.4.0",
+  "version": "15.5.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/modal/message-popup/README.md
+++ b/projects/systelab-components/src/lib/modal/message-popup/README.md
@@ -61,7 +61,7 @@ Use showCustomQuestionPopup to show a popup with custom buttons and a question i
 public showCustomQuestionPopup(titleDescription: string, messageDescription: string, modalClass?: string, width?: number, height?: number, buttons?: MessagePopupButton[], icon?: MessagePopupIcon): Observable<any>
 ```
 
-Use showAskAgainPopup to show a popup with a check. Closing the popup will send the check status.
+Use showAskAgainPopup to show a popup with a check. Closing the popup will send an array with the button value and the check status.
 
 ```javascript
 public showAskAgainPopup(titleDescription: string, messageDescription: string, modalClass?: string, width?: number, height?: number, buttons?: MessagePopupButton[], icon?: MessagePopupIcon, messageAskAgain?: string): Observable<any>

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup-view.component.spec.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup-view.component.spec.ts
@@ -80,7 +80,7 @@ describe('Systelab MessagePopupViewComponent', () => {
 			.toBeTruthy();
 
 		component.close();
-		expect(spyDialogRef.close).toHaveBeenCalledWith(false);
+		expect(spyDialogRef.close).toHaveBeenCalledWith([undefined, false]);
 	});
 
 	it('Closing different popup from AskAgainPopup', () => {

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup-view.component.spec.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup-view.component.spec.ts
@@ -99,4 +99,21 @@ describe('Systelab MessagePopupViewComponent', () => {
 		expect(spyDialogRef.close).toHaveBeenCalledWith(undefined);
 	});
 
+	it('Closing the AskAgainPopup returns an array', () => {
+		parameters.askAgain = true;
+
+		spyDialogRef.context = parameters;
+		fixture = TestBed.createComponent(MessagePopupViewComponent);
+		component = fixture.componentInstance;
+		component.parameters = parameters;
+		fixture.detectChanges();
+
+		expect(component)
+			.toBeTruthy();
+
+		component.checkAskAgain = true;
+		component.close('value');
+		expect(spyDialogRef.close).toHaveBeenCalledWith(['value', true]);
+	});
+
 });

--- a/projects/systelab-components/src/lib/modal/message-popup/message-popup-view.component.ts
+++ b/projects/systelab-components/src/lib/modal/message-popup/message-popup-view.component.ts
@@ -45,7 +45,7 @@ export class MessagePopupViewComponent implements ModalComponent<MessagePopupVie
 
 	public close(value?: any): void {
 		if (this.parameters.askAgain) {
-			this.dialog.close(this.checkAskAgain);
+			this.dialog.close([value, this.checkAskAgain]);
 		} else {
 			this.dialog.close(value);
 		}


### PR DESCRIPTION
Modified the return value when we are using the AskAgain popup in order to return the value of the button pressed and the value of the switch AskAgain

# PR Details

Changed the return value of the popup 

## Description

When the dialog is closed, now it will be send a two elements array with button value in the first position and the switch value in the second position

## Related Issue

#736 

## Motivation and Context

It was required to know the value of the button because if we use more than one button this functionality does not was available

## How Has This Been Tested

Automatic test
Manual test launching

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
