### PR TITLE
feature-773 add option to unselect rows when context menu is opened

### DIFF
--- a/projects/showcase/src/app/components/grid/showcase-grid.component.html
+++ b/projects/showcase/src/app/components/grid/showcase-grid.component.html
@@ -4,6 +4,7 @@
         <showcase-inner-grid #grid [rowData]="gridData" [menu]="getMenu()" (action)="doMenuAction($event)"
                              [headerMenu]="getHeaderContextMenuOptions()"
                              [showChecks]="true"
+                             [removeSelectionOnOpenContextMenu]="true"
                              [multipleSelection]="true" (clickRow)="doSelect($event)"></showcase-inner-grid>
     </form>
     <div class="pt-2">

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.5",
+  "version": "15.3.6",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/README.md
+++ b/projects/systelab-components/src/lib/grid/README.md
@@ -326,17 +326,18 @@ With the **canHideAllColumns** parameter you can control if the dialog allows hi
 
 ## Properties
 
-| Name | Type | Default | Description                                                                                                                                                                            |
-| ---- |:----:|:-------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| preferenceName | string | | Preference prefix in order to store the columns size                                                                                                                                   |
-| multipleSelection | boolean | false | Set multiple selection                                                                                                                                                                 |
-| showChecks | boolean | false | Show a column with a checkbox for each element                                                                                                                                         |
-| headerCheckboxSelection | boolean | false | Show a column with a checkbox in the header row                                                                                                                                        |
-| noRowsText | string | No Rows To Show (provided by ag-grid) | String/Template to display in the grid is empty (can be html)                                                                                                                          |
-| loadingText | string | Loading... (provided by ag-grid) | String/Template to display in the grid while the grid is loading the data (can be html)                                                                                                |
-| rowData | Array&lt;T&gt; | | Array of the elements of type <T> displayed in the table. Only for components extending from AbstractGrid                                                                              |
-| menu | Array&lt;GridContextMenuOption&lt;T&gt;&gt; | | Array with the menu options. Each option is a GridContextMenuOption. If used a column is added as the first of the table having three dots button on each row to open the context menu |
-| headerMenu | Array&lt;GridContextMenuOption&lt;Object&gt;&gt; | | Array with the header column menu options. Each option is a GridContextMenuOption. If used a three dots button is added in the header to open the context menu                         |
+| Name |                          Type                           | Default | Description                                                                                                                                                                            |
+| ---- |:-------------------------------------------------------:|:-------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| preferenceName |                         string                          | | Preference prefix in order to store the columns size                                                                                                                                   |
+| multipleSelection |                         boolean                         | false | Set multiple selection                                                                                                                                                                 |
+| showChecks |                         boolean                         | false | Show a column with a checkbox for each element                                                                                                                                         |
+| headerCheckboxSelection |                         boolean                         | false | Show a column with a checkbox in the header row                                                                                                                                        |
+| noRowsText |                         string                          | No Rows To Show (provided by ag-grid) | String/Template to display in the grid is empty (can be html)                                                                                                                          |
+| loadingText |                         string                          | Loading... (provided by ag-grid) | String/Template to display in the grid while the grid is loading the data (can be html)                                                                                                |
+| rowData |                     Array&lt;T&gt;                      | | Array of the elements of type <T> displayed in the table. Only for components extending from AbstractGrid                                                                              |
+| menu |       Array&lt;GridContextMenuOption&lt;T&gt;&gt;       | | Array with the menu options. Each option is a GridContextMenuOption. If used a column is added as the first of the table having three dots button on each row to open the context menu |
+| headerMenu |    Array&lt;GridContextMenuOption&lt;Object&gt;&gt;     | | Array with the header column menu options. Each option is a GridContextMenuOption. If used a three dots button is added in the header to open the context menu                         |
+| removeSelectionOnOpenContextMenu | boolean | | If true removes multiple selection when the context menu is opened                                                                                                                     |
 
 ## Events
 

--- a/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
@@ -91,7 +91,7 @@ export class SystelabGridComponent extends AbstractApiGrid<TestData> implements 
 	template: `
                   <div class="position-relative" style="height: 200px;">
                       <systelab-grid #grid [menu]="getMenu()" (action)="doMenuAction($event)" [headerMenu]="getHeaderMenu()"
-                                     [multipleSelection]="true" (clickRow)="doSelect($event)"></systelab-grid>
+                                     [showChecks]="true" [removeSelectionOnOpenContextMenu]="true" [multipleSelection]="true" (rowSelected)="doSelect($event)"></systelab-grid>
                   </div>
                   <systelab-button id="button-options" (action)="grid.showOptions()">Options</systelab-button>
 			  `
