### PR TITLE
feature-797 made clear button optional for autocomplete fields

### DIFF
--- a/projects/showcase/src/app/components/combobox/showcase-combobox.component.html
+++ b/projects/showcase/src/app/components/combobox/showcase-combobox.component.html
@@ -38,6 +38,13 @@
         </div>
     </div>
     <div class="row mt-1">
+        <label class="col-md-3 col-form-label" for="form-h-s">Autocomplete with clear option</label>
+        <div class="col-md-9">
+            <showcase-autocomplete [withClearOption]="true" (selectedItemChange)="comboChangeEvent($event)">
+            </showcase-autocomplete>
+        </div>
+    </div>
+    <div class="row mt-1">
         <label class="col-md-3 col-form-label" for="form-h-s">Editable input</label>
         <div class="col-md-9">
             <systelab-select

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.10",
+  "version": "15.3.11",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -69,6 +69,10 @@ export class SystelabAutocompleteComponent extends AutocompleteApiComboBox<TestD
 	public override doSearch(event: any) {
 		super.doSearch(event);
 	}
+
+	public testableResetComboSelection() {
+		this.resetComboSelection();
+	}
 }
 
 @Component({
@@ -158,5 +162,18 @@ describe('AutocompleteApiAutocomplete', () => {
 		component.combobox.clearText(event);
 		expect(component.combobox.input.nativeElement.value).toBe('');
 		expect(doSearchTextSpy).toHaveBeenCalled();
+	});
+
+	it('should reset combo selection', () => {
+		component.combobox.id = 'id';
+		component.combobox.description = 'description';
+		component.combobox.code = 'code';
+		component.combobox.currentSelected = {};
+		const resetComboSelectionSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'resetComboSelection').and.callThrough();
+		component.combobox.testableResetComboSelection();
+		expect(component.combobox.id).toBe(undefined);
+		expect(component.combobox.code).toBe(undefined);
+		expect(component.combobox.description).toBe(undefined);
+		expect(component.combobox.currentSelected).toBe(undefined);
 	});
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -187,4 +187,29 @@ describe('AutocompleteApiAutocomplete', () => {
 		expect(openDropDownSpy).toHaveBeenCalled();
 		expect(doSearchTextSpy).toHaveBeenCalledWith('description test');
 	});
+
+	it('should close drop down on enter key event on cell', () => {
+		const keyEvent = new KeyboardEvent('keydown', {key: KeyName.enter});
+		const setSelectedMock = () => {}
+		const event = {event: keyEvent, node: {setSelected: setSelectedMock}}
+		const closeDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'closeDropDown').and.callThrough();
+		component.combobox.onCellKeyDown(event);
+		expect(closeDropDownSpy).toHaveBeenCalled();
+	});
+
+	it('should remove last character on backspace key event on cell', () => {
+		const keyEvent = new KeyboardEvent('keydown', {key: KeyName.backspace});
+		const event = {event: keyEvent}
+		component.combobox.inputElement.nativeElement.value = 'aa'
+		component.combobox.onCellKeyDown(event);
+		expect(component.combobox.inputElement.nativeElement.value).toEqual('a');
+	});
+
+	it('should append new character on alphanumeric key event on cell', () => {
+		const keyEvent = new KeyboardEvent('keydown', {key: 'a'});
+		const event = {event: keyEvent}
+		component.combobox.inputElement.nativeElement.value = 'a'
+		component.combobox.onCellKeyDown(event);
+		expect(component.combobox.inputElement.nativeElement.value).toEqual('aa');
+	});
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -146,7 +146,7 @@ describe('AutocompleteApiAutocomplete', () => {
 
 	it('should close dropdown on escape, enter, or tab key press', () => {
 		const event = new KeyboardEvent('keydown', { key: KeyName.escape });
-		const closeDropDownSpy = spyOn(AutocompleteApiComboBox.prototype, 'closeDropDown');
+		const closeDropDownSpy = spyOn(AutocompleteApiComboBox.prototype, 'closeDropDown').and.callThrough();
 		component.combobox.isDropdownOpened = true;
 		component.combobox.doSearch(event);
 		expect(closeDropDownSpy).toHaveBeenCalled();

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -1,0 +1,162 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChangeDetectorRef, Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
+import { AutocompleteApiComboBox, KeyName } from './autocomplete-api-combobox.component';
+import { Observable, of } from 'rxjs';
+import { GridContextMenuCellRendererComponent } from '../../grid/contextmenu/grid-context-menu-cell-renderer.component';
+import { GridHeaderContextMenuComponent } from '../../grid/contextmenu/grid-header-context-menu-renderer.component';
+import { ComboBoxInputRendererComponent } from '../renderer/combobox-input-renderer.component';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { ButtonModule } from 'primeng/button';
+import { HttpClientModule } from '@angular/common/http';
+import { SystelabTranslateModule } from 'systelab-translate';
+import { SystelabPreferencesModule } from 'systelab-preferences';
+import { AgGridModule } from 'ag-grid-angular';
+
+export class TestData {
+	constructor(public id: string | number, public description: string) {
+	}
+}
+
+@Component({
+	selector:    'systelab-autocomplete-example',
+	templateUrl: 'autocomplete-combobox.component.html'
+})
+export class SystelabAutocompleteComponent extends AutocompleteApiComboBox<TestData> {
+
+	private totalItems: number;
+
+	constructor(myRenderer: Renderer2, public chref: ChangeDetectorRef) {
+		super(myRenderer, chref);
+	}
+
+	public getInstance() {
+		return new TestData('', '');
+	}
+
+	public getDescriptionField(): string {
+		return 'description';
+	}
+
+	public getCodeField(): string {
+		return null;
+	}
+
+	public getIdField(): string {
+		return 'id';
+	}
+
+	public getData(): Observable<Array<TestData>> {
+		const values: TestData[] = [];
+		values.push(new TestData('1', 'Description 1'));
+		values.push(new TestData('2', 'Description 2'));
+		values.push(new TestData('3', 'Description 3'));
+		values.push(new TestData('4', 'Description 4'));
+		this.totalItems = values.length;
+		return of(values);
+	}
+
+	public getTotalItems(): number {
+		return this.totalItems;
+	}
+
+	public override closeDropDown() {
+		super.closeDropDown();
+	}
+
+	public override doSearch(event: any) {
+		super.doSearch(event);
+	}
+}
+
+@Component({
+	selector: 'systelab-autocomplete-test',
+	template: `
+                <div class="container-fluid" style="height: 200px;">
+                    <div class="row mt-1">
+                        <label class="col-md-3 col-form-label" for="form-h-s">Test:</label>
+                        <div class="col-md-9">
+                            <systelab-autocomplete-example #combobox [(id)]="id" [(description)]="description"
+													   [multipleSelection]="multipleSelection"
+													   [withClearOption]="true"
+                                                       [(multipleSelectedItemList)]="multipleSelectedItemList">
+							</systelab-autocomplete-example>
+                        </div>
+                    </div>
+                </div>
+	          `
+})
+export class AutocompleteTestComponent {
+	@ViewChild('combobox') public combobox: SystelabAutocompleteComponent;
+	public id = '1';
+	public description = 'Description 2';
+	public multipleSelection = false;
+	public multipleSelectedItemList = [
+		new TestData('3', 'Description 3'),
+		new TestData('4', 'Description 4')
+	];
+}
+
+describe('AutocompleteApiAutocomplete', () => {
+	let component: AutocompleteTestComponent;
+	let fixture: ComponentFixture<AutocompleteTestComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [
+				BrowserModule,
+				BrowserAnimationsModule,
+				FormsModule,
+				OverlayModule,
+				ButtonModule,
+				HttpClientModule,
+				SystelabTranslateModule,
+				SystelabPreferencesModule,
+				AgGridModule
+			],
+			declarations: [
+				GridContextMenuCellRendererComponent,
+				GridHeaderContextMenuComponent,
+				ComboBoxInputRendererComponent,
+				SystelabAutocompleteComponent,
+				AutocompleteTestComponent
+			],
+			providers: [Renderer2, ChangeDetectorRef],
+		}).compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(AutocompleteTestComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	it('should not do search on shift or ctrl key press', () => {
+		const event = new KeyboardEvent('keydown', { shiftKey: true });
+		const doSearchText = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
+		component.combobox.doSearch(event);
+		expect(doSearchText).not.toHaveBeenCalled();
+	});
+
+	it('should close dropdown on escape, enter, or tab key press', () => {
+		const event = new KeyboardEvent('keydown', { key: KeyName.escape });
+		const closeDropDownSpy = spyOn(AutocompleteApiComboBox.prototype, 'closeDropDown');
+		component.combobox.isDropdownOpened = true;
+		component.combobox.doSearch(event);
+		expect(closeDropDownSpy).toHaveBeenCalled();
+	});
+
+	it('should clear input text and do search to reset result table', () => {
+		const event = new MouseEvent('click');
+		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
+		component.combobox.clearText(event);
+		expect(component.combobox.input.nativeElement.value).toBe('');
+		expect(doSearchTextSpy).toHaveBeenCalled();
+	});
+});

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -154,7 +154,7 @@ describe('AutocompleteApiAutocomplete', () => {
 
 	it('should clear input text and do search to reset result table', () => {
 		const event = new MouseEvent('click');
-		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
+		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText').and.callThrough();
 		component.combobox.clearText(event);
 		expect(component.combobox.input.nativeElement.value).toBe('');
 		expect(doSearchTextSpy).toHaveBeenCalled();

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -176,4 +176,15 @@ describe('AutocompleteApiAutocomplete', () => {
 		expect(component.combobox.description).toBe(undefined);
 		expect(component.combobox.currentSelected).toBe(undefined);
 	});
+
+	it('should open dropdown and search text on input click when it is not disabled and not already opened', () => {
+		component.combobox.isDisabled = false;
+		component.combobox.isDropdownOpened = false;
+		component.combobox.description = 'description test'
+		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown').and.callThrough();
+		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
+		component.combobox.onInputClicked(new MouseEvent(''));
+		expect(openDropDownSpy).toHaveBeenCalled();
+		expect(doSearchTextSpy).toHaveBeenCalledWith('description test');
+	});
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -19,6 +19,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 
 	public override startsWith = '';
 	@Input() public debounceTime: number = 350;
+	@Input() public withClearOption: boolean = false;
 
 	constructor(
 		public override myRenderer: Renderer2,
@@ -158,6 +159,15 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 		jQuery('#' + this.comboId)
 			.dropdown('toggle');
 		this.isDropdownOpened = true;
+	}
+
+	public inputIsEmpty(): boolean {
+		return this.input?.nativeElement.value.length === 0;
+	}
+
+	public clearText(event: MouseEvent): void {
+		this.input.nativeElement.value = '';
+		this.doSearch(event);
 	}
 
 }

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -38,7 +38,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 				this.closeDropDown();
 			}
 		} else {
-			this.doSearchText(event.target.value);
+			this.doSearchText(event.target?.value);
 		}
 	}
 
@@ -162,7 +162,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	}
 
 	public inputIsEmpty(): boolean {
-		return this.input?.nativeElement.value.length === 0;
+		return !this.input || this.input.nativeElement?.value.length === 0;
 	}
 
 	public clearText(event: MouseEvent): void {

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -17,13 +17,13 @@
                (keydown.arrowDown)="onInputNavigate()"
                (keydown.arrowUp)="onInputNavigate()"
                 (click)="onInputClicked($event)"/>
+        <button *ngIf="withClearOption && !inputIsEmpty()" type="button" #clearButton
+                class="slab-combo-button border-right-0 rounded-0 {{deleteIconClass}}" (click)="clearText($event)"
+                tabindex="-1"></button>
         <button type="button" *ngIf="withFavourites && id" #favouriteButton class="slab-combo-button slab-combo-star border-right-0 rounded-0 text-primary"
                 [ngClass]="{'icon-star': isFavourite, 'icon-star-o': !isFavourite}" (click)="doToggleFavourite($event)" tabindex="-1"></button>
         <button #combobutton type="button" class="slab-combo-button slab-combo-button-icon" [disabled]="isDisabled"
                 (click)="onComboClicked($event)" tabindex="-1"></button>
-        <button *ngIf="withClearOption && !inputIsEmpty()" type="button" #clearButton
-                class="slab-combo-button border-right-0 rounded-0 {{deleteIconClass}}" (click)="clearText($event)"
-                tabindex="-1"></button>
     </div>
     <div #dropdownmenu class="dropdown-menu slab-combo-dropdown" (click)="clickDropDownMenu($event)" [ngClass]="{'disabled': isDisabled}">
         <div #dropdown id="slab-combo-dropdown-box" class="slab-combo-dropdown-box">

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -2,7 +2,7 @@
      class="dropdown slab-combobox d-flex w-100"
      [ngClass]="{'disabled': isDisabled}">
     <div #dropdowntoogle class="slab-flex-1 d-flex dropdown-toggle slab-dropdown-toogle" id="{{comboId}}" data-toggle="dropdown">
-        <input #input type="search" class="slab-flex-1 d-flex slab-combo-input" keyup-debounce
+        <input #input type="text" class="slab-flex-1 d-flex slab-combo-input" keyup-debounce
                [disabled]="isDisabled"
                [(ngModel)]="fieldToShow"
                [keyupDebounceTime]="debounceTime" (keyupDebounced)="doSearch($event)"
@@ -21,6 +21,9 @@
                 [ngClass]="{'icon-star': isFavourite, 'icon-star-o': !isFavourite}" (click)="doToggleFavourite($event)" tabindex="-1"></button>
         <button #combobutton type="button" class="slab-combo-button slab-combo-button-icon" [disabled]="isDisabled"
                 (click)="onComboClicked($event)" tabindex="-1"></button>
+        <button *ngIf="withClearOption && !inputIsEmpty()" type="button" #clearButton
+                class="slab-combo-button border-right-0 rounded-0 {{deleteIconClass}}" (click)="clearText($event)"
+                tabindex="-1"></button>
     </div>
     <div #dropdownmenu class="dropdown-menu slab-combo-dropdown" (click)="clickDropDownMenu($event)" [ngClass]="{'disabled': isDisabled}">
         <div #dropdown id="slab-combo-dropdown-box" class="slab-combo-dropdown-box">


### PR DESCRIPTION
# PR Details

Made clear button for autocomplete fields optional

## Description

new option: [withClearOption] = true/false
By default is set to false

## Related Issue

#797

## Motivation and Context

Clear button was added previously but it was required to make it optional so we only add this clear button when we really want it

## How Has This Been Tested

manual test

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
