### PR TITLE
864-image-viewer-allow-showhide-download-button

### DIFF
--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
@@ -2,6 +2,10 @@
     <input type="checkbox" [checked]="transparentBackgroundForButtons" [(ngModel)]="transparentBackgroundForButtons" id="check-transparent">
     <label for="check-transparent">Transparent header</label>
 </div>
+<div>
+    <input type="checkbox" [checked]="showSaveButton" [(ngModel)]="showSaveButton" id="check-show-save-button">
+    <label for="check-show-save-button">Show / Hide download button</label>
+</div>
 <div class="position-relative d-flex slab-flex-1 border" style="height:600px;width:900px">
     <systelab-image-viewer class="slab-overflow-container d-flex slab-flex-1" #imageViewer
               [imageSrc]="imageSrc"
@@ -10,6 +14,7 @@
               [actionButtons]="actionButtons"
               [imageFilters]="imageFilters"
               [sliderZoomMax]="200"
+              [showSaveButton]="showSaveButton"
               [showZoomByAreaButton]="true"
               [showAdjustButton]="true"
               [showZoomScale]="true"

--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
@@ -41,6 +41,7 @@ export class ShowcaseImageViewerComponent {
 	   </filter>`;
 
 	public transparentBackgroundForButtons = false;
+	public showSaveButton = true;
 
 	constructor() {
 	}

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.12",
+  "version": "17.1.13",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -39,7 +39,7 @@
         </div>
         <div class="d-flex slab-flex-1" id="OverImageArea"></div>
         <div class="ml-auto">
-            <systelab-button systelabTooltip="{{ 'COMMON_SAVE' | translate | async }}">
+            <systelab-button *ngIf="showSaveButton" data-test-id="SaveBtn" systelabTooltip="{{ 'COMMON_SAVE' | translate | async }}">
             <a [href]="imageSrc" download="{{imageTitle}}"><i class="icon-download1"></i></a>
             </systelab-button>
             <systelab-toggle-button *ngIf="showZoomByAreaButton" class="ml-2" data-test-id="ZoomByAreaBtn" systelabTooltip="{{ 'COMMON_ZOOM_DRAG' | translate | async }}"

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -21,6 +21,7 @@ import {SystelabTranslateModule} from 'systelab-translate';
                                          [imageFilters]="imageFilters"
                                          (clickActionButton)="doClickActionButton($event)"
                                          (clickOverlayText)="doClickOverlayText()"
+										 [showSaveButton]="showDownloadButton"
                                          [showZoomByAreaButton]="true"
                                          [showAdjustButton]="true"
                                          [transparentBackgroundForButtons]="transparentBackgroundForButtons"
@@ -54,6 +55,7 @@ export class ImageViewerTestComponent {
 								 0 0 0 1 0"/>
 	</filter>`;
 	public transparentBackgroundForButtons = false;
+	public showDownloadButton = true;
 
 	public doClickActionButton($event: string): void {
 		if ($event === 'Action 1') {
@@ -253,6 +255,20 @@ describe('ImageViewerTestComponent', () => {
 		const isTransparentClass = fixture.debugElement.nativeElement.getElementsByClassName('bg-color-transparent').length;
 		expect(fixture.componentInstance.imageViewer.transparentBackgroundForButtons).toBe(true);
 		expect(isTransparentClass).toBeGreaterThan(0);
+	});
+
+	it('should show download button when input is true', () => {
+		fixture.componentInstance.showDownloadButton = true;
+		fixture.detectChanges();
+		const button = fixture.debugElement.nativeElement.querySelector('[data-test-id="SaveBtn"]');
+		expect(button).toBeDefined();
+	});
+
+	it('should not show download button when input is true', () => {
+		fixture.componentInstance.showDownloadButton = false;
+		fixture.detectChanges();
+		const button = fixture.debugElement.nativeElement.querySelector('[data-test-id="SaveBtn"]');
+		expect(button).toBeNull();
 	});
 });
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -36,6 +36,7 @@ export class ImageViewerComponent implements OnInit {
 	@Input() public overlayText: string;
 	@Input() public actionButtons: ActionButton[];
 	@Input() public imageFilters = '';
+	@Input() public showSaveButton = true;
 	@Input() public showZoomByAreaButton = false;
 	@Input() public showAdjustButton = false;
 	@Input() public showZoomScale = false;


### PR DESCRIPTION
# PR Details

Added possibility to hide save button

## Description

Now you can decide if you want save button to be shown by passing a value to input [showSaveButton]

## Related Issue

#864 

## How Has This Been Tested

Showcase functionality and automatic test covering all cases

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
