### PR TITLE
bug-943-grid-checkbox-with-tab

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.3.1",
+  "version": "17.3.2",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -96,6 +96,7 @@ export class SystelabGridComponent extends AbstractApiGrid<TestData> implements 
 			  `
 })
 export class GridTestComponent {
+	@ViewChild('grid') public grid: SystelabGridComponent;
 
 	public selectedOptionID = '';
 	public selectedTestData: TestData;
@@ -417,4 +418,16 @@ describe('Systelab Grid', () => {
 
 		expect(getNumberOfRowsSelected(fixture)).toEqual(1);
 	});
+
+	it('should startCellEditorWithTab be false when the start edition without tab key', ()=> {
+		fixture.componentInstance.grid['onCellEditingStarted']({event: null});
+
+		expect(fixture.componentInstance.grid.startCellEditorWithTab).toBeFalse();
+	})
+
+	it('should startCellEditorWithTab be true when the start edition with tab key', ()=> {
+		fixture.componentInstance.grid['onCellEditingStarted']({event: { key: 'Tab'}});
+
+		expect(fixture.componentInstance.grid.startCellEditorWithTab).toBeTrue();
+	})
 });

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -109,7 +109,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 		return options;
 	}
 
-	onCellEditingStarted(event: any): void {
+	protected onCellEditingStarted(event: any): void {
 		this.startCellEditorWithTab = event.event?.key === 'Tab';
 	}
 

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -26,6 +26,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	public gridOptions: GridOptions;
 	public overlayNoRowsTemplate;
 	public overlayLoadingTemplate;
+	public startCellEditorWithTab = false;
 
 	@Input() public headerMenu: Array<GridContextMenuOption<Object>>;
 	@Input() public menu: Array<GridContextMenuOption<T>>;
@@ -103,8 +104,13 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 		options.isFullWidthRow = (isFullWidthRowParams: IsFullWidthRowParams) => this.getIsFullWidthRow(isFullWidthRowParams);
 		options.fullWidthCellRenderer = this.getFullWidthCellRenderer();
 		options.context = {componentParent: this};
+		options.onCellEditingStarted = (event) => this.onCellEditingStarted(event);
 
 		return options;
+	}
+
+	onCellEditingStarted(event: any): void {
+		this.startCellEditorWithTab = event.event?.key === 'Tab';
 	}
 
 	public onModelUpdated(event: any) {

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.spec.ts
@@ -59,4 +59,26 @@ describe('CheckboxCellEditorComponent', () => {
 		expect(component.isCheckboxActive).toBe(true);
 		expect(params.stopEditing).not.toHaveBeenCalled();
 	}));
+
+	it('should not toggle checkbox value if navigation comes from Tab key', fakeAsync(() => {
+		const params = {
+			stopEditing: jasmine.createSpy('stopEditing'),
+			column: { colDef: { elementID: 'id' } },
+			singleClickEdit: true,
+			node: { data: {} },
+			value: true,
+			context: {
+				componentParent: {
+					startCellEditorWithTab: true
+				}
+			}
+		};
+
+		component.agInit(params);
+		component.ngAfterViewInit();
+
+		tick();
+		expect(component.isCheckboxActive).toBe(true);
+		expect(params.stopEditing).not.toHaveBeenCalled();
+	}));
 });

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
@@ -14,7 +14,7 @@ export class CheckboxCellEditorComponent implements AgEditorComponent, AfterView
 
 	public ngAfterViewInit() {
 			setTimeout(() => {
-				if (this.singleClickEdit && !this.params.context.componentParent.startCellEditorWithTab) {
+				if (this.singleClickEdit && !this.params.context?.componentParent.startCellEditorWithTab) {
 					this.isCheckboxActive = !this.isCheckboxActive;
 					this.params.stopEditing();
 				}

--- a/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
+++ b/projects/systelab-components/src/lib/grid/custom-cells/checkbox/checkbox-cell-editor.component.ts
@@ -13,12 +13,12 @@ export class CheckboxCellEditorComponent implements AgEditorComponent, AfterView
 	private singleClickEdit: boolean;
 
 	public ngAfterViewInit() {
-		if (this.singleClickEdit) {
-			this.isCheckboxActive = !this.isCheckboxActive;
 			setTimeout(() => {
-				this.params.stopEditing();
+				if (this.singleClickEdit && !this.params.context.componentParent.startCellEditorWithTab) {
+					this.isCheckboxActive = !this.isCheckboxActive;
+					this.params.stopEditing();
+				}
 			}, 0);
-		}
 	}
 
 	public agInit(params: any): void {


### PR DESCRIPTION
# PR Details

Preventing toggle checkbox in grids when the navigation is with TAB key

## Related Issue

https://github.com/systelab/systelab-components/issues/943

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
