### PR TITLE
868 custom border color for image-viewer zoom area selector

### DIFF
--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.html
@@ -10,6 +10,12 @@
     <input type="checkbox" [checked]="overlapImage" [(ngModel)]="overlapImage" id="check-overlap-image">
     <label for="check-overlap-image">Overlap image & buttons</label>
 </div>
+<div class="row mt-1">
+    <label class="col-md-3 col-form-label" for="allow-border-color">Border color for allowed zoom area: </label>
+    <div class="col-md-9">
+        <input type="text" class="form-control" placeholder="color" [(ngModel)]="allowBorderColor" id="allow-border-color">
+    </div>
+</div>
 <div class="position-relative d-flex slab-flex-1 border" style="height:600px;width:900px">
     <systelab-image-viewer class="slab-overflow-container d-flex slab-flex-1" #imageViewer
               [imageSrc]="imageSrc"
@@ -25,6 +31,7 @@
               [showSliderToolTip]="false"
               [transparentBackgroundForButtons]="transparentBackgroundForButtons"
               [overlapImageWithButtons]="overlapImage"
+              [allowBorderColor]="allowBorderColor"
               (clickActionButton)="doClickActionButton($event)"
               (clickOverlayText)="doClickOverlayText()">
     </systelab-image-viewer>

--- a/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
+++ b/projects/showcase/src/app/components/image-viewer/showcase-image-viewer.component.ts
@@ -43,6 +43,7 @@ export class ShowcaseImageViewerComponent {
 	public transparentBackgroundForButtons = false;
 	public showSaveButton = true;
 	public overlapImage = true;
+	public allowBorderColor = 'white';
 
 	constructor() {
 	}

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.13",
+  "version": "17.1.14",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -84,7 +84,7 @@
 
     <div id="selector" data-test-id="ZoomSelector"
          [style.display]="zoomSelector.visible ? 'block' : 'none'"
-         [style.borderColor]="zoomSelector.allow ? 'white' : 'red'"
+         [style.borderColor]="zoomSelector.allow ? allowBorderColor : 'red'"
          [style.top.px]="zoomSelector.top"
          [style.left.px]="zoomSelector.left"
          [style.width.px]="zoomSelector.width"

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.spec.ts
@@ -26,6 +26,7 @@ import {SystelabTranslateModule} from 'systelab-translate';
                                          [showAdjustButton]="true"
                                          [transparentBackgroundForButtons]="transparentBackgroundForButtons"
 										 [overlapImageWithButtons]="overlapImageWithButtons"
+										 [allowBorderColor]="allowBorderColor"
                                          [showZoomScale]="true">
                   </systelab-image-viewer>`,
 	styles:   []
@@ -58,6 +59,7 @@ export class ImageViewerTestComponent {
 	public transparentBackgroundForButtons = false;
 	public showDownloadButton = true;
 	public overlapImageWithButtons = true;
+	public allowBorderColor = 'white';
 
 	public doClickActionButton($event: string): void {
 		if ($event === 'Action 1') {
@@ -286,6 +288,13 @@ describe('ImageViewerTestComponent', () => {
 		const isNoOverlapClass = fixture.debugElement.nativeElement.getElementsByClassName('no-overlapping').length;
 		expect(fixture.componentInstance.imageViewer.overlapImageWithButtons).toBe(false);
 		expect(isNoOverlapClass).toBeGreaterThan(0);
+	});
+
+	it('should set allow zoom area border color to the input value', () => {
+		fixture.componentInstance.allowBorderColor = 'blue';
+		fixture.detectChanges();
+		const area = fixture.debugElement.nativeElement.querySelector('[data-test-id="ZoomSelector"]');
+		expect(area.style.borderColor).toEqual('blue');
 	});
 });
 

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.ts
@@ -46,6 +46,7 @@ export class ImageViewerComponent implements OnInit {
 	@Input() public sliderZoomStep = 1;
 	@Input() public transparentBackgroundForButtons = false;
 	@Input() public overlapImageWithButtons = true;
+	@Input() public allowBorderColor = 'white';
 
 	@Output() public clickActionButton = new EventEmitter<string>();
 	@Output() public clickOverlayText = new EventEmitter();


### PR DESCRIPTION
# PR Details

custom border color for image-viewer zoom area selector

## Description

added input with default value as it was before that allows you to provide a custom color for the zoom selector area border

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
#868 

## Motivation and Context

It makes possible to make the zoom selector more visible in adverse situations

## How Has This Been Tested

automatic test + showcase functional example

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
