### PR TITLE
825-adjust-image-viewer-horizontally

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.0",
+  "version": "17.1.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -72,6 +72,10 @@ export class ImageViewerTestComponent {
 			this.imageViewer.setFilter(action);
 		}
 	}
+
+	public setInitials() {
+		this.imageViewer.setInitialValues();
+	}
 }
 
 const clickActionButton = (imageViewer: ComponentFixture<ImageViewerTestComponent>, children: number) => {
@@ -180,14 +184,14 @@ describe('ImageViewerTestComponent', () => {
 
 	it('should adjust image zoom on init', () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		imageViewerComponent.setInitialValues();
+		fixture.componentInstance.setInitials();
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
 	});
 
 	it('should adjust image zoom after doing adjust', () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		imageViewerComponent.setInitialValues();
+		fixture.componentInstance.setInitials();
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
 
@@ -199,7 +203,7 @@ describe('ImageViewerTestComponent', () => {
 
 	it('should toggleZoomByArea when zoom is enabled', () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		imageViewerComponent.setInitialValues();
+		fixture.componentInstance.setInitials();
 		imageViewerComponent.zoomEnabled = true;
 		imageViewerComponent.toggleZoomByArea();
 		expect(imageViewerComponent.zoomEnabled).toBeFalse();
@@ -207,7 +211,7 @@ describe('ImageViewerTestComponent', () => {
 
 	it('should toggleZoomByArea when zoom is disabled', () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		imageViewerComponent.setInitialValues();
+		fixture.componentInstance.setInitials();
 		imageViewerComponent.zoomEnabled = false;
 		imageViewerComponent.toggleZoomByArea();
 		expect(imageViewerComponent.zoomEnabled).toBeTrue();

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -92,6 +92,12 @@ const clickToggleButton = (imageViewer: ComponentFixture<ImageViewerTestComponen
 	imageViewer.detectChanges();
 };
 
+const clickAdjustButton = (imageViewer: ComponentFixture<ImageViewerTestComponent>) => {
+	const button = imageViewer.debugElement.nativeElement.querySelector('[data-test-id="AdjustBtn"]');
+	button.click();
+	imageViewer.detectChanges();
+};
+
 const clickOverlay = (imageViewer: ComponentFixture<ImageViewerTestComponent>) => {
 	const overlay = imageViewer.debugElement.nativeElement.querySelector('#imageViewerOverlayText');
 	overlay.click();
@@ -182,41 +188,21 @@ describe('ImageViewerTestComponent', () => {
 		expect(imageViewerComponent.zoomScale.marks.length).toBeGreaterThanOrEqual(0);
 	});
 
-	it('should adjust image zoom on init', () => {
+	it('should have initialized zoom with valid value', async () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
 		fixture.componentInstance.setInitials();
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
 	});
 
-	it('should adjust image zoom after doing adjust', () => {
+	it('should adjust image zoom after doing adjust to a valid value', async () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
 		fixture.componentInstance.setInitials();
-		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
-		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
-
 		imageViewerComponent.imgParams.sliderZoomPct = 199;
-		imageViewerComponent.doAdjust();
+		clickAdjustButton(fixture);
+		await fixture.whenStable();
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
 	});
-
-	it('should toggleZoomByArea when zoom is enabled', () => {
-		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		fixture.componentInstance.setInitials();
-		imageViewerComponent.zoomEnabled = true;
-		imageViewerComponent.toggleZoomByArea();
-		expect(imageViewerComponent.zoomEnabled).toBeFalse();
-	});
-
-	it('should toggleZoomByArea when zoom is disabled', () => {
-		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		fixture.componentInstance.setInitials();
-		imageViewerComponent.zoomEnabled = false;
-		imageViewerComponent.toggleZoomByArea();
-		expect(imageViewerComponent.zoomEnabled).toBeTrue();
-		expect(imageViewerComponent.dragEnabled).toBeFalse();
-	});
-
 });
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -177,11 +177,23 @@ describe('ImageViewerTestComponent', () => {
 		expect(imageViewerComponent.zoomScale.marks.length).toBeGreaterThanOrEqual(0);
 	});
 
-	it('should adjust image', () => {
+	it('should adjust image zoom on init', () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
 		imageViewerComponent.setInitialValues();
-		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThan(0);
-		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(200);
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
+	});
+
+	it('should adjust image zoom after doing adjust', () => {
+		const imageViewerComponent = fixture.componentInstance.imageViewer;
+		imageViewerComponent.setInitialValues();
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
+
+		imageViewerComponent.imgParams.sliderZoomPct = 199;
+		imageViewerComponent.doAdjust();
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
 	});
 
 });

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -177,5 +177,13 @@ describe('ImageViewerTestComponent', () => {
 		expect(imageViewerComponent.zoomScale.marks.length).toBeGreaterThanOrEqual(0);
 	});
 
+	it('should adjust image', () => {
+		const imageViewerComponent = fixture.componentInstance.imageViewer;
+		spyOn<any>(imageViewerComponent, 'getInitialZoom').and.callThrough();
+		imageViewerComponent.setInitialValues();
+		expect(imageViewerComponent['getInitialZoom']).toHaveBeenCalled();
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toEqual(55.666666666666664);
+	});
+
 });
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {Component, ViewChild} from '@angular/core';
+import { Component, NO_ERRORS_SCHEMA, ViewChild } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
@@ -105,7 +105,8 @@ describe('ImageViewerTestComponent', () => {
 				HttpClientModule,
 				SystelabTranslateModule
 			],
-			declarations: [ImageViewerComponent,ImageViewerTestComponent,ButtonComponent,SliderComponent,ToggleButtonComponent]
+			declarations: [ImageViewerComponent,ImageViewerTestComponent,ButtonComponent,SliderComponent,ToggleButtonComponent],
+			schemas: [ NO_ERRORS_SCHEMA ]
 		}).compileComponents();
 
 		fixture = TestBed.createComponent(ImageViewerTestComponent);
@@ -194,6 +195,23 @@ describe('ImageViewerTestComponent', () => {
 		imageViewerComponent.doAdjust();
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
+	});
+
+	it('should toggleZoomByArea when zoom is enabled', () => {
+		const imageViewerComponent = fixture.componentInstance.imageViewer;
+		imageViewerComponent.setInitialValues();
+		imageViewerComponent.zoomEnabled = true;
+		imageViewerComponent.toggleZoomByArea();
+		expect(imageViewerComponent.zoomEnabled).toBeFalse();
+	});
+
+	it('should toggleZoomByArea when zoom is disabled', () => {
+		const imageViewerComponent = fixture.componentInstance.imageViewer;
+		imageViewerComponent.setInitialValues();
+		imageViewerComponent.zoomEnabled = false;
+		imageViewerComponent.toggleZoomByArea();
+		expect(imageViewerComponent.zoomEnabled).toBeTrue();
+		expect(imageViewerComponent.dragEnabled).toBeFalse();
 	});
 
 });

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -204,5 +204,23 @@ describe('ImageViewerTestComponent', () => {
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThanOrEqual(imageViewerComponent.sliderZoomMin);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(imageViewerComponent.sliderZoomMax);
 	});
+
+
+	it('should toggleZoomByArea when zoom is enabled', () => {
+		const imageViewerComponent = fixture.componentInstance.imageViewer;
+		fixture.componentInstance.setInitials();
+		imageViewerComponent.zoomEnabled = true;
+		imageViewerComponent.toggleZoomByArea();
+		expect(imageViewerComponent.zoomEnabled).toBeFalse();
+	});
+
+	it('should toggleZoomByArea when zoom is disabled', () => {
+		const imageViewerComponent = fixture.componentInstance.imageViewer;
+		fixture.componentInstance.setInitials();
+		imageViewerComponent.zoomEnabled = false;
+		imageViewerComponent.toggleZoomByArea();
+		expect(imageViewerComponent.zoomEnabled).toBeTrue();
+		expect(imageViewerComponent.dragEnabled).toBeFalse();
+	});
 });
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -179,9 +179,7 @@ describe('ImageViewerTestComponent', () => {
 
 	it('should adjust image', () => {
 		const imageViewerComponent = fixture.componentInstance.imageViewer;
-		spyOn<any>(imageViewerComponent, 'getInitialZoom').and.callThrough();
 		imageViewerComponent.setInitialValues();
-		expect(imageViewerComponent['getInitialZoom']).toHaveBeenCalled();
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThan(0);
 		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(200);
 	});

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -182,7 +182,8 @@ describe('ImageViewerTestComponent', () => {
 		spyOn<any>(imageViewerComponent, 'getInitialZoom').and.callThrough();
 		imageViewerComponent.setInitialValues();
 		expect(imageViewerComponent['getInitialZoom']).toHaveBeenCalled();
-		expect(imageViewerComponent.imgParams.sliderZoomPct).toEqual(55.666666666666664);
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeGreaterThan(0);
+		expect(imageViewerComponent.imgParams.sliderZoomPct).toBeLessThanOrEqual(200);
 	});
 
 });

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -392,8 +392,8 @@ export class ImageViewerComponent {
 		const zoomWidth = (availableWidth / imageWidth) * 100;
 		const zoomHeight = (availableHeight / imageHeight) * 100;
 
-		// Use Zoom calculation of the smaller size, so it always fits
-		return Math.min(Math.min(zoomWidth, zoomHeight), 200);
+		// Use Zoom calculation of the smaller size, so it always fits, and it is between the allowed limits
+		return Math.max(Math.min(Math.min(zoomWidth, zoomHeight), this.sliderZoomMax), this.sliderZoomMin);
 	}
 
 }

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -388,12 +388,20 @@ export class ImageViewerComponent {
 		const imageWidth = this.image.naturalWidth;
 		const imageHeight = this.image.naturalHeight;
 
-		// Calculate Zoom for width and height
-		const zoomWidth = (availableWidth / imageWidth) * 100;
-		const zoomHeight = (availableHeight / imageHeight) * 100;
-
-		// Use Zoom calculation of the smaller size, so it always fits, and it is between the allowed limits
-		return Math.max(Math.min(Math.min(zoomWidth, zoomHeight), this.sliderZoomMax), this.sliderZoomMin);
+		let newZoom: number;
+		if (imageWidth > imageHeight) {
+			if (imageWidth < availableWidth) {
+				newZoom = (availableHeight / imageHeight) * 100;
+			} else {
+				newZoom = (availableWidth / imageWidth) * 100;
+			}
+		} else {
+			if (imageHeight < availableHeight) {
+				newZoom = (availableWidth / imageWidth) * 100;
+			} else {
+				newZoom = (availableHeight / imageHeight) * 100;
+			}
+		}
+		return Math.min(newZoom, this.sliderZoomMax);
 	}
-
 }

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -381,11 +381,19 @@ export class ImageViewerComponent {
 	}
 
 	private getInitialZoom(): number {
-		// Calculate initial zoom of the image to fit the window
-		const availableSize = this.viewPort.offsetWidth < this.viewPort.offsetHeight ? this.viewPort.offsetWidth
-			: this.viewPort.offsetHeight;
-		const imageSize = this.image.naturalWidth < this.image.naturalHeight ? this.image.naturalWidth : this.image.naturalHeight;
-		return availableSize / imageSize * 100;
+		// Calculate initial Zoom of the image to fit the window
+		const availableWidth = this.viewPort.offsetWidth;
+		const availableHeight = this.viewPort.offsetHeight;
+
+		const imageWidth = this.image.naturalWidth;
+		const imageHeight = this.image.naturalHeight;
+
+		// Calculate Zoom for width and height
+		const zoomWidth = (availableWidth / imageWidth) * 100;
+		const zoomHeight = (availableHeight / imageHeight) * 100;
+
+		// Use Zoom calculation of the smaller size, so it always fits
+		return Math.min(Math.min(zoomWidth, zoomHeight), 200);
 	}
 
 }


### PR DESCRIPTION
# PR Details

Horizontal adjustment for image viewer

## Description

Added the calculation to have a correct adjustment for the image inside an image viewer when it is horizontal (it still adjusts when it is vertical or square)

## Related Issue

#825 

## Motivation and Context

We normally display vertical or square images in image viewers but now we need to also display charts that are normally horizontal and they were not being shown correctly adjusted inside the image viewer available space.

## How Has This Been Tested

manually tested with different image sizes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
