### PR TITLE
922 single click edit for checkbox cells in grids

### DIFF
--- a/projects/showcase/src/app/components/grid/showcase-grid.util.ts
+++ b/projects/showcase/src/app/components/grid/showcase-grid.util.ts
@@ -71,6 +71,7 @@ export class ShowcaseGridUtil {
 				width:               200,
 				cellRenderer:        CheckboxCellRendererComponent,
 				cellEditorFramework: CheckboxCellEditorComponent,
+				singleClickEdit:     true,
 				onCellValueChanged:  e => console.log('checkbox', e),
 				editable:            true,
 				elementID:           'checkboxID',

--- a/projects/showcase/src/app/components/grid/showcase-grid.util.ts
+++ b/projects/showcase/src/app/components/grid/showcase-grid.util.ts
@@ -71,7 +71,7 @@ export class ShowcaseGridUtil {
 				width:               200,
 				cellRenderer:        CheckboxCellRendererComponent,
 				cellEditorFramework: CheckboxCellEditorComponent,
-				singleClickEdit:     true,
+				cellEditorParams: { singleClickEdit: true},
 				onCellValueChanged:  e => console.log('checkbox', e),
 				editable:            true,
 				elementID:           'checkboxID',

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.24",
+  "version": "17.2.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.1.23",
+  "version": "17.1.24",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/README.md
+++ b/projects/systelab-components/src/lib/grid/README.md
@@ -103,6 +103,23 @@ To use the checkbox we need to send a parameter that has to be searched in the d
 }
 ```
 
+To use the checkbox with a single click we have the parameter singleClickEdit true as default. Inform with false to use the old behaviour of two clicks to open editor and change the value.
+```
+{
+    colId:                 'checkbox',
+    headerName:            'Cell with Checkbox',
+    field:                 'checkboxValue',
+    width:                 200,
+    cellRendererFramework: CheckboxCellRendererComponent,
+    cellEditorFramework:   CheckboxCellEditorComponent,
+    cellEditorParams: { singleClickEdit: true},
+    onCellValueChanged:    e => console.log('checkbox', e),
+    editable:              true,
+    elementID: 		       'checkboxID',
+    resizable:             false
+}
+```
+
 Spinner
 ```
 {

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { CheckboxCellEditorComponent } from './checkbox-cell-editor.component';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+describe('CheckboxCellEditorComponent', () => {
+	let fixture: ComponentFixture<CheckboxCellEditorComponent>;
+	let component: CheckboxCellEditorComponent;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [CheckboxCellEditorComponent],
+			imports: [],
+			providers: [],
+			schemas: [NO_ERRORS_SCHEMA]
+		})
+			.compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(CheckboxCellEditorComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	it('should toggle checkbox value if singleClickEdit is enabled', fakeAsync(() => {
+		const params = {
+			stopEditing: jasmine.createSpy('stopEditing'),
+			column: { colDef: { singleClickEdit: true } },
+			node: { data: {} },
+			value: true
+		};
+
+		component.agInit(params);
+		component.ngAfterViewInit();
+
+		tick();
+		expect(component.isCheckboxActive).toBe(false);
+		expect(params.stopEditing).toHaveBeenCalled();
+	}));
+
+	it('should not toggle checkbox value if singleClickEdit is enabled', fakeAsync(() => {
+		const params = {
+			stopEditing: jasmine.createSpy('stopEditing'),
+			column: { colDef: { singleClickEdit: false } },
+			node: { data: {} },
+			value: true
+		};
+
+		component.agInit(params);
+		component.ngAfterViewInit();
+
+		tick();
+		expect(component.isCheckboxActive).toBe(true);
+		expect(params.stopEditing).not.toHaveBeenCalled();
+	}));
+});

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.spec.ts
@@ -29,7 +29,8 @@ describe('CheckboxCellEditorComponent', () => {
 	it('should toggle checkbox value if singleClickEdit is enabled', fakeAsync(() => {
 		const params = {
 			stopEditing: jasmine.createSpy('stopEditing'),
-			column: { colDef: { singleClickEdit: true } },
+			column: { colDef: { elementID: 'id' } },
+			singleClickEdit: true,
 			node: { data: {} },
 			value: true
 		};
@@ -45,7 +46,8 @@ describe('CheckboxCellEditorComponent', () => {
 	it('should not toggle checkbox value if singleClickEdit is enabled', fakeAsync(() => {
 		const params = {
 			stopEditing: jasmine.createSpy('stopEditing'),
-			column: { colDef: { singleClickEdit: false } },
+			column: { colDef: { elementID: 'id' } },
+			singleClickEdit: false,
 			node: { data: {} },
 			value: true
 		};

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
@@ -1,15 +1,25 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
 import { AgEditorComponent } from 'ag-grid-angular';
 
 @Component({
 	selector:    'systelab-checkbox-cell',
 	templateUrl: 'checkbox-cell-editor.component.html'
 })
-export class CheckboxCellEditorComponent implements AgEditorComponent {
+export class CheckboxCellEditorComponent implements AgEditorComponent, AfterViewInit {
 	private params: any;
 
 	public isCheckboxActive: boolean;
 	public id: string;
+	private singleClickEdit = false;
+
+	public ngAfterViewInit() {
+		if (this.singleClickEdit) {
+			this.isCheckboxActive = !this.isCheckboxActive;
+			setTimeout(() => {
+				this.params.stopEditing();
+			}, 0);
+		}
+	}
 
 	public agInit(params: any): void {
 		this.params = params;
@@ -17,6 +27,7 @@ export class CheckboxCellEditorComponent implements AgEditorComponent {
 			this.id = this.params.node.data[this.params.column.colDef['elementID']];
 		}
 		this.isCheckboxActive = this.params.value;
+		this.singleClickEdit = this.params.column.colDef['singleClickEdit'];
 	}
 
 	public getValue(): any {

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
@@ -10,7 +10,7 @@ export class CheckboxCellEditorComponent implements AgEditorComponent, AfterView
 
 	public isCheckboxActive: boolean;
 	public id: string;
-	private singleClickEdit = false;
+	private singleClickEdit: boolean;
 
 	public ngAfterViewInit() {
 		if (this.singleClickEdit) {
@@ -27,7 +27,7 @@ export class CheckboxCellEditorComponent implements AgEditorComponent, AfterView
 			this.id = this.params.node.data[this.params.column.colDef['elementID']];
 		}
 		this.isCheckboxActive = this.params.value;
-		this.singleClickEdit = this.params.column.colDef['singleClickEdit'];
+		this.singleClickEdit = !this.params.hasOwnProperty('singleClickEdit') || this.params.singleClickEdit;
 	}
 
 	public getValue(): any {


### PR DESCRIPTION
# PR Details

single click edit for checkbox cells in grids

## Description

added the posibility to enable new single click edit mode for checkboxes inside grids, added example in showcase and added tests

## Related Issue

#922 

## Motivation and Context

it allows the user to toggle checkbox with a single click

## How Has This Been Tested

spec and manual test in showcase

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
