### PR TITLE
870 let select highlighted option after typing text in autocomplete combobox

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.15",
+  "version": "17.1.16",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.ts
@@ -60,7 +60,6 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 			if (this.totalItemsLoaded) {
 				this.setDropdownHeight();
 				this.setDropdownPosition();
-				this.transferFocusToGrid();
 				result = false;
 			}
 		}

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -14,6 +14,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { SystelabTranslateModule } from 'systelab-translate';
 import { SystelabPreferencesModule } from 'systelab-preferences';
 import { AgGridModule } from 'ag-grid-angular';
+import { GridApi, RowNode } from 'ag-grid-community';
 
 export class TestData {
 	constructor(public id: string | number, public description: string) {
@@ -211,5 +212,15 @@ describe('AutocompleteApiAutocomplete', () => {
 		component.combobox.inputElement.nativeElement.value = 'a'
 		component.combobox.onCellKeyDown(event);
 		expect(component.combobox.inputElement.nativeElement.value).toEqual('aa');
+	});
+
+	it('onEnterDoSelect', () => {
+		const selectThisNodeSpy = spyOn(RowNode.prototype, 'selectThisNode');
+		component.combobox.onEnterDoSelect(new KeyboardEvent('keydown', {}));
+		if (component.combobox.isDropdownOpened) {
+			expect(selectThisNodeSpy).toHaveBeenCalled();
+		} else {
+			expect(selectThisNodeSpy).not.toHaveBeenCalled();
+		}
 	});
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -15,6 +15,7 @@ import { SystelabTranslateModule } from 'systelab-translate';
 import { SystelabPreferencesModule } from 'systelab-preferences';
 import { AgGridModule } from 'ag-grid-angular';
 import { GridApi, RowNode } from 'ag-grid-community';
+import { roundToNearestMinutesWithOptions } from 'date-fns/fp';
 
 export class TestData {
 	constructor(public id: string | number, public description: string) {
@@ -107,6 +108,12 @@ export class AutocompleteTestComponent {
 describe('AutocompleteApiAutocomplete', () => {
 	let component: AutocompleteTestComponent;
 	let fixture: ComponentFixture<AutocompleteTestComponent>;
+	const gridApiSpy = jasmine.createSpyObj('GridApi', ['getDisplayedRowAtIndex']);
+	const gridApiMock = {
+		getDisplayedRowAtIndex: () => {
+			return new RowNode<any>(null);
+		}
+	} as unknown as GridApi;
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
@@ -128,7 +135,10 @@ describe('AutocompleteApiAutocomplete', () => {
 				SystelabAutocompleteComponent,
 				AutocompleteTestComponent
 			],
-			providers: [Renderer2, ChangeDetectorRef],
+			providers: [
+				Renderer2,
+				ChangeDetectorRef,
+			],
 		}).compileComponents();
 	});
 
@@ -215,12 +225,21 @@ describe('AutocompleteApiAutocomplete', () => {
 	});
 
 	it('onEnterDoSelect', () => {
-		const selectThisNodeSpy = spyOn(RowNode.prototype, 'selectThisNode');
+		const getDisplayedRowAtIndexSpy = spyOn<any>(gridApiMock, 'getDisplayedRowAtIndex').and.callThrough();
+		spyOn(RowNode.prototype, 'selectThisNode');
+		component.combobox.gridOptions.api = gridApiMock;
+		component.combobox.isDropdownOpened = true;
 		component.combobox.onEnterDoSelect(new KeyboardEvent('keydown', {}));
-		if (component.combobox.isDropdownOpened) {
-			expect(selectThisNodeSpy).toHaveBeenCalled();
-		} else {
-			expect(selectThisNodeSpy).not.toHaveBeenCalled();
-		}
+		expect(getDisplayedRowAtIndexSpy).toHaveBeenCalled();
 	});
+
+	it('onEnterDoSelect', () => {
+		const getDisplayedRowAtIndexSpy = spyOn<any>(gridApiMock, 'getDisplayedRowAtIndex').and.callThrough();
+		spyOn(RowNode.prototype, 'selectThisNode');
+		component.combobox.gridOptions.api = gridApiMock;
+		component.combobox.isDropdownOpened = false;
+		component.combobox.onEnterDoSelect(new KeyboardEvent('keydown', {}));
+		expect(getDisplayedRowAtIndexSpy).not.toHaveBeenCalled();
+	});
+
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ChangeDetectorRef, Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, Renderer2, ViewChild } from '@angular/core';
 import { AutocompleteApiComboBox, KeyName } from './autocomplete-api-combobox.component';
 import { Observable, of } from 'rxjs';
 import { GridContextMenuCellRendererComponent } from '../../grid/contextmenu/grid-context-menu-cell-renderer.component';
@@ -55,7 +55,6 @@ export class SystelabAutocompleteComponent extends AutocompleteApiComboBox<TestD
 		values.push(new TestData('3', 'Description 3'));
 		values.push(new TestData('4', 'Description 4'));
 		this.totalItems = values.length;
-		console.log("AAAAAAAAAAAAAAAAAA")
 		return of(values);
 	}
 
@@ -212,41 +211,5 @@ describe('AutocompleteApiAutocomplete', () => {
 		component.combobox.inputElement.nativeElement.value = 'a'
 		component.combobox.onCellKeyDown(event);
 		expect(component.combobox.inputElement.nativeElement.value).toEqual('aa');
-	});
-
-	fit('should select first row and focus input on Enter key press', async () => {
-		component.combobox.isDisabled = false;
-		component.combobox.isDropdownOpened = false;
-		component.combobox.description = '3'
-		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown').and.callThrough();
-		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
-		component.combobox.onInputClicked(new MouseEvent(''));
-		expect(openDropDownSpy).toHaveBeenCalled();
-		expect(doSearchTextSpy).toHaveBeenCalledWith('3');
-
-		//component.combobox.onEnterDoSelect(new KeyboardEvent('keydown', {key: KeyName.enter}));
-		component.combobox.inputElement.nativeElement.value = '3'
-		component.combobox.inputElement.nativeElement.dispatchEvent(new KeyboardEvent('keydown', {key: KeyName.enter}));
-
-		fixture.detectChanges();
-		await fixture.whenStable();
-
-		expect(component.combobox.isDropdownOpened).toBeFalse();
-		expect(component.combobox.description).toEqual('Description 3');
-	});
-
-	xit('should select first row after enter key is pressed and close dropdown ', () => {
-		const keyEvent = new KeyboardEvent('keydown', {key: 'd'});
-		const event = {event: keyEvent}
-		component.combobox.inputElement.nativeElement.value = ''
-		component.combobox.onCellKeyDown(event);
-
-		const keyEnterEvent = new KeyboardEvent('keydown', {key: KeyName.enter});
-		const setSelectedMock = () => {};
-		const enterEvent = {event: keyEnterEvent, node: {setSelected: setSelectedMock}}
-		component.combobox.onEnterDoSelect(keyEnterEvent);
-		component.combobox.onCellKeyDown(enterEvent);
-
-		expect(component.combobox.description).toEqual('Description 1');
 	});
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -55,6 +55,7 @@ export class SystelabAutocompleteComponent extends AutocompleteApiComboBox<TestD
 		values.push(new TestData('3', 'Description 3'));
 		values.push(new TestData('4', 'Description 4'));
 		this.totalItems = values.length;
+		console.log("AAAAAAAAAAAAAAAAAA")
 		return of(values);
 	}
 
@@ -211,5 +212,41 @@ describe('AutocompleteApiAutocomplete', () => {
 		component.combobox.inputElement.nativeElement.value = 'a'
 		component.combobox.onCellKeyDown(event);
 		expect(component.combobox.inputElement.nativeElement.value).toEqual('aa');
+	});
+
+	fit('should select first row and focus input on Enter key press', async () => {
+		component.combobox.isDisabled = false;
+		component.combobox.isDropdownOpened = false;
+		component.combobox.description = '3'
+		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown').and.callThrough();
+		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
+		component.combobox.onInputClicked(new MouseEvent(''));
+		expect(openDropDownSpy).toHaveBeenCalled();
+		expect(doSearchTextSpy).toHaveBeenCalledWith('3');
+
+		//component.combobox.onEnterDoSelect(new KeyboardEvent('keydown', {key: KeyName.enter}));
+		component.combobox.inputElement.nativeElement.value = '3'
+		component.combobox.inputElement.nativeElement.dispatchEvent(new KeyboardEvent('keydown', {key: KeyName.enter}));
+
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		expect(component.combobox.isDropdownOpened).toBeFalse();
+		expect(component.combobox.description).toEqual('Description 3');
+	});
+
+	xit('should select first row after enter key is pressed and close dropdown ', () => {
+		const keyEvent = new KeyboardEvent('keydown', {key: 'd'});
+		const event = {event: keyEvent}
+		component.combobox.inputElement.nativeElement.value = ''
+		component.combobox.onCellKeyDown(event);
+
+		const keyEnterEvent = new KeyboardEvent('keydown', {key: KeyName.enter});
+		const setSelectedMock = () => {};
+		const enterEvent = {event: keyEnterEvent, node: {setSelected: setSelectedMock}}
+		component.combobox.onEnterDoSelect(keyEnterEvent);
+		component.combobox.onCellKeyDown(enterEvent);
+
+		expect(component.combobox.description).toEqual('Description 1');
 	});
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -1,10 +1,9 @@
-import { ChangeDetectorRef, Directive, ElementRef, Input, Renderer2, ViewChild } from '@angular/core';
-import { AgGridAngular, AgRendererComponent } from 'ag-grid-angular';
+import { ChangeDetectorRef, Directive, Input, Renderer2 } from '@angular/core';
+import { AgRendererComponent } from 'ag-grid-angular';
 import {IGetRowsParams } from 'ag-grid-community';
 import { AbstractApiComboBox } from '../abstract-api-combobox.component';
 import { AbstractComboBox } from '../abstract-combobox.component';
 import { PreferencesService } from 'systelab-preferences';
-import { grid } from '@interactjs/snappers/all';
 
 declare const jQuery: any;
 
@@ -24,8 +23,6 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	public override startsWith = '';
 	@Input() public debounceTime: number = 350;
 	@Input() public withClearOption: boolean = false;
-
-	@ViewChild('grid', { read: ElementRef }) grid: ElementRef;
 
 	constructor(
 		public override myRenderer: Renderer2,

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -181,9 +181,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 
 	public onEnterDoSelect(event: KeyboardEvent) {
 		if (this.isDropdownOpened) {
-			//this.grid.nativeElement.getElementsByClassName('ag-row-first')[0].click();
 			this.gridOptions.api.getDisplayedRowAtIndex(0).selectThisNode(true);
-			this.inputElement.nativeElement.focus();
 		}
 	}
 

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -1,9 +1,10 @@
-import { ChangeDetectorRef, Directive, Input, Renderer2 } from '@angular/core';
-import { AgRendererComponent } from 'ag-grid-angular';
+import { ChangeDetectorRef, Directive, ElementRef, Input, Renderer2, ViewChild } from '@angular/core';
+import { AgGridAngular, AgRendererComponent } from 'ag-grid-angular';
 import {IGetRowsParams } from 'ag-grid-community';
 import { AbstractApiComboBox } from '../abstract-api-combobox.component';
 import { AbstractComboBox } from '../abstract-combobox.component';
 import { PreferencesService } from 'systelab-preferences';
+import { grid } from '@interactjs/snappers/all';
 
 declare const jQuery: any;
 
@@ -23,6 +24,8 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	public override startsWith = '';
 	@Input() public debounceTime: number = 350;
 	@Input() public withClearOption: boolean = false;
+
+	@ViewChild('grid', { read: ElementRef }) grid: ElementRef;
 
 	constructor(
 		public override myRenderer: Renderer2,
@@ -174,6 +177,14 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 	public clearText(event: MouseEvent): void {
 		this.input.nativeElement.value = '';
 		this.doSearch(event);
+	}
+
+	public onEnterDoSelect(event: KeyboardEvent) {
+		if (this.isDropdownOpened) {
+			//this.grid.nativeElement.getElementsByClassName('ag-row-first')[0].click();
+			this.gridOptions.api.getDisplayedRowAtIndex(0).selectThisNode(true);
+			this.inputElement.nativeElement.focus();
+		}
 	}
 
 }

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-combobox.component.html
@@ -16,6 +16,7 @@
                (keydown.Tab)="closeDropDown()"
                (keydown.arrowDown)="onInputNavigate($event)"
                (keydown.arrowUp)="onInputNavigate($event)"
+               (keydown.enter)="onEnterDoSelect($event)"
                 (click)="onInputClicked($event)"/>
         <button *ngIf="withClearOption && !inputIsEmpty()" type="button" #clearButton [hidden]="isDisabled"
                 class="slab-combo-button border-right-0 rounded-0 {{deleteIconClass}}" (click)="clearText($event)"

--- a/projects/systelab-components/src/lib/datepicker/date-transformer.service.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/date-transformer.service.spec.ts
@@ -26,6 +26,25 @@ describe('DataTransformerService Test', () => {
 				expected: new Date(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate() + 2)},
 	];
 
+	const checkMonthScenarios = [
+		{description: 'Month number -1', monthNumber: -1, expected: false},
+		{description: 'Month Number 5', monthNumber: 5, expected: true},
+		{description: 'Month Number 15', monthNumber: 15, expected: false},
+	];
+
+	const checkDayScenarios = [
+		{description: 'Day Number -1', yearInDate: 2024, monthInDate: 6, dayNumber: -1, expected: false},
+		{description: 'Day Number 21', yearInDate: 2024, monthInDate: 6, dayNumber: 21, expected: true},
+		{description: 'Day Number 35', yearInDate: 2024, monthInDate: 6, dayNumber: 35, expected: false},
+	];
+
+	const getSeparatorScenarios = [
+		{description: 'Format Date yy/mm', dateFormat: 'yy/mm', expected: '/'},
+		{description: 'Format Date yy-mm', dateFormat: 'yy-mm', expected: '-'},
+		{description: 'Format Date yy.mm', dateFormat: 'yy.mm', expected: '.'},
+		{description: 'Format Date yy', dateFormat: 'yy', expected: undefined},
+	];
+
  	const isSameDate = (date1: Date, date2: Date): boolean => {
 		if (date1.getDate() !== date2.getDate()) {
 			return false;
@@ -63,5 +82,26 @@ describe('DataTransformerService Test', () => {
 			expect(isSameDate(transformedDate, parameter.expected)).toBeTrue();
 		});
 	});
+
+	checkMonthScenarios.forEach(scenario => {
+		it(scenario.description, () => {
+			const result = dataTransformerService['checkMonthNumber'](scenario.monthNumber);
+			expect(result).toEqual(scenario.expected);
+		});
+	})
+
+	checkDayScenarios.forEach(scenario => {
+		it(scenario.description, () => {
+			const result = dataTransformerService['checkDayNumber'](scenario.yearInDate, scenario.monthInDate, scenario.dayNumber);
+			expect(result).toEqual(scenario.expected);
+		});
+	})
+
+	getSeparatorScenarios.forEach(scenario => {
+		it(scenario.description, () => {
+			const result = dataTransformerService['getDateSeparator'](scenario.dateFormat);
+			expect(result).toEqual(scenario.expected);
+		});
+	})
 
 });


### PR DESCRIPTION
# PR Details

Added on enter event to be able to select when focused on input after typing

## Description

Added on enter event

## Related Issue

#870 

## Motivation and Context

It gives the user more usability

## How Has This Been Tested

manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
