### PR TITLE
842-allow-having-transparent-header-for-image-viewer

### DIFF
--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
@@ -1,3 +1,7 @@
+<div>
+    <input type="checkbox" [checked]="setTransparent" [(ngModel)]="setTransparent" id="check-transparent">
+    <label for="check-transparent">Transparent header</label>
+</div>
 <div class="position-relative d-flex slab-flex-1 border" style="height:600px;width:900px">
     <systelab-image-viewer class="slab-overflow-container d-flex slab-flex-1" #imageViewer
               [imageSrc]="imageSrc"
@@ -10,6 +14,7 @@
               [showAdjustButton]="true"
               [showZoomScale]="true"
               [showSliderToolTip]="false"
+              [setTransparentBackgroundForButtons]="setTransparent"
               (clickActionButton)="doClickActionButton($event)"
               (clickOverlayText)="doClickOverlayText()">
     </systelab-image-viewer>

--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
@@ -1,5 +1,5 @@
 <div>
-    <input type="checkbox" [checked]="setTransparent" [(ngModel)]="setTransparent" id="check-transparent">
+    <input type="checkbox" [checked]="transparentBackgroundForButtons" [(ngModel)]="transparentBackgroundForButtons" id="check-transparent">
     <label for="check-transparent">Transparent header</label>
 </div>
 <div class="position-relative d-flex slab-flex-1 border" style="height:600px;width:900px">
@@ -14,7 +14,7 @@
               [showAdjustButton]="true"
               [showZoomScale]="true"
               [showSliderToolTip]="false"
-              [setTransparentBackgroundForButtons]="setTransparent"
+              [transparentBackgroundForButtons]="transparentBackgroundForButtons"
               (clickActionButton)="doClickActionButton($event)"
               (clickOverlayText)="doClickOverlayText()">
     </systelab-image-viewer>

