### PR TITLE
Merge to master - Feature 743 - Shorten long breadcrumb items

### DIFF
--- a/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.html
+++ b/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.html
@@ -1,3 +1,3 @@
 <systelab-breadcrumb [items]="items"></systelab-breadcrumb>
 
-<systelab-breadcrumb [items]="items" [backgroundColor]="'white'" [itemMaxWidth]="'40px'" [subItemMaxWidth]="'40px'" [fontColor]="'#158fef'"></systelab-breadcrumb>
+<systelab-breadcrumb [items]="items" [backgroundColor]="'white'" [itemMaxWidth]="'40px'" [subItemMaxWidth]="'60px'" [fontColor]="'#158fef'"></systelab-breadcrumb>

--- a/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.html
+++ b/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.html
@@ -1,4 +1,3 @@
 <systelab-breadcrumb [items]="items"></systelab-breadcrumb>
 
-<systelab-breadcrumb [items]="items" [backgroundColor]="'white'"
-                     [fontColor]="'#158fef'"></systelab-breadcrumb>
+<systelab-breadcrumb [items]="items" [backgroundColor]="'white'" [itemMaxWidth]="'40px'" [fontColor]="'#158fef'"></systelab-breadcrumb>

--- a/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.html
+++ b/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.html
@@ -1,3 +1,3 @@
 <systelab-breadcrumb [items]="items"></systelab-breadcrumb>
 
-<systelab-breadcrumb [items]="items" [backgroundColor]="'white'" [itemMaxWidth]="'40px'" [fontColor]="'#158fef'"></systelab-breadcrumb>
+<systelab-breadcrumb [items]="items" [backgroundColor]="'white'" [itemMaxWidth]="'40px'" [subItemMaxWidth]="'40px'" [fontColor]="'#158fef'"></systelab-breadcrumb>

