### PR TITLE
bug-855 remove open dialog animation for firefox

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.7",
+  "version": "17.1.8",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/modern/_dialog.scss
+++ b/projects/systelab-components/sass/modern/_dialog.scss
@@ -61,6 +61,12 @@ $slab-button-fontsize: 25px !default;
     animation: scaleUp .2s;
   }
 
+  // avoid animation in firefox because it produces an unpleasant flickering effect
+  @-moz-document url-prefix() {
+    &:not(.fullscreen) {
+      animation: none;
+    }
+  }
 
   &.fullscreen {
     border: 0;


### PR DESCRIPTION
# PR Details
Remove animation for firefox when a dialog is opened because it produces an unpleasent flickering effect.

## Related Issue

https://github.com/systelab/systelab-components/issues/855

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
