### PR TITLE
815-clear-button-should-be-disabled-when-input-is-disabled

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "15.3.13",
+  "version": "15.3.14",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -17,7 +17,7 @@
                (keydown.arrowDown)="onInputNavigate()"
                (keydown.arrowUp)="onInputNavigate()"
                 (click)="onInputClicked($event)"/>
-        <button *ngIf="withClearOption && !inputIsEmpty()" type="button" #clearButton
+        <button *ngIf="withClearOption && !inputIsEmpty()" type="button" #clearButton [hidden]="isDisabled"
                 class="slab-combo-button border-right-0 rounded-0 {{deleteIconClass}}" (click)="clearText($event)"
                 tabindex="-1"></button>
         <button type="button" *ngIf="withFavourites && id" #favouriteButton class="slab-combo-button slab-combo-star border-right-0 rounded-0 text-primary"


### PR DESCRIPTION
# PR Details

hidded clear button when field is disabled

## Description

hidded clear button when field is disabled

## Related Issue

#815 

## Motivation and Context

When the field is disabled you can still see clear button and its clickable, although it has no effect (aesthetic change)

## How Has This Been Tested

manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
