### PR TITLE
900 chip add button disable style

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.19",
+  "version": "17.1.20",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/modern/_chip-button.scss
+++ b/projects/systelab-components/sass/modern/_chip-button.scss
@@ -83,5 +83,9 @@ systelab-chip-button {
     margin-top: 1px;
     padding-top: 0;
     width: 26px;
+
+    &:disabled {
+      opacity: 0.45;
+    }
   }
 }


### PR DESCRIPTION
# PR Details

added style for add button on chip-button component

## Description

added disable style for add button on chip-button component to show it with less opacity

## Related Issue

#900 

## Motivation and Context

It shows the add button as disabled when it is in that status

## How Has This Been Tested

manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
