### PR TITLE
767 image viewer component improve button state management

### DIFF
--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
@@ -14,8 +14,8 @@ export class ShowcaseImageViewerComponent {
 	public actionButtons: Array<ActionButton> = [
 		{action: 'Action 1', label: 'Action 1', tooltip: 'Action 1 tooltip', type: ActionButtonType.BUTTON},
 		{action: 'contrast', label: 'High contrast', tooltip: 'High contrast tooltip', type: ActionButtonType.TOGGLE_BUTTON},
-		{action: 'green', label: 'Apply green', tooltip: 'Apply green tooltip', type: ActionButtonType.TOGGLE_BUTTON},
-		{action: 'red', label: 'Apply red', tooltip: 'Apply red tooltip', type: ActionButtonType.TOGGLE_BUTTON}
+		{action: 'green', label: 'Apply green', tooltip: 'Apply green tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}},
+		{action: 'red', label: 'Apply red', tooltip: 'Apply red tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: true, disabled: true}}
 	];
 	public imageFilters = `
 		<filter id="red">
@@ -48,6 +48,10 @@ export class ShowcaseImageViewerComponent {
 			alert('Click on '+$event);
 		} else {
 			this.applyImageFilter($event);
+			const actionButton = this.actionButtons.find(button=>button.action===$event);
+			if (actionButton && actionButton.state) {
+				actionButton.state.checked = true;
+			}
 		}
 	}
 

--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
@@ -15,7 +15,7 @@ export class ShowcaseImageViewerComponent {
 		{action: 'Action 1', label: 'Action 1', tooltip: 'Action 1 tooltip', type: ActionButtonType.BUTTON},
 		{action: 'contrast', label: 'High contrast', tooltip: 'High contrast tooltip', type: ActionButtonType.TOGGLE_BUTTON},
 		{action: 'green', label: 'Apply green', tooltip: 'Apply green tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}},
-		{action: 'red', label: 'Apply red', tooltip: 'Apply red tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: true, disabled: true}}
+		{action: 'red', label: 'Apply red', tooltip: 'Apply red tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}}
 	];
 	public imageFilters = `
 		<filter id="red">

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.8.3",
+  "version": "15.9.3",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.9.3",
+  "version": "15.10.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/image-viewer/README.md
+++ b/projects/systelab-components/src/lib/image-viewer/README.md
@@ -64,12 +64,13 @@ an event with the corresponding action. The parent component must implement the 
 
 The _actionButtons_ input parameter must be an array of ActionButton, an interface defined in the image-viewer with the following attributes:
 
-| Name    |         Type          | Description                                                                |
-|---------|:---------------------:|----------------------------------------------------------------------------|
-| action  |        string         | Key that identifies the action.                                            |
-| label   |        string         | Label of the button.                                                       |
-| tooltip |        string         | Tooltip of the button.                                                     |
-| type    | enum ActionButtonType | Type of the button: ActionButtonType.BUTTON, ActionButtonType.TOGGLEBUTTON |
+| Name    |         Type          | Description                                                                  |
+|---------|:---------------------:|------------------------------------------------------------------------------|
+| action  |        string         | Key that identifies the action.                                              |
+| label   |        string         | Label of the button.                                                         |
+| tooltip |        string         | Tooltip of the button.                                                       |
+| type    | enum ActionButtonType | Type of the button: ActionButtonType.BUTTON, ActionButtonType.TOGGLEBUTTON   |
+| state   |        object         | Object with two attributes representing the button state: checked & disabled |
 
 ## Applying SVG filters to the image
 
@@ -99,8 +100,8 @@ In order to apply these filters we will need also the corresponding custom actio
 
 ```typescript
 const actionButtons: Array<ActionButton> = [
-    {action: 'green', label: 'Apply green', tooltip: 'Apply green tooltip', type: ActionButtonType.TOGGLE_BUTTON},
-    {action: 'red', label: 'Apply red', tooltip: 'Apply red tooltip', type: ActionButtonType.TOGGLE_BUTTON}
+    {action: 'green', label: 'Apply green', tooltip: 'Apply green tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}},
+    {action: 'red', label: 'Apply red', tooltip: 'Apply red tooltip', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}}
 ];
 ```
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -5,11 +5,12 @@
         <div class="ml-1">
             <ng-container *ngFor="let actionButton of actionButtons">
                 <systelab-toggle-button *ngIf="actionButton.type===actionButtonType.TOGGLE_BUTTON" class="mr-2"
-                                        [isChecked]="isFilterEnabled(actionButton.action)"
+                                        [isChecked]="actionButton.state?.checked"
+                                        [disabled]="actionButton.state?.disabled"
                                         (click)="clickActionButton.emit(actionButton.action)" [systelabTooltip]="actionButton.tooltip">
                     {{actionButton.label}}
                 </systelab-toggle-button>
-                <systelab-button *ngIf="actionButton.type===actionButtonType.BUTTON" type="primary" class="mr-2"
+                <systelab-button *ngIf="actionButton.type===actionButtonType.BUTTON" class="mr-2"
                                  (click)="clickActionButton.emit(actionButton.action)" [systelabTooltip]="actionButton.tooltip">
                     {{actionButton.label}}
                 </systelab-button>

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -11,7 +11,9 @@
                     {{actionButton.label}}
                 </systelab-toggle-button>
                 <systelab-button *ngIf="actionButton.type===actionButtonType.BUTTON" class="mr-2"
-                                 (click)="clickActionButton.emit(actionButton.action)" [systelabTooltip]="actionButton.tooltip">
+                                 [systelabTooltip]="actionButton.tooltip"
+                                 [disabled]="actionButton.state?.disabled"
+                                 (click)="clickActionButton.emit(actionButton.action)">
                     {{actionButton.label}}
                 </systelab-button>
                 <div *ngIf="actionButton.type===actionButtonType.DROP_DOWN" class="dropup slab-button-dropdown">

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -34,8 +34,8 @@ export class ImageViewerTestComponent {
 	public imageTitle = 'Barcelona Eixample District';
 	public actionButtons: ActionButton[] = [
 		{action: 'Action 1', label: 'Action 1', type: ActionButtonType.BUTTON},
-		{action: 'red', label: 'Apply red', type: ActionButtonType.TOGGLE_BUTTON},
-		{action: 'green', label: 'Apply green', type: ActionButtonType.TOGGLE_BUTTON}
+		{action: 'red', label: 'Apply red', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}},
+		{action: 'green', label: 'Apply green', type: ActionButtonType.TOGGLE_BUTTON, state: {checked: false, disabled: false}}
 	];
 	public imageFilters = `
 	<filter id="red">

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -131,6 +131,15 @@ describe('ImageViewerTestComponent', () => {
 		expect(numActionButton).toEqual(3);
 	});
 
+	it('should render action buttons with the correct state (enabled and non-primary look&feel)', () => {
+		const toggleButtons = fixture.debugElement.nativeElement.querySelectorAll('systelab-toggle-button');
+
+		toggleButtons.forEach(toggleButton => {
+			expect(toggleButton.querySelector('button').disabled).toBe(false);
+			expect(toggleButton.querySelector('button').classList.contains('btn-outline-primary')).toBe(true);
+		});
+	});
+
 	it('should render description parameter as overlay text', () => {
 		const overlayText = fixture.debugElement.nativeElement.querySelector('#imageViewerOverlayText').innerHTML;
 		expect(overlayText).toEqual(fixture.componentInstance.imageTitle);

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -21,7 +21,7 @@ export interface ActionButton {
 	label: string;
 	tooltip?: string;
 	type: ActionButtonType;
-	state?: { checked: boolean, disabled: boolean }
+	state?: { checked?: boolean, disabled: boolean };
 }
 
 @Component({

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -21,6 +21,7 @@ export interface ActionButton {
 	label: string;
 	tooltip?: string;
 	type: ActionButtonType;
+	state?: { checked: boolean, disabled: boolean }
 }
 
 @Component({


### PR DESCRIPTION
# PR Details

Improve the action button state management

## Description

Added new attributes to the ActionButton interface to manage the state (checked/unchecked and disabled/enabled).

## Related Issue

https://github.com/systelab/systelab-components/issues/767

## Motivation and Context

With these new attributes the state of the action buttons can be managed through the input parameter [actionButtons] directly.

## How Has This Been Tested

A new component unit test has been added to cover the new feature.
The new version of the component has been tested in the showcase and in a custom project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation 
- [X] I have updated the documentation accordingly (README.md for each UI component)
- [X] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [X] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [X] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [X] All UI components must be added into the showcase (at least 1 component with the default settings)
- [X] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
