### PR TITLE
Feature 762

### DIFF
--- a/projects/showcase/src/app/components/grid/showcase-grid.model.ts
+++ b/projects/showcase/src/app/components/grid/showcase-grid.model.ts
@@ -3,7 +3,7 @@ import { IStackedBar } from 'systelab-components';
 
 export class ShowcaseData {
 
-	constructor(public eventDate: string, public value: string, public flag: string, public decimalValue: number, public inputValue: number,
+	constructor(public eventDate: string, public value: string, public flag: string, public decimalValue: number, public positiveIntegerValue:number, public inputValue: number,
 				public checkboxValue: boolean, public checkboxID: number, public spinnerValues: TouchSpinValues, public stackedBarValues?: Array<IStackedBar>) {
 	}
 }

--- a/projects/showcase/src/app/components/grid/showcase-grid.util.ts
+++ b/projects/showcase/src/app/components/grid/showcase-grid.util.ts
@@ -1,4 +1,6 @@
-import { CheckboxCellEditorComponent, CheckboxCellRendererComponent, DecimalInputCellEditorComponent, GridHeaderContextMenuComponent, InputCellEditorComponent, IStackedBar, SpinnerCellEditorComponent, SpinnerCellRendererComponent, StackedBarCellRendererComponent, TouchSpinValues } from 'systelab-components';
+import { CheckboxCellEditorComponent, CheckboxCellRendererComponent, DecimalInputCellEditorComponent,
+	GridHeaderContextMenuComponent, InputCellEditorComponent, IStackedBar, SpinnerCellEditorComponent, SpinnerCellRendererComponent,
+	StackedBarCellRendererComponent, TouchSpinValues, PositiveIntegerInputCellEditorComponent } from 'systelab-components';
 import { ShowcaseData } from './showcase-grid.model';
 
 export class ShowcaseGridUtil {
@@ -42,6 +44,15 @@ export class ShowcaseGridUtil {
 				field:               'decimalValue',
 				width:               200,
 				cellEditorFramework: DecimalInputCellEditorComponent,
+				editable:            true,
+				sortable:            true,
+				onCellValueChanged:  e => console.log('input', e)
+			}, {
+				colId:               'positive-integer-input',
+				headerName:          'Cell with Positive Integer',
+				field:               'positiveIntegerValue',
+				width:               200,
+				cellEditorFramework: PositiveIntegerInputCellEditorComponent,
 				editable:            true,
 				sortable:            true,
 				onCellValueChanged:  e => console.log('input', e)
@@ -143,7 +154,7 @@ export class ShowcaseGridUtil {
 	public static getGridData(): ShowcaseData[] {
 		const values: ShowcaseData[] = [];
 		for (let i = 0; i < 10; i++) {
-			values.push(new ShowcaseData('12/12/2017', i + '', '10x', 26, 10,
+			values.push(new ShowcaseData('12/12/2017', i + '', '10x', 26, 24,10,
 				false, i, new TouchSpinValues(5, 0, 100, 1), this.stackedBars[i % 4]));
 		}
 		return values;

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.2",
+  "version": "15.3.3",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/README.md
+++ b/projects/systelab-components/src/lib/grid/README.md
@@ -71,6 +71,20 @@ Decimal Input
 }
 ```
 
+Positive Integer Input
+```
+{
+    colId:               'positive-integer-input',
+    headerName:          'Cell with Positive Integer',
+    field:               'positiveIntegerValue',
+    width:               200,
+    cellEditorFramework: PositiveIntegerInputCellEditorComponent,
+    editable:            true,
+    onCellValueChanged:  e => console.log('input', e)
+}
+```
+
+
 CheckBox
 
 To use the checkbox we need to send a parameter that has to be searched in the data to get a unique id. By this way we can have all the checkbox working independent from the other.

--- a/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.html
+++ b/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.html
@@ -1,0 +1,4 @@
+<input title="input-cell" type="number" step="any" class="w-100 h-100 border-0 bg-transparent"
+       [disabled]="!isEditable"
+       [(ngModel)]="value"
+       (keydown)="onKeyDown($event)">

--- a/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.spec.ts
@@ -50,4 +50,8 @@ describe('PositiveIntegerInputCellEditorComponent', () => {
         expect(event2.preventDefault).toHaveBeenCalled();
         expect(event3.preventDefault).not.toHaveBeenCalled();
     });
+
+    it ('refresh should return true', () => {
+        expect(component.refresh({})).toBeTrue();
+    });
 });

--- a/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PositiveIntegerInputCellEditorComponent } from './positive-integer-input-cell-editor.component';
+
+describe('PositiveIntegerInputCellEditorComponent', () => {
+    let component: PositiveIntegerInputCellEditorComponent;
+    let fixture: ComponentFixture<PositiveIntegerInputCellEditorComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [PositiveIntegerInputCellEditorComponent],
+        });
+
+        fixture = TestBed.createComponent(PositiveIntegerInputCellEditorComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should create the component', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should initialize value and isEditable from params', () => {
+        const params = { value: '42' };
+        component.agInit(params);
+
+        expect(component.params).toBe(params);
+        expect(component.value).toBe(params.value);
+    });
+
+    it('should return the value in getValue()', () => {
+        component.value = '123';
+        const result = component.getValue();
+
+        expect(result).toBe('123');
+    });
+
+    it('should allow only digits and certain keys in onKeyDown()', () => {
+        const event1 = new KeyboardEvent('keydown', { key: '1' });
+        const event2 = new KeyboardEvent('keydown', { key: 'A' });
+        const event3 = new KeyboardEvent('keydown', { key: 'Enter' });
+
+        spyOn(event1, 'preventDefault');
+        spyOn(event2, 'preventDefault');
+        spyOn(event3, 'preventDefault');
+
+        component.onKeyDown(event1);
+        component.onKeyDown(event2);
+        component.onKeyDown(event3);
+
+        expect(event1.preventDefault).not.toHaveBeenCalled();
+        expect(event2.preventDefault).toHaveBeenCalled();
+        expect(event3.preventDefault).not.toHaveBeenCalled();
+    });
+});

--- a/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { AgEditorComponent } from 'ag-grid-angular';
+
+@Component({
+	selector: 'systelab-positive-integer-input-cell-editor',
+	templateUrl: 'positive-integer-input-cell-editor.component.html',
+})
+export class PositiveIntegerInputCellEditorComponent implements AgEditorComponent {
+	public value: string;
+	public isEditable = true;
+	public params: any;
+
+	public agInit(params: any): void {
+		this.params = params;
+		this.value = this.params.value;
+	}
+
+	public getValue(): any {
+		return this.value;
+	}
+
+	// Only digits and some keys are allowed to enter a positive number
+	public onKeyDown(event: KeyboardEvent): void {
+		const allowedKeys = ['Backspace', 'Tab', 'Delete', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'Enter'];
+		if (allowedKeys.includes(event.key)) {
+			return;
+		}
+
+		if (!/^\d+$/.test(event.key)) {
+			event.preventDefault();
+		}
+	}
+
+	public refresh(params: any): boolean {
+		return true;
+	}
+}

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -99,6 +99,9 @@ import { DraggableDirective } from './directives/draggable.directive';
 import { ResizableDirective } from './directives/resizable.directive';
 import {ImageViewerComponent} from './image-viewer/image-viewer.component';
 import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numeric.directive';
+import {
+	PositiveIntegerInputCellEditorComponent
+} from './grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component';
 
 @NgModule({
 	imports:      [
@@ -200,7 +203,8 @@ import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numer
 		DraggableDirective,
 		ResizableDirective,
 		ImageViewerComponent,
-		NumpadDecimalNumericDirective
+		NumpadDecimalNumericDirective,
+		PositiveIntegerInputCellEditorComponent
 	],
 	exports:      [
 		SliderComponent,
@@ -285,7 +289,8 @@ import { NumpadDecimalNumericDirective } from './directives/numpad-decimal-numer
 		DraggableDirective,
 		ResizableDirective,
 		ImageViewerComponent,
-		NumpadDecimalNumericDirective
+		NumpadDecimalNumericDirective,
+		PositiveIntegerInputCellEditorComponent
 	],
 	providers:    [
 		StylesUtilService,

--- a/projects/systelab-components/src/public-api.ts
+++ b/projects/systelab-components/src/public-api.ts
@@ -85,6 +85,7 @@ export * from './lib/grid/custom-cells/checkbox/checkbox-cell-renderer.component
 export * from './lib/grid/custom-cells/decimal-input/decimal-input-cell-editor.component';
 export * from './lib/grid/custom-cells/input/input-cell-editor.component';
 export * from './lib/grid/custom-cells/stacked-bar/stacked-bar-cell-renderer.component';
+export * from './lib/grid/custom-cells/positive-integer/positive-integer-input-cell-editor.component';
 export * from './lib/grid/contextmenu/grid-header-context-menu-renderer.component';
 export * from './lib/grid/contextmenu/grid-header-context-menu.component';
 export * from './lib/grid/contextmenu/grid-context-menu-component';


### PR DESCRIPTION
# PR Details

Ag grid cell editor for positive integers. Only accept digits and some keys (backspace, arrows.. etc)i


## Related Issue
https://github.com/systelab/systelab-components/issues/762

## Motivation and Context

We want edit a cell and only accept positive numbers instead to do a validation

## How Has This Been Tested

Added new column in an ag grid table in showcase

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
