### PR TITLE
Bugfix 918 the tree type dropdown is not displayed the second time it is clicked

### DIFF
--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -647,11 +647,11 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		if (this.gridOptions.api && this.columnDefs) {
 			if (this.windowResized) {
 				setTimeout(() => {
-					AutosizeGridHelper.sizeColumnsToFit(this.gridOptions);
+					this.doAutoSizeManagement();
 					this.windowResized = false;
 				}, 5);
 			} else {
-				AutosizeGridHelper.sizeColumnsToFit(this.gridOptions);
+				this.doAutoSizeManagement();
 			}
 		}
 	}

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -12,6 +12,7 @@ declare var jQuery: any;
 export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit, OnDestroy {
 
 	public static ROW_HEIGHT = -1;
+	public static DROPDOWN_MENU_MARGIN = 16;
 
 	@ViewChild('input', {static: false}) public input: ElementRef;
 	@ViewChild('filterInput', {static: false}) public filterInput: ElementRef;
@@ -547,16 +548,17 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		this.myRenderer.setStyle(this.dropdownMenuElement.nativeElement, 'position', 'fixed');
 		const dropdownParentRect: any = this.inputElement.nativeElement.getBoundingClientRect();
 		this.top = dropdownParentRect.top;
+		this.left = dropdownParentRect.left;
 
 		// Trick for positioning in IE11
 		if (!!(<any>window).MSInputMethodContext && !!(<any>window).document.documentMode) {
 			this.top = dropdownParentRect.top + this.inputElement.nativeElement.offsetHeight;
 		}
 
-		this.left = dropdownParentRect.left;
 		if (this.top + this.dropdownElement.nativeElement.offsetHeight > window.innerHeight) {
-			this.top = this.top - this.dropdownElement.nativeElement.offsetHeight - this.inputElement.nativeElement.offsetHeight - 2;
+			this.top = this.top - this.dropdownElement.nativeElement.offsetHeight - this.inputElement.nativeElement.offsetHeight - AbstractComboBox.DROPDOWN_MENU_MARGIN;
 		}
+
 		this.myRenderer.setStyle(this.dropdownElement.nativeElement, 'top', this.top + 'px');
 		this.myRenderer.setStyle(this.dropdownElement.nativeElement, 'left', this.left + 'px');
 	}

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -645,11 +645,11 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		if (this.gridOptions.api && this.columnDefs) {
 			if (this.windowResized) {
 				setTimeout(() => {
-					this.doAutoSizeManagement();
+					AutosizeGridHelper.sizeColumnsToFit(this.gridOptions);
 					this.windowResized = false;
 				}, 5);
 			} else {
-				this.doAutoSizeManagement();
+				AutosizeGridHelper.sizeColumnsToFit(this.gridOptions);
 			}
 		}
 	}

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -318,7 +318,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 			if (item[this.getIdField()] != null) {
 				return item[this.getIdField()];
 			}
-			return item.data[this.getIdField()] ?? '';
+			return this.getIdField() === '' ? '' : item.data[this.getIdField()] ?? '';
 		}
 		return '';
 	}

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
@@ -33,6 +33,7 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 	}
 
 	public override ngOnInit(): void {
+
 		this.setRowHeight();
 		this.configGrid();
 		this.initializeFavouriteList();
@@ -118,9 +119,9 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 			}
 
 			if (this.totalItemsLoaded) {
-				this.transferFocusToGrid();
 				this.setDropdownHeight();
 				this.setDropdownPosition();
+				this.transferFocusToGrid();
 				result = false;
 			}
 		}


### PR DESCRIPTION
# PR Details

Fix for the bug that prevented the combobox from opening.

## Description

This bug occurred because when rendering the content of the dropdown, it was positioned on the screen in such a way that the browser had to scroll to render it. The issue was that the scroll event triggers closeDropdown to ensure that if the user scrolls while a dropdown is open, it gets closed. In the case of this bug, this caused the dropdown content to immediately close, giving the impression that the dropdown was not opening, when in fact it was opening but closing immediately.

## Related Issue

[918](https://github.com/systelab/systelab-components/issues/918)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

This PR fix a bug with abstract-api-tree component and fix the another combobox positioning bug.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