@@ -140,13 +140,22 @@ export class GridTestComponent {
 const getNumberOfRows = (fixture: ComponentFixture<GridTestComponent>) =>
 	fixture.debugElement.nativeElement.querySelectorAll('.ag-center-cols-container > .ag-row').length;
 
+const getNumberOfRowsSelected = (fixture: ComponentFixture<GridTestComponent>) =>
+	fixture.debugElement.nativeElement.querySelectorAll('.ag-center-cols-container > .ag-row-selected').length;
+
 const clickMenuOnRow = (fixture: ComponentFixture<GridTestComponent>, row: number) => {
 	fixture.debugElement.nativeElement.querySelectorAll('div[role="row"] * .slab-context-menu')[row].click();
 	fixture.detectChanges();
 };
 
+const selectRow = (fixture: ComponentFixture<GridTestComponent>, row: number) => {
+	fixture.debugElement.nativeElement.querySelectorAll('div[role="gridcell"] .ag-checkbox-input')[row].click();
+	fixture.detectChanges();
+};
+
 const clickOnGridCell = (fixture: ComponentFixture<GridTestComponent>, cell: number) => {
 	fixture.debugElement.nativeElement.querySelectorAll('div[role="gridcell"]')[cell].click();
+	// fixture.debugElement.nativeElement.querySelectorAll('div[role="gridcell"] .ag-checkbox-input')[cell].click();
 	fixture.detectChanges();
 };
 
@@ -232,7 +241,7 @@ describe('Systelab Grid', () => {
 
 	it('should have the right number of columns', () => {
 		expect(getNumberOfColumns(fixture))
-			.toEqual(3);
+			.toEqual(4);
 	});
 
 	it('should have the right number of rows', (done) => {
@@ -247,7 +256,7 @@ describe('Systelab Grid', () => {
 	it('should be possible to select a row', (done) => {
 		fixture.whenStable()
 			.then(() => {
-				clickOnGridCell(fixture, 5);
+				selectRow(fixture, 1);
 				fixture.whenStable()
 					.then(() => {
 						expect(fixture.componentInstance.selectedTestData.field1)
@@ -315,7 +324,7 @@ describe('Systelab Grid', () => {
 	it('should be possible to select the options', (done) => {
 		fixture.whenStable()
 			.then(() => {
-				clickOnGridCell(fixture, 5);
+				clickOnGridCell(fixture, 2);
 				fixture.whenStable()
 					.then(() => {
 						expect(fixture.componentInstance.selectedTestData.field1)
@@ -344,5 +353,25 @@ describe('Systelab Grid', () => {
 							});
 					});
 			});
+	});
+
+	it('should be possible to select more than one row', async () => {
+		await fixture.whenStable();
+		selectRow(fixture, 1);
+		selectRow(fixture, 2);
+		await fixture.whenStable();
+
+		expect(getNumberOfRowsSelected(fixture)).toEqual(2);
+	});
+
+	it('should unselect other rows when context menu is opened', async () => {
+		await fixture.whenStable();
+		selectRow(fixture, 1);
+		selectRow(fixture, 2);
+		await fixture.whenStable();
+		clickMenuOnRow(fixture, 2);
+		await fixture.whenStable();
+
+		expect(getNumberOfRowsSelected(fixture)).toEqual(1);
 	});
 });

--- a/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
@@ -155,7 +155,6 @@ const selectRow = (fixture: ComponentFixture<GridTestComponent>, row: number) =>
 
 const clickOnGridCell = (fixture: ComponentFixture<GridTestComponent>, cell: number) => {
 	fixture.debugElement.nativeElement.querySelectorAll('div[role="gridcell"]')[cell].click();
-	// fixture.debugElement.nativeElement.querySelectorAll('div[role="gridcell"] .ag-checkbox-input')[cell].click();
 	fixture.detectChanges();
 };
 

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -36,6 +36,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	@Input() public rowData: Array<T> = [];
 	@Input() public noRowsText;
 	@Input() public loadingText;
+	@Input() public removeSelectionOnOpenContextMenu = false;
 
 	@Output() public action = new EventEmitter();
 	@Output() public clickRow = new EventEmitter();

--- a/projects/systelab-components/src/lib/grid/contextmenu/grid-context-menu-cell-renderer.component.ts
+++ b/projects/systelab-components/src/lib/grid/contextmenu/grid-context-menu-cell-renderer.component.ts
@@ -25,6 +25,8 @@ export class GridContextMenuCellRendererComponent<T> implements AgRendererCompon
 
 		if (event.ctrlKey) {
 			selectedRows = this.container.getSelectedRows();
+		} else if (this.container.removeSelectionOnOpenContextMenu) {
+			this.container.gridOptions.api.deselectAll();
 		}
 		this.container.dotsClicked(this.rowIndex, selectedRows, event);
 	}


### PR DESCRIPTION
# PR Details

Added the parameter removeSelectionOnOpenContextMenu to be able to remove multiple selection when the context menu is open. This is useful when we want to clarify that the option menu is only for the active row and not for all the rows selected

## Related Issue

https://github.com/systelab/systelab-components/issues/773


## How Has This Been Tested

Added option in a showcase grid

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
