### PR TITLE
New APP_CONFIG flag to configure dialog behaviour for default

### DIFF
--- a/projects/showcase/src/app/showcase.module.ts
+++ b/projects/showcase/src/app/showcase.module.ts
@@ -115,6 +115,7 @@ import {
 } from './components/progress-bars/progressbar-with-text-dialog/showcase-progressbar-with-text-dialog.component';
 import { ShowcaseImageViewerComponent } from './components/image-viewer/showcase-image-viewer.component';
 import { CdkTreeModule } from '@angular/cdk/tree';
+import { environment } from '../environments/environment';
 
 @NgModule({ declarations: [
         ShowcaseComponent,

--- a/projects/systelab-components/src/lib/modal/header/dialog-header.component.ts
+++ b/projects/systelab-components/src/lib/modal/header/dialog-header.component.ts
@@ -1,4 +1,6 @@
-import { AfterViewInit, Component,  EventEmitter, Input, Output } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Inject, Input, Optional, Output } from '@angular/core';
+import { APP_CONFIG, AppConfig } from '../../systelab-components.module.config';
+import { DEFAULT_SYSTELAB_DIALOG_CONFIG } from '../systelab-dialog-config';
 
 @Component({
 	selector:    'systelab-dialog-header',
@@ -35,7 +37,9 @@ export class DialogHeaderComponent implements AfterViewInit {
 	private on: number;
 	private here: number;
 
-	constructor() {
+	constructor(@Optional() @Inject(APP_CONFIG) private config: AppConfig) {
+		this.withDrag = config?.dialogConfig?.dialogsDraggableByDefault !== undefined ?
+			config.dialogConfig.dialogsDraggableByDefault : DEFAULT_SYSTELAB_DIALOG_CONFIG.dialogsDraggableByDefault;
 	}
 
 	public ngAfterViewInit() {

--- a/projects/systelab-components/src/lib/modal/systelab-dialog-config.ts
+++ b/projects/systelab-components/src/lib/modal/systelab-dialog-config.ts
@@ -1,0 +1,7 @@
+export interface SystelabDialogConfig {
+	dialogsDraggableByDefault?: boolean;
+}
+
+export const DEFAULT_SYSTELAB_DIALOG_CONFIG: SystelabDialogConfig = {
+	dialogsDraggableByDefault: true
+};

--- a/projects/systelab-components/src/lib/systelab-components.module.config.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.config.ts
@@ -1,9 +1,11 @@
 import { InjectionToken } from '@angular/core';
 import { ToastConfig } from './toast/toast-config';
+import { SystelabDialogConfig } from './modal/systelab-dialog-config';
 
 export const APP_CONFIG = new InjectionToken<AppConfig>('APP_CONFIG_PARAMS');
 
 export interface AppConfig{
     productionMode: boolean;
     toast?: ToastConfig;
+    dialogConfig?: SystelabDialogConfig;
 }


### PR DESCRIPTION
# PR Details

A new configuration object for the default behavior of dialogs is added, along with a new flag to determine whether dialogs are draggable by default or not.

## Description

In some projects, we don’t want dialogs to be draggable by default, and it’s costly to update every systelab-header instance to set the withDrag flag to false, especially since this flag is true by default. To maintain backward compatibility for any project that expects dialogs to be draggable by default, we’ve added a new configuration object to APP_CONFIG, similar to the ToastConfig, to define a default behavior for dialogs. This object includes the dialogsDraggableByDefault flag, which determines whether dialogs are draggable by default or not.

This behavior of allowing dialogs to be draggable by default causes a bug where, in full-size dialogs, the header can be dragged independently.

## Related Issue

https://github.com/systelab/systelab-components/issues/953

## Motivation and Context

This behavior of allowing dialogs to be draggable by default causes a bug where, in full-size dialogs, the header can be dragged independently.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
