### PR TITLE
Searcher dialog help is not opened with '?' when multiple selection #781

### DIFF
--- a/projects/systelab-components/src/lib/searcher/abstract-searcher.component.ts
+++ b/projects/systelab-components/src/lib/searcher/abstract-searcher.component.ts
@@ -170,6 +170,9 @@ export abstract class AbstractSearcherComponent<T> implements OnInit {
 							if (response !== undefined) {
 								if (this.multipleSelection) {
 									this.multipleSelectedItemList = response;
+									if (!response?.length) {
+										this.openSearchDialog();
+									}
 								} else {
 									if (response.length === 1) {
 										this.id = response[0][this.abstractSearcher.getIdField()];


### PR DESCRIPTION
Fix Searcher dialog help is not opened with '?' when multiple selection #781

Tested manually in showcase and in external app as a library

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
