### PR TITLE
feature-783 grid fixings

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.7",
+  "version": "15.3.8",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
@@ -171,6 +171,9 @@ const clickOption = (fixture: ComponentFixture<GridTestComponent>, option: numbe
 const getNumberOfColumns = (fixture: ComponentFixture<GridTestComponent>) =>
 	fixture.debugElement.nativeElement.querySelectorAll('.ag-header-cell').length;
 
+const getNumberOfOptionRows = () =>
+	document.querySelectorAll('li.slab-twolistboxrow').length;
+
 const clickOnOptionsButton = (fixture: ComponentFixture<GridTestComponent>) => {
 	const button = fixture.debugElement.query(By.css('#button-options button')).nativeElement;
 	button.click();
@@ -348,6 +351,25 @@ describe('Systelab Grid', () => {
 							.then(() => {
 								expect(isModalVisible())
 									.toBeFalsy();
+								done();
+							});
+					});
+			});
+	});
+
+	it('should be possible to remove all the columns of the grid', (done) => {
+		fixture.whenStable()
+			.then(() => {
+				clickOnOptionsButton(fixture);
+				fixture.whenStable()
+					.then(() => {
+						expect(isModalVisible())
+							.toBeTruthy();
+						clickCloseButton(fixture, 'slab-remove-all');
+						fixture.whenStable()
+							.then(() => {
+								expect(getNumberOfOptionRows())
+									.toBe(2);
 								done();
 							});
 					});

--- a/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
@@ -376,6 +376,33 @@ describe('Systelab Grid', () => {
 			});
 	});
 
+
+	it('should be possible to remove one of the column of the grid', async(done) => {
+		await fixture.whenStable();
+		clickOnOptionsButton(fixture);
+
+		await fixture.whenStable();
+		expect(isModalVisible()).toBeTruthy();
+
+		document.getElementById('element0').click();
+
+		await fixture.whenStable();
+		// We remove one column
+		const buttonLeft: any = document.querySelector('.btn.icon-angle-left');
+		buttonLeft.click();
+
+		await fixture.whenStable();
+		expect(getNumberOfOptionRows()).toBe(1);
+
+		clickCloseButton(fixture, 'ID_optionsSubmitButton');
+
+		await fixture.whenStable();
+		expect(getNumberOfColumns(fixture))
+			.toEqual(3);
+
+		done();
+	});
+
 	it('should be possible to select more than one row', async () => {
 		await fixture.whenStable();
 		selectRow(fixture, 1);

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -327,7 +327,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	}
 
 	public doClick(event: any): void {
-		if (event.column.colId === 'contextMenu') {
+		if (event.column.colId === 'contextMenu' && !(event.event.ctrlKey && this.showChecks)) {
 			event.node.setSelected(true);
 		} else {
 			if (event.column.colId === 'selectCol') {
@@ -385,7 +385,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 			.map(column => new TwoListItem(column.getColDef().headerName, column.getColDef().colId, false, false));
 
 		options.visible = columnApi.getAllDisplayedColumns()
-			.filter(column => column.getColId() !== 'contextMenu')
+			.filter(column => column.getColId() !== 'contextMenu' && column.getColId() !== 'selectCol')
 			.map(column => new TwoListItem(column.getColDef().headerName, column.getColDef().colId, false, true));
 
 		options.defaultVisibleColumns = columnDefs.filter(column => !column.hide)
@@ -397,7 +397,8 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	}
 
 	protected applyGridColumnOptions(columnApi: ColumnApi, columnOptions: GridColumnsOptions): void {
-		const numberOfFixedInitialColumns = (columnApi.getColumn('contextMenu') !== null) ? 1 : 0;
+		let numberOfFixedInitialColumns = (columnApi.getColumn('contextMenu') !== null) ? 1 : 0;
+		numberOfFixedInitialColumns += (columnApi.getColumn('selectCol') !== null) ? 1 : 0;
 
 		columnOptions.visible.forEach((tlp, index) => {
 			const col: Column = columnApi.getColumns()
@@ -408,7 +409,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 
 		columnApi.getColumns()
 			.forEach((column) => {
-				if (column.getColId() !== 'contextMenu') {
+				if (column.getColId() !== 'contextMenu' && column.getColId() !== 'selectCol') {
 					if (!columnOptions.visible.some(tlp => tlp.colId === column.getColDef().colId)) {
 						columnApi.setColumnVisible(column.getColId(), false);
 					}


### PR DESCRIPTION
# PR Details

Fixing grid bugs: context menu ctrl click and empty column option

## Description

When there are checkboxes for multiple selection we don't want to multi select whith ctrl click in the context menu.

In Options grid dialog appears an empty column for the checkbox selection. It has to be the same behaviour than the context menu column that doesn't appears in the options dialog.


## Related Issue

https://github.com/systelab/systelab-components/issues/783


## How Has This Been Tested

Tested in showcase grids

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
