### PR TITLE
abstract-grid recover variable name from feature-857 breaking change

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.11",
+  "version": "17.1.12",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -487,7 +487,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	}
 
 	private doAutoSizeManagement(event?: any) {
-		this.firstSizeToFitExecuted = true;
+		this.firstSizeToFitExecuted = true; 
 		AutosizeGridHelper.doAutoSizeManagement(this.calculatedGridState, this.gridOptions, event);
 	}
 }

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -50,7 +50,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	@ViewChild('popupmenu', {static: false}) public popupmenu: GridContextMenuComponent<T>;
 	@ViewChild('headerpopupmenu', {static: false}) public headerPopupMenu: GridHeaderContextMenu<Object>;
 
-	protected firstAutoSizeExecuted = false;
+	protected firstSizeToFitExecuted = false;
 	private calculatedGridState: CalculatedGridState;
 	private scrollTimeout;
 
@@ -124,7 +124,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	}
 
 	protected saveColumnsStateInPreferences(): void {
-		if (this.firstAutoSizeExecuted) {
+		if (this.firstSizeToFitExecuted) {
 			this.preferencesService.put(this.getGridOptionsPreferencesPrefix(), this.gridOptions.columnApi.getColumnState());
 		}
 	}
@@ -487,7 +487,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	}
 
 	private doAutoSizeManagement(event?: any) {
-		this.firstAutoSizeExecuted = true;
+		this.firstSizeToFitExecuted = true;
 		AutosizeGridHelper.doAutoSizeManagement(this.calculatedGridState, this.gridOptions, event);
 	}
 }


### PR DESCRIPTION
# PR Details

Recover variable name from feature-857 breaking change

## Description

firstAutoSizeExecuted is renamed back to firstSizeToFitExecuted

## Related Issue

[#861](#861)

## Motivation and Context

version 17.1.10 introduced a breaking change

## How Has This Been Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