--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
@@ -40,7 +40,7 @@ export class ShowcaseImageViewerComponent {
 									0 0 0 1 0"/>
 	   </filter>`;
 
-	public setTransparent = false;
+	public transparentBackgroundForButtons = false;
 
 	constructor() {
 	}

--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
@@ -40,6 +40,8 @@ export class ShowcaseImageViewerComponent {
 									0 0 0 1 0"/>
 	   </filter>`;
 
+	public setTransparent = false;
+
 	constructor() {
 	}
 

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.4",
+  "version": "17.1.5",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -1,6 +1,8 @@
 <svg class="d-none" [innerHTML]="safeHtml"></svg>
 
-<div class="d-flex flex-column slab-flex-1" id="imageViewerHeader" data-test-id="imageViewerHeader">
+<div class="d-flex flex-column slab-flex-1" id="imageViewerHeader"
+     [ngClass]="setTransparentBackgroundForButtons ? 'bg-color-transparent' : 'bg-color-primary'"
+     data-test-id="imageViewerHeader">
     <div class="d-flex">
         <div class="ml-1">
             @for (actionButton of actionButtons; track actionButton.label) {

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -1,7 +1,7 @@
 <svg class="d-none" [innerHTML]="safeHtml"></svg>
 
 <div class="d-flex flex-column slab-flex-1" id="imageViewerHeader"
-     [ngClass]="setTransparentBackgroundForButtons ? 'bg-color-transparent' : 'bg-color-primary'"
+     [ngClass]="transparentBackgroundForButtons ? 'bg-color-transparent' : 'bg-color-primary'"
      data-test-id="imageViewerHeader">
     <div class="d-flex">
         <div class="ml-1">

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.scss
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.scss
@@ -5,7 +5,6 @@
   z-index: 100;
   width: 100%;
   padding: 10px;
-  background-color: rgba($background-primary, 0.8);
 
   /* Allow click on the image also below the header area */
   pointer-events: none;
@@ -13,6 +12,14 @@
   div > div:not(#overImageArea),
   #ImageViewerSlider {
     pointer-events: initial;
+  }
+
+  &.bg-color-transparent {
+    background-color: transparent;
+  }
+
+  &.bg-color-primary {
+    background-color: rgba($background-primary, 0.8);
   }
 
   #zoomScale {

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -13,19 +13,19 @@ import {SystelabTranslateModule} from 'systelab-translate';
 @Component({
 	selector: 'systelab-image-viewer-test',
 	template: `
-        <systelab-image-viewer #imageViewer class="slab-overflow-container"
-			   [imageSrc]="imageSrc"
-			   [imageTitle]="imageTitle"
-			   [overlayText]="imageTitle"
-			   [actionButtons]="actionButtons"
-				 [imageFilters]="imageFilters"
-			   (clickActionButton)="doClickActionButton($event)"
-				 (clickOverlayText)="doClickOverlayText()"
-			   [showZoomByAreaButton]="true"
-			   [showAdjustButton]="true"
-			   [setTransparentBackgroundForButtons]="setTransparentBackgroundForButtons"
-			   [showZoomScale]="true">
-        </systelab-image-viewer>`,
+                  <systelab-image-viewer #imageViewer class="slab-overflow-container"
+                                         [imageSrc]="imageSrc"
+                                         [imageTitle]="imageTitle"
+                                         [overlayText]="imageTitle"
+                                         [actionButtons]="actionButtons"
+                                         [imageFilters]="imageFilters"
+                                         (clickActionButton)="doClickActionButton($event)"
+                                         (clickOverlayText)="doClickOverlayText()"
+                                         [showZoomByAreaButton]="true"
+                                         [showAdjustButton]="true"
+                                         [transparentBackgroundForButtons]="transparentBackgroundForButtons"
+                                         [showZoomScale]="true">
+                  </systelab-image-viewer>`,
 	styles:   []
 })
 export class ImageViewerTestComponent {
@@ -53,7 +53,7 @@ export class ImageViewerTestComponent {
 								 0 0 0 0 0
 								 0 0 0 1 0"/>
 	</filter>`;
-	public setTransparentBackgroundForButtons = false;
+	public transparentBackgroundForButtons = false;
 
 	public doClickActionButton($event: string): void {
 		if ($event === 'Action 1') {
@@ -243,15 +243,15 @@ describe('ImageViewerTestComponent', () => {
 
 	it('should should not have transparent class when input is false', () => {
 		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
-		expect(fixture.componentInstance.imageViewer.setTransparentBackgroundForButtons).toBe(false);
+		expect(fixture.componentInstance.imageViewer.transparentBackgroundForButtons).toBe(false);
 		expect(isTransparentClass).toBe(0);
 	});
 
 	it('should should have transparent class when input is true', () => {
-		fixture.componentInstance.setTransparentBackgroundForButtons = true;
+		fixture.componentInstance.transparentBackgroundForButtons = true;
 		fixture.detectChanges();
 		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
-		expect(fixture.componentInstance.imageViewer.setTransparentBackgroundForButtons).toBe(true);
+		expect(fixture.componentInstance.imageViewer.transparentBackgroundForButtons).toBe(true);
 		expect(isTransparentClass).toBeGreaterThan(0);
 	});
 });

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -23,6 +23,7 @@ import {SystelabTranslateModule} from 'systelab-translate';
 				 (clickOverlayText)="doClickOverlayText()"
 			   [showZoomByAreaButton]="true"
 			   [showAdjustButton]="true"
+			   [setTransparentBackgroundForButtons]="false"
 			   [showZoomScale]="true">
         </systelab-image-viewer>`,
 	styles:   []

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -23,7 +23,7 @@ import {SystelabTranslateModule} from 'systelab-translate';
 				 (clickOverlayText)="doClickOverlayText()"
 			   [showZoomByAreaButton]="true"
 			   [showAdjustButton]="true"
-			   [setTransparentBackgroundForButtons]="false"
+			   [setTransparentBackgroundForButtons]="setTransparentBackgroundForButtons"
 			   [showZoomScale]="true">
         </systelab-image-viewer>`,
 	styles:   []
@@ -53,6 +53,7 @@ export class ImageViewerTestComponent {
 								 0 0 0 0 0
 								 0 0 0 1 0"/>
 	</filter>`;
+	public setTransparentBackgroundForButtons = false;
 
 	public doClickActionButton($event: string): void {
 		if ($event === 'Action 1') {
@@ -246,7 +247,7 @@ describe('ImageViewerTestComponent', () => {
 	});
 
 	it('should should have transparent class when input is true', () => {
-		fixture.componentInstance.imageViewer.setTransparentBackgroundForButtons = true;
+		fixture.componentInstance.setTransparentBackgroundForButtons = true;
 		fixture.detectChanges();
 		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
 		expect(isTransparentClass).toBeGreaterThan(0);

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -238,5 +238,17 @@ describe('ImageViewerTestComponent', () => {
 		imageViewerComponent.toggleZoomByArea();
 		expect(imageViewerComponent.imageWidth).not.toBe('');
 	});
+
+	it('should should not have transparent class when input is false', () => {
+		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
+		expect(isTransparentClass).toBe(0);
+	});
+
+	it('should should have transparent class when input is true', () => {
+		fixture.componentInstance.imageViewer.setTransparentBackgroundForButtons = true;
+		fixture.detectChanges();
+		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
+		expect(isTransparentClass).toBeGreaterThan(0);
+	});
 });
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -243,6 +243,7 @@ describe('ImageViewerTestComponent', () => {
 
 	it('should should not have transparent class when input is false', () => {
 		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
+		expect(fixture.componentInstance.imageViewer.setTransparentBackgroundForButtons).toBe(false);
 		expect(isTransparentClass).toBe(0);
 	});
 
@@ -250,6 +251,7 @@ describe('ImageViewerTestComponent', () => {
 		fixture.componentInstance.setTransparentBackgroundForButtons = true;
 		fixture.detectChanges();
 		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
+		expect(fixture.componentInstance.imageViewer.setTransparentBackgroundForButtons).toBe(true);
 		expect(isTransparentClass).toBeGreaterThan(0);
 	});
 });

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -43,6 +43,7 @@ export class ImageViewerComponent implements OnInit {
 	@Input() public sliderZoomMin = 100;
 	@Input() public sliderZoomMax = 200;
 	@Input() public sliderZoomStep = 1;
+	@Input() public setTransparentBackgroundForButtons = false;
 
 	@Output() public clickActionButton = new EventEmitter<string>();
 	@Output() public clickOverlayText = new EventEmitter();

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -43,7 +43,7 @@ export class ImageViewerComponent implements OnInit {
 	@Input() public sliderZoomMin = 100;
 	@Input() public sliderZoomMax = 200;
 	@Input() public sliderZoomStep = 1;
-	@Input() public setTransparentBackgroundForButtons = false;
+	@Input() public transparentBackgroundForButtons = false;
 
 	@Output() public clickActionButton = new EventEmitter<string>();
 	@Output() public clickOverlayText = new EventEmitter();


### PR DESCRIPTION
# PR Details

Added functionality

## Description

New input for image viewer component to allow it having a transparent header.
Added showcase option to enable/disable this option and test

## Related Issue

#842 

## Motivation and Context

It allows setting header to transparent for small images that could get covered by header

## How Has This Been Tested

showcase, manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