--- a/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.ts
+++ b/projects/showcase/src/app/components/breadcrumb/showcase-breadcrumb.component.ts
@@ -16,10 +16,10 @@ export class ShowcaseBreadcrumbComponent {
 		subItems.push(new BreadcrumbSubItem('1', 'Apartments', null, 'https://google.com?apartments'));
 		subItems.push(new BreadcrumbSubItem('2', 'Campings', () => this.showModal()));
 
-		this.items.push(new BreadcrumbItem('1', 'Home', false, null, null, 'https://google.com'));
-		this.items.push(new BreadcrumbItem('2', 'Holidays', false, () => this.showModal()));
-		this.items.push(new BreadcrumbItem('3', 'Hotels', false, null, subItems, 'https://google.com'));
-		this.items.push(new BreadcrumbItem('4', 'Rooms', true, null, null, 'https://google.com'));
+		this.items.push(new BreadcrumbItem('1', 'Home', true, null, null, 'https://google.com'));
+		this.items.push(new BreadcrumbItem('2', 'Holidays', true, () => this.showModal()));
+		this.items.push(new BreadcrumbItem('3', 'Hotels', true, null, subItems, 'https://google.com'));
+		this.items.push(new BreadcrumbItem('4', 'Rooms', false, null, null, 'https://google.com'));
 
 	}
 

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.7.1",
+  "version": "15.8.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.7.0",
+  "version": "15.7.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/_breadcrumb.scss
+++ b/projects/systelab-components/sass/_breadcrumb.scss
@@ -1,53 +1,58 @@
-.breadcrumb {
-  & > li + li:before {
-    padding: 0 5px;
-    color: #cccccc;
-    content: "/\00a0";
-  }
-
-  & > li > a {
-    cursor: pointer;
-
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline flow-root list-item;
-
-    &:hover {
-      text-decoration: underline;
+systelab-breadcrumb {
+  .breadcrumb {
+    & > li + li:before {
+      padding: 0 5px;
+      color: #cccccc;
+      content: "/\00a0";
     }
-  }
 
-  .slab-caret-button {
-    border: 0;
-    padding: 0;
-    background-color: transparent;
-    cursor: pointer;
-  }
-
-  .slab-sub-items {
-    padding-top: 0px;
-    padding-bottom: 0px;
-
-    .slab-items {
-      padding: 5px;
+    & > li > a {
       cursor: pointer;
 
-      & > a {
-        width: 100%;
-        display: block;
-      }
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline flow-root list-item;
 
       &:hover {
-        background-color: $slab-selected-background-color;
+        text-decoration: underline;
+      }
+    }
+
+    .slab-caret-button {
+      border: 0;
+      padding: 0;
+      background-color: transparent;
+      cursor: pointer;
+    }
+
+    .slab-sub-items {
+      padding-top: 0px;
+      padding-bottom: 0px;
+
+      min-width: 2rem !important;
+
+      .slab-items {
+        padding: 5px;
+        cursor: pointer;
+
         & > a {
-          text-decoration: underline;
+          //width: 100%;
+          //display: block;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: inline flow-root list-item
+        }
+
+        &:hover {
+          background-color: $slab-selected-background-color;
+
+          & > a {
+            text-decoration: underline;
+          }
         }
       }
     }
   }
-
 }
-
-
-

--- a/projects/systelab-components/sass/_breadcrumb.scss
+++ b/projects/systelab-components/sass/_breadcrumb.scss
@@ -37,8 +37,6 @@ systelab-breadcrumb {
         cursor: pointer;
 
         & > a {
-          //width: 100%;
-          //display: block;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/projects/systelab-components/sass/_breadcrumb.scss
+++ b/projects/systelab-components/sass/_breadcrumb.scss
@@ -8,6 +8,11 @@
   & > li > a {
     cursor: pointer;
 
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline flow-root list-item;
+
     &:hover {
       text-decoration: underline;
     }

--- a/projects/systelab-components/sass/_breadcrumb.scss
+++ b/projects/systelab-components/sass/_breadcrumb.scss
@@ -1,5 +1,10 @@
 systelab-breadcrumb {
   .breadcrumb {
+
+    & > li {
+      display: inline-flex;
+    }
+
     & > li + li:before {
       padding: 0 5px;
       color: #cccccc;
@@ -12,11 +17,22 @@ systelab-breadcrumb {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      display: inline flow-root list-item;
+      display: inline-block;
 
       &:hover {
         text-decoration: underline;
       }
+    }
+
+    & > li > label {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline-block;
+    }
+
+    & > li > button {
+      min-width: 15px;
     }
 
     .slab-caret-button {
@@ -40,7 +56,7 @@ systelab-breadcrumb {
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
-          display: inline flow-root list-item
+          display: inline-block;
         }
 
         &:hover {

--- a/projects/systelab-components/sass/modern/_breadcrumb.scss
+++ b/projects/systelab-components/sass/modern/_breadcrumb.scss
@@ -37,8 +37,6 @@ systelab-breadcrumb {
         cursor: pointer;
 
         & > a {
-          //width: 100%;
-          //display: block;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/projects/systelab-components/sass/modern/_breadcrumb.scss
+++ b/projects/systelab-components/sass/modern/_breadcrumb.scss
@@ -1,5 +1,10 @@
 systelab-breadcrumb {
   .breadcrumb {
+
+    & > li {
+      display: inline-flex;
+    }
+
     & > li + li:before {
       padding: 0 5px;
       color: #cccccc;
@@ -12,11 +17,22 @@ systelab-breadcrumb {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      display: inline flow-root list-item;
+      display: inline-block;
 
       &:hover {
         text-decoration: underline;
       }
+    }
+
+    & > li > label {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline-block;
+    }
+
+    & > li > button {
+      min-width: 15px;
     }
 
     .slab-caret-button {
@@ -40,7 +56,7 @@ systelab-breadcrumb {
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
-          display: inline flow-root list-item
+          display: inline-block;
         }
 
         &:hover {

--- a/projects/systelab-components/sass/modern/_breadcrumb.scss
+++ b/projects/systelab-components/sass/modern/_breadcrumb.scss
@@ -30,13 +30,19 @@ systelab-breadcrumb {
       padding-top: 0px;
       padding-bottom: 0px;
 
+      min-width: 2rem !important;
+
       .slab-items {
         padding: 5px;
         cursor: pointer;
 
         & > a {
-          width: 100%;
-          display: block;
+          //width: 100%;
+          //display: block;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: inline flow-root list-item
         }
 
         &:hover {

--- a/projects/systelab-components/sass/modern/_breadcrumb.scss
+++ b/projects/systelab-components/sass/modern/_breadcrumb.scss
@@ -9,6 +9,11 @@ systelab-breadcrumb {
     & > li > a {
       cursor: pointer;
 
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline flow-root list-item;
+
       &:hover {
         text-decoration: underline;
       }

--- a/projects/systelab-components/src/lib/breadcrumb/README.md
+++ b/projects/systelab-components/src/lib/breadcrumb/README.md
@@ -5,10 +5,10 @@ Component to show a Breadcrumb.
 ## Using the component
 
 ```html
-<systelab-breadcrumb [items]="items" [backgroundColor]="backgroundColor" [fontColor]="fontColor"></systelab-breadcrumb>
+<systelab-breadcrumb [items]="items" [backgroundColor]="backgroundColor" [fontColor]="fontColor" [itemMaxWidth]="'90px'" [subItemMaxWidth]="'120px'"></systelab-breadcrumb>
 ```
 
-The parameters **backgroundColor**, and a **fontColor** are optionals.
+The parameters **backgroundColor**, **fontColor**, **itemMaxWidth** and **subItemMaxWidth** are optionals.
 
 How to add a breadcrumb item with an action:
 
@@ -25,10 +25,12 @@ this.items.push(new BreadcrumbItem('2', 'Holidays', false, null, null, 'http://w
 Use **action** for navigating internally in the application and use the **url** external navigations.
 
 ## Properties
-| Name | Type | Default | Description |
-| ---- |:----:|:-------:| ----------- |
-| backgroundColor | string |  | Breadcrumb background color |
-| fontColor | string | | The font color of the text in the breadcrumb |
+| Name | Type | Default | Description                                              |
+| ---- |:----:|:-------:|----------------------------------------------------------|
+| backgroundColor | string |  | Breadcrumb background color                              |
+| fontColor | string | | The font color of the text in the breadcrumb             |
+| itemMaxWidth | string | | The max width of the item text in the breadcrumb         |
+| subItemMaxWidth | string | | The max width of the sub-item text in the breadcrumb     |
 | items | Array<BreadcrumbItem> | | An array with the elements to be shownmin the breadcrumb |
 
 #### BreadcrumbItem

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb-maxwidth.component.spec.ts
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb-maxwidth.component.spec.ts
@@ -1,0 +1,103 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {BrowserModule, By} from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { TreeModule } from 'primeng/tree';
+import { HttpClientModule } from '@angular/common/http';
+import {BreadcrumbComponent, BreadcrumbItem, BreadcrumbSubItem} from './breadcrumb.component';
+
+@Component({
+	selector: 'systelab-breadcrumb-maxwidth-test',
+	template: `
+                <div>
+                    <systelab-breadcrumb [items]="items" [itemMaxWidth]="itemMaxWidth" [subItemMaxWidth]="subItemMaxWidth"></systelab-breadcrumb>
+                </div>
+	          `,
+	styles:   []
+})
+export class BreadcrumbMaxWidthTestComponent {
+
+	public items: Array<BreadcrumbItem> = [];
+	public itemMaxWidth = '40px';
+	public subItemMaxWidth = '60px';
+
+	constructor() {
+
+		const subItems: BreadcrumbSubItem[] = [];
+		subItems.push(new BreadcrumbSubItem('1', 'SubItemItem 1', null, 'https://google.com?apartments'));
+		subItems.push(new BreadcrumbSubItem('2', 'SubItemItem 2', () => this.doSomething()));
+
+		this.items.push(new BreadcrumbItem('1', 'ItemItem 1', true,  () => this.doSomething()));
+		this.items.push(new BreadcrumbItem('2', 'ItemItem 2', true, () => this.doSomethingElse(), subItems));
+		this.items.push(new BreadcrumbItem('3', 'ItemItem 3', false, () => this.doSomethingElse()));
+	}
+
+	public doSomething() {
+	}
+
+	public doSomethingElse() {
+	}
+}
+
+const checkActiveItemTextStyleWidth = (fixture: ComponentFixture<BreadcrumbMaxWidthTestComponent>, itemIndex: number, width: string) => {
+	const label = fixture.debugElement.query(By.css('li:nth-of-type(' + itemIndex + ')')).query(By.css('a')).nativeElement;
+	expect(label.attributes['style'].value).toBe(width);
+};
+
+
+const checkInactiveItemTextStyleWidth = (fixture: ComponentFixture<BreadcrumbMaxWidthTestComponent>, itemIndex: number, width: string) => {
+	const label = fixture.debugElement.query(By.css('li:nth-of-type(' + itemIndex + ')')).query(By.css('label')).nativeElement;
+	expect(label.attributes['style'].value).toBe(width);
+};
+
+const checkSubItemTextStyleWidth = (fixture: ComponentFixture<BreadcrumbMaxWidthTestComponent>, itemIndex: number, subItemIndex: number, width: string) => {
+	const label = fixture.debugElement.query(By.css('li:nth-of-type(' + itemIndex + ')')).query(By.css('ul')).query(By.css('li:nth-of-type(' + subItemIndex + ')')).query(By.css('a')).nativeElement;
+	expect(label.attributes['style'].value).toBe(width);
+};
+
+describe('Systelab Breadcrumb With Max Width', () => {
+	let fixture: ComponentFixture<BreadcrumbMaxWidthTestComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports:      [BrowserModule,
+				BrowserAnimationsModule,
+				FormsModule,
+				DragDropModule,
+				OverlayModule,
+				TreeModule,
+				HttpClientModule],
+			declarations: [BreadcrumbComponent, BreadcrumbMaxWidthTestComponent]
+		})
+			.compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(BreadcrumbMaxWidthTestComponent);
+		fixture.detectChanges();
+	});
+
+	it('-should instantiate', () => {
+		expect(fixture.componentInstance)
+			.toBeDefined();
+	});
+
+	it('-First item should have the right text', () => {
+		checkActiveItemTextStyleWidth(fixture, 1, 'width: 40px;');
+	});
+
+	it('-Second item should have the right text', () => {
+		checkActiveItemTextStyleWidth(fixture, 2, 'width: 40px;');
+	});
+
+	it('-Third item should have the right text', () => {
+		checkInactiveItemTextStyleWidth(fixture, 3, 'width: 40px;');
+	});
+
+	it('-First sub item should have the right text', () => {
+		checkSubItemTextStyleWidth(fixture, 2, 1, 'width: 60px;');
+	});
+});

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,7 +1,6 @@
 <ol class="breadcrumb" [style.background-color]="backgroundColor">
     <li *ngFor="let bread of items" [class.active]="bread.isActive" (click)="bread.isActive?bread.action():noop()">
-        <a *ngIf="!bread.isActive"
-           [attr.target]="bread.url ? '_self' : null " [attr.href]="bread.url ?  bread.url  : null "
+        <a *ngIf="!bread.isActive" [attr.target]="bread.url ? '_self' : null " [attr.href]="bread.url ?  bread.url  : null "
            [style.color]="fontColor" [style.width]="itemMaxWidth">{{bread.text}}</a>
         <label *ngIf="bread.isActive">{{bread.text}}</label>
         <button *ngIf="bread.subItems" class="slab-caret-button" type="button"
@@ -11,7 +10,7 @@
         <ul *ngIf="bread.subItems" class="dropdown-menu slab-sub-items" aria-labelledby="dropdownMenu1">
             <li *ngFor="let subBread of bread.subItems" (click)="subBread.action()" class="slab-items">
                 <a [attr.target]="subBread.url ? '_self' : null " [attr.href]="subBread.url ?  subBread.url  : null "
-                   [style.color]="fontColor">{{subBread.text}}</a>
+                   [style.color]="fontColor" [style.width]="subItemMaxWidth">{{subBread.text}}</a>
             </li>
         </ul>
     </li>

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,8 +1,8 @@
 <ol class="breadcrumb" [style.background-color]="backgroundColor">
     <li *ngFor="let bread of items" [class.active]="bread.isActive" (click)="bread.isActive?bread.action():noop()">
-        <a *ngIf="!bread.isActive" [attr.target]="bread.url ? '_self' : null " [attr.href]="bread.url ?  bread.url  : null "
+        <a *ngIf="bread.isActive" [attr.target]="bread.url ? '_self' : null " [attr.href]="bread.url ?  bread.url  : null "
            [style.color]="fontColor" [style.width]="itemMaxWidth">{{bread.text}}</a>
-        <label *ngIf="bread.isActive">{{bread.text}}</label>
+        <label *ngIf="!bread.isActive" [style.width]="itemMaxWidth">{{bread.text}}</label>
         <button *ngIf="bread.subItems" class="slab-caret-button" type="button"
                 id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
             &nbsp;<i class="icon-caret-down" [style.color]="fontColor"></i>

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,14 +1,17 @@
 <ol class="breadcrumb" [style.background-color]="backgroundColor">
     <li *ngFor="let bread of items" [class.active]="bread.isActive" (click)="bread.isActive?bread.action():noop()">
-        <a *ngIf="!bread.isActive" [attr.target]="bread.url ? '_self' : null " [attr.href]="bread.url ?  bread.url  : null " [style.color]="fontColor">{{bread.text}}</a>
+        <a *ngIf="!bread.isActive"
+           [attr.target]="bread.url ? '_self' : null " [attr.href]="bread.url ?  bread.url  : null "
+           [style.color]="fontColor" [style.width]="itemMaxWidth">{{bread.text}}</a>
         <label *ngIf="bread.isActive">{{bread.text}}</label>
         <button *ngIf="bread.subItems" class="slab-caret-button" type="button"
                 id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            <i class="icon-caret-down" [style.color]="fontColor"></i>
+            &nbsp;<i class="icon-caret-down" [style.color]="fontColor"></i>
         </button>
         <ul *ngIf="bread.subItems" class="dropdown-menu slab-sub-items" aria-labelledby="dropdownMenu1">
             <li *ngFor="let subBread of bread.subItems" (click)="subBread.action()" class="slab-items">
-                <a [attr.target]="subBread.url ? '_self' : null " [attr.href]="subBread.url ?  subBread.url  : null " [style.color]="fontColor">{{subBread.text}}</a>
+                <a [attr.target]="subBread.url ? '_self' : null " [attr.href]="subBread.url ?  subBread.url  : null "
+                   [style.color]="fontColor">{{subBread.text}}</a>
             </li>
         </ul>
     </li>

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.ts
@@ -20,6 +20,7 @@ export class BreadcrumbComponent {
 	@Input() public items: BreadcrumbItem[];
 	@Input() public backgroundColor: string;
 	@Input() public fontColor: string;
+	@Input() public itemMaxWidth: '9999px';
 
 	constructor() {
 	}

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.ts
@@ -21,6 +21,7 @@ export class BreadcrumbComponent {
 	@Input() public backgroundColor: string;
 	@Input() public fontColor: string;
 	@Input() public itemMaxWidth: '9999px';
+	@Input() public subItemMaxWidth: '9999px';
 
 	constructor() {
 	}

--- a/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/systelab-components/src/lib/breadcrumb/breadcrumb.component.ts
@@ -20,8 +20,8 @@ export class BreadcrumbComponent {
 	@Input() public items: BreadcrumbItem[];
 	@Input() public backgroundColor: string;
 	@Input() public fontColor: string;
-	@Input() public itemMaxWidth: '9999px';
-	@Input() public subItemMaxWidth: '9999px';
+	@Input() public itemMaxWidth: string = '100%';
+	@Input() public subItemMaxWidth: string = '100%';
 
 	constructor() {
 	}


### PR DESCRIPTION
# PR Details

Added two new input parameters (width) to the breadcrumb component to allow shortening long items and sub-items.

## Description

By default the compenent displays the long items, when the input parameters are set the items appear with the new width.

## Motivation and Context

In the Synapse project, the component show long names and now everybody can use these new options.

## How Has This Been Tested

Exploratory

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
