### PR TITLE
Impossible to import multiple time SystelabComponentsModule on router lazy loading

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.5.0",
+  "version": "15.6.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -1,4 +1,4 @@
-import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { Inject, ModuleWithProviders, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SliderComponent } from './slider/slider.component';
 import { SwitchComponent } from './switch/switch.component';
@@ -101,6 +101,20 @@ import { ImageViewerComponent } from './image-viewer/image-viewer.component';
 import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numeric.directive';
 import { APP_CONFIG, AppConfig } from './config';
 import { TestIdDirective } from './directives/test-id.directive';
+
+export const factory = () => {
+	const platformModuleCreated = (factory as any)._platformModuleCreated || false;
+	if (platformModuleCreated) {
+		throw new Error('PlatformModule.forRoot imported to many times');
+	}
+	(factory as any)._platformModuleCreated = true;
+};
+
+const providers = [
+	StylesUtilService,
+	ColorUtilService,
+	LoadingService
+];
 
 @NgModule({
 	imports:      [
@@ -205,7 +219,7 @@ import { TestIdDirective } from './directives/test-id.directive';
 		NumpadDecimalNumericDirective,
   		TestIdDirective,
 	],
-	exports:      [
+	exports: [
 		SliderComponent,
 		SliderDoubleRangeComponent,
 		SwitchComponent,
@@ -291,28 +305,32 @@ import { TestIdDirective } from './directives/test-id.directive';
 		NumpadDecimalNumericDirective,
 		TestIdDirective,
 	],
-	providers:    [
-		StylesUtilService,
-		ColorUtilService,
-		LoadingService
-	]
 })
 export class SystelabComponentsModule {
 
-	constructor(@Optional() @SkipSelf() parentModule: SystelabComponentsModule) {
-		if(parentModule) {
-			throw new Error('SystelabComponentsModule is already loaded. Please add it in AppModule only.');
-		}
+	constructor(@Inject('PlatformModuleInstance') instance: any) {
 	}
 
 	public static forRoot(conf?: AppConfig): ModuleWithProviders<SystelabComponentsModule> {
 		return {
 			ngModule: SystelabComponentsModule,
 			providers: [
+				...providers,
+				{
+					provide: 'PlatformModuleInstance',
+					useFactory: factory
+				},
 				{
 					provide: APP_CONFIG, useValue: conf
 				}
 			]
+		};
+	}
+
+	public static forChild(): ModuleWithProviders<SystelabComponentsModule> {
+		return {
+			ngModule: SystelabComponentsModule,
+			providers: [],
 		};
 	}
 }


### PR DESCRIPTION
# PR Details

This PR solve the "Impossible to import multiple time SystelabComponentsModule on router lazy loading" error.

## Description

This PR solve the "Impossible to import multiple time SystelabComponentsModule on router lazy loading" error applying the forChild method to be lazy loaded.

## Related Issue

#738 

## Motivation and Context

If a project is using the lazy loading in routing the usage of the library throw a console error and the application doesn't compile.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
