### PR TITLE
17.3.x feature

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.3.3",
+  "version": "17.3.4",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/searcher/abstract-generic-searcher.component.html
+++ b/projects/systelab-components/src/lib/searcher/abstract-generic-searcher.component.html
@@ -2,8 +2,8 @@
     <div class="slab-flex-1">
         <ng-content/>
     </div>
-    <div class="input-group-append ml-1">
-        <button class="btn btn-sm py-0" type="button" [disabled]="isDisabled"
+    <div class="input-group-append ml-1 d-flex justify-content-center align-items-center">
+        <button class="btn btn-sm py-0 btn-outline-primary rounded-circle h-90" type="button" [disabled]="isDisabled"
                 (click)="openSearchDialog()"><i class="icon-search"></i></button>
     </div>
 </div>

--- a/projects/systelab-components/src/lib/searcher/searcher.dialog.component.html
+++ b/projects/systelab-components/src/lib/searcher/searcher.dialog.component.html
@@ -8,13 +8,15 @@
         <div class="d-flex slab-flex-1 border rounded">
             <div class="d-flex border-right pb-1">
                 <div class="slab-first-option ml-3 mr-2">
-                    <input name="status-searchby1" type="radio" id="status-searchby-starts" [(ngModel)]="searchByContains" [value]="false"
-                    (ngModelChange)="setFocusToInput()">
+                    <input name="status-searchby1" type="radio" id="status-searchby-starts"
+                           [(ngModel)]="searchByContains" [value]="false"
+                           (ngModelChange)="setFocusToInput()">
                     <label for="status-searchby-starts">{{ 'COMMON_STARTS_WITH' | translate | async}}</label>
                 </div>
                 <div class="slab-second-option ml-2 mr-3">
-                    <input name="status-searchby2" type="radio" id="status-searchby-contains" [(ngModel)]="searchByContains" [value]="true"
-                       (ngModelChange)="setFocusToInput()">
+                    <input name="status-searchby2" type="radio" id="status-searchby-contains"
+                           [(ngModel)]="searchByContains" [value]="true"
+                           (ngModelChange)="setFocusToInput()">
                     <label for="status-searchby-contains">{{ 'COMMON_CONTAINS' | translate | async}}</label>
                 </div>
             </div>

--- a/projects/systelab-components/src/lib/searcher/searcher.dialog.component.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.dialog.component.ts
@@ -46,6 +46,7 @@ export class SearcherDialog<T> implements ModalComponent<SearcherDialogParameter
 	}
 
 	public setFocusToInput(): void {
+		this.refreshSearch();
 		setTimeout(() => this.valueToSearchInput?.nativeElement.focus(), 100);
 	}
 

--- a/projects/systelab-components/src/lib/searcher/searcher.dialog.component.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.dialog.component.ts
@@ -26,6 +26,7 @@ export class SearcherDialog<T> implements ModalComponent<SearcherDialogParameter
 	constructor(public dialog: DialogRef<SearcherDialogParameters<T>>, protected i18nService: I18nService) {
 		this.parameters = dialog.context;
 		this.searchingValue = this.parameters.valueToSearch;
+		this.searchByContains = !this.parameters.searchByStartWithAsDefault;
 
 		this.showClose = this.parameters.showCloseButton;
 		if (!this.parameters.showCloseButton) {

--- a/projects/systelab-components/src/lib/searcher/searcher.dialog.parameters.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.dialog.parameters.ts
@@ -8,4 +8,5 @@ export class SearcherDialogParameters<T> extends SystelabModalContext {
 	public showSelectedRowsInSubmitButton = false;
 	public isTeeSearcher: boolean = false;
 	public debounceTime: number = 0;
+	public searchByStartWithAsDefault: boolean = false;
 }


### PR DESCRIPTION
# PR Details

Generic Searcher has Search by contains as default but the parameter to set Search by starts with have added.

## Description

We have add the search by contains as default for searchers but also We have added a parameter to set Search by starts with as default if is neccessary..

## Related Issue
https://github.com/systelab/systelab-components/issues/938

## Motivation and Context
We need any component to be able to have a searcher.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
