### PR TITLE
Feature 765 add random id to avoid problems with checkboxes in pages with more than one add-remove comp

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.3",
+  "version": "15.3.4",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/add-remove-list/abstract-add-remove-list.component.html
+++ b/projects/systelab-components/src/lib/add-remove-list/abstract-add-remove-list.component.html
@@ -13,8 +13,8 @@
                  (click)="selectElement(element,$event)" cdkDrag>
 
                  <div class="slab-sortable-checkbox" *ngIf="showChecks">
-                     <input type="checkbox" id="{{index}}-check" (change)="selectCheckbox(element)">
-                     <label for="{{index}}-check" class="col-form-label"></label>
+                     <input type="checkbox" id="{{checkId}}-{{index}}-check" (change)="selectCheckbox(element)">
+                     <label for="{{checkId}}-{{index}}-check" class="col-form-label"></label>
                  </div>
 
                 <i *ngIf="showIcon" class="mr-1 d-flex align-items-center" [ngClass]="[getIcon(element), isDisabled ? 'text-black-50' : 'text-primary']"></i>

--- a/projects/systelab-components/src/lib/add-remove-list/abstract-add-remove-list.component.ts
+++ b/projects/systelab-components/src/lib/add-remove-list/abstract-add-remove-list.component.ts
@@ -9,6 +9,7 @@ export abstract class AbstractAddRemoveList<T> extends AbstractSortableListCompo
 	@Input() public isDisabled = false;
 	@Input() public showChecks = false;
 	@Input() public showSelectedRowsInRemoveButton = false;
+	public checkId: string = (Math.floor(Math.random() * (999999999999 - 1))).toString();
 
 	constructor() {
 		super();


### PR DESCRIPTION
# PR Details

Added a random id to avoid problems with checkboxes in pages with more than one add and remove list component

#765 

## Description

If the checkboxes id's are repeated the checkboxes doesn't work properly, added a random number to avoid the problem.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
