### PR TITLE
878 let user navigate with arrows after using clear button

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.16",
+  "version": "17.1.17",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -166,7 +166,7 @@ describe('AutocompleteApiAutocomplete', () => {
 		expect(closeDropDownSpy).toHaveBeenCalled();
 	});
 
-	fit('should clear input text and do search to reset result table', () => {
+	it('should clear input text and do search to reset result table', () => {
 		const event = new MouseEvent('click');
 		component.combobox.filterInput = {
 			nativeElement: jasmine.createSpyObj('nativeElement', ['focus'])
@@ -190,7 +190,7 @@ describe('AutocompleteApiAutocomplete', () => {
 		expect(component.combobox.currentSelected).toBe(undefined);
 	});
 
-	fit('should open dropdown and search text on input click when it is not disabled and not already opened', () => {
+	it('should open dropdown and search text on input click when it is not disabled and not already opened', () => {
 		component.combobox.isDisabled = false;
 		component.combobox.isDropdownOpened = false;
 		component.combobox.description = 'description test';

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -169,7 +169,7 @@ describe('AutocompleteApiAutocomplete', () => {
 
 	it('should clear input text and do search to reset result table', () => {
 		const event = new MouseEvent('click');
-		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText').and.callThrough();
+		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
 		component.combobox.clearText(event);
 		expect(component.combobox.input.nativeElement.value).toBe('');
 		expect(doSearchTextSpy).toHaveBeenCalled();
@@ -192,7 +192,7 @@ describe('AutocompleteApiAutocomplete', () => {
 		component.combobox.isDisabled = false;
 		component.combobox.isDropdownOpened = false;
 		component.combobox.description = 'description test'
-		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown').and.callThrough();
+		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown');
 		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
 		component.combobox.onInputClicked(new MouseEvent(''));
 		expect(openDropDownSpy).toHaveBeenCalled();

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -15,7 +15,6 @@ import { SystelabTranslateModule } from 'systelab-translate';
 import { SystelabPreferencesModule } from 'systelab-preferences';
 import { AgGridModule } from 'ag-grid-angular';
 import { GridApi, RowNode } from 'ag-grid-community';
-import { roundToNearestMinutesWithOptions } from 'date-fns/fp';
 
 export class TestData {
 	constructor(public id: string | number, public description: string) {
@@ -240,6 +239,15 @@ describe('AutocompleteApiAutocomplete', () => {
 		component.combobox.isDropdownOpened = false;
 		component.combobox.onEnterDoSelect(new KeyboardEvent('keydown', {}));
 		expect(getDisplayedRowAtIndexSpy).not.toHaveBeenCalled();
+	});
+
+	it('should open dropdown and give inputFilter the focus', () => {
+		component.combobox.filterInput = {
+			nativeElement: jasmine.createSpyObj('nativeElement', ['focus'])
+		}
+		component.combobox['openDropDown']();
+		expect(component.combobox.isDropdownOpened).toBeTrue();
+		expect(component.combobox.filterInput.nativeElement.focus).toHaveBeenCalled();
 	});
 
 });

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.spec.ts
@@ -166,9 +166,12 @@ describe('AutocompleteApiAutocomplete', () => {
 		expect(closeDropDownSpy).toHaveBeenCalled();
 	});
 
-	it('should clear input text and do search to reset result table', () => {
+	fit('should clear input text and do search to reset result table', () => {
 		const event = new MouseEvent('click');
-		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
+		component.combobox.filterInput = {
+			nativeElement: jasmine.createSpyObj('nativeElement', ['focus'])
+		}
+		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText').and.callThrough();
 		component.combobox.clearText(event);
 		expect(component.combobox.input.nativeElement.value).toBe('');
 		expect(doSearchTextSpy).toHaveBeenCalled();
@@ -187,11 +190,14 @@ describe('AutocompleteApiAutocomplete', () => {
 		expect(component.combobox.currentSelected).toBe(undefined);
 	});
 
-	it('should open dropdown and search text on input click when it is not disabled and not already opened', () => {
+	fit('should open dropdown and search text on input click when it is not disabled and not already opened', () => {
 		component.combobox.isDisabled = false;
 		component.combobox.isDropdownOpened = false;
-		component.combobox.description = 'description test'
-		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown');
+		component.combobox.description = 'description test';
+		component.combobox.filterInput = {
+			nativeElement: jasmine.createSpyObj('nativeElement', ['focus'])
+		}
+		const openDropDownSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'openDropDown').and.callThrough();
 		const doSearchTextSpy = spyOn<any>(AutocompleteApiComboBox.prototype, 'doSearchText');
 		component.combobox.onInputClicked(new MouseEvent(''));
 		expect(openDropDownSpy).toHaveBeenCalled();

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -165,6 +165,7 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 		jQuery('#' + this.comboId)
 			.dropdown('toggle');
 		this.isDropdownOpened = true;
+		this.filterInput.nativeElement.focus();
 	}
 
 	public inputIsEmpty(): boolean {


### PR DESCRIPTION
# PR Details

Enable arrow navigation after clearing text

## Description

Solution came up by focusing on input filter after opening dropdown (clicking arrow)

## Related Issue

#878 

## Motivation and Context

It allows user to continue navigating with arrows right after clearing with clear button

## How Has This Been Tested

tested here: autocomplete-api-combobox.component.spec.ts
and showcase example available

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
