### PR TITLE
fix dropdown width when is tree combobox is reopened

### DIFF
--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -645,11 +645,11 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		if (this.gridOptions.api && this.columnDefs) {
 			if (this.windowResized) {
 				setTimeout(() => {
-					this.doAutoSizeManagement();
+					AutosizeGridHelper.sizeColumnsToFit(this.gridOptions);
 					this.windowResized = false;
 				}, 5);
 			} else {
-				this.doAutoSizeManagement();
+				AutosizeGridHelper.sizeColumnsToFit(this.gridOptions);
 			}
 		}
 	}


### PR DESCRIPTION
# PR Details

Call the method to resize columns without event.

## Description

Previously We call the doAutoSizeManagement() method but this method can't do autosize correctly and put the column width with min-width value and due this the content of column is not rendered correctly.

## Related Issue

[#911 ](url)

## Motivation and Context

In tree combobox We need to set width for display his content.

## How Has This Been Tested

Unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
