### PR TITLE
Fature 785

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.8",
+  "version": "15.3.9",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -2,10 +2,11 @@
      class="dropdown slab-combobox d-flex w-100"
      [ngClass]="{'disabled': isDisabled}">
     <div #dropdowntoogle class="slab-flex-1 d-flex dropdown-toggle slab-dropdown-toogle" id="{{comboId}}" data-toggle="dropdown">
-        <input #input type="text" class="slab-flex-1 d-flex slab-combo-input" keyup-debounce
+        <input #input type="search" class="slab-flex-1 d-flex slab-combo-input" keyup-debounce
                [disabled]="isDisabled"
                [(ngModel)]="fieldToShow"
                [keyupDebounceTime]="debounceTime" (keyupDebounced)="doSearch($event)"
+               (search)="doSearch($event)"
                [ngStyle]="getInputHeight()"
                [style.font-family]="fontFamily"
                [style.font-size.px]="fontSize"


### PR DESCRIPTION
# PR Details

Added functionality to clear input text on autocomplete component, also added the event capture to reset autocomplete search result to empty

## Description

Changed input type from "text" to "search" to make the clear button appear when the input is not empty
Added "search" event capture, which is the event fired by this clear button, to refresh the autocomplete query and its results.

## Related Issue

#785 

## Motivation and Context

Users struggled to clear text in their input using their keyboard, so they demanded a button to clear its content at once

## How Has This Been Tested

this change has been tested manually, and run existing tests to check nothing was broken

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
