### PR TITLE
Bugfix/17.2.x/934 error in the console when select the shift combo with empty value on abstractcombobox

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.2.2",
+  "version": "17.2.3",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -318,7 +318,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 			if (item[this.getIdField()] != null) {
 				return item[this.getIdField()];
 			}
-			return this.getIdField() === '' ? '' : item.data[this.getIdField()] ?? '';
+			return item.data?.[this.getIdField()] ?? '';
 		}
 		return '';
 	}


### PR DESCRIPTION
# PR Details

Fix for solve error console when emptyValue is true.

## Description

<!--- Describe your changes in detail. Do not repeat the Issue description. -->
This bug has been fixed by checking that the item data already exists, since it caused an error if it was empty.

## Related Issue
934

## Motivation and Context

## How Has This Been Tested

This PR fix an error console on AbstractComboBox.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
