### PR TITLE
Bugfix 951

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "17.4.0",
+  "version": "17.4.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/accordion/accordion.component.scss
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.scss
@@ -3,7 +3,7 @@
   border-radius: 4px 4px 0 0;
   height: 40px;
   i {
-    &:after {
+    &::after {
       content: '';
       background-color: white;
       width: 15px;
@@ -11,7 +11,7 @@
       z-index: 1;
       position: absolute;
     }
-    &:before {
+    &::before {
       z-index: 2;
     }
     font-size: 25px;

--- a/projects/systelab-components/src/lib/chips/chips.component.spec.ts
+++ b/projects/systelab-components/src/lib/chips/chips.component.spec.ts
@@ -162,4 +162,39 @@ describe('Systelab Chips', () => {
 
 		flush();
 	}));
+
+	it('should handle enter key press', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		// Simulate user input
+		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+		inputEl.value = 'TestValue';
+
+		// Create a KeyboardEvent
+		const event = new KeyboardEvent('keydown', { key: 'Enter' });
+
+		// Manually assign the target property
+		Object.defineProperty(event, 'target', { value: inputEl, writable: true });
+
+		// Explicitly call the onKeyEnter method
+		chips.onKeyEnter(event);
+		fixture.detectChanges();
+
+		// Verify that the value was added to the filter
+		expect(chips.filter).toContain('TestValue');
+
+		// Verify that the input was cleared
+		expect(inputEl.value).toEqual('');
+
+		// Verify that the filtered event was emitted
+		const emitSpy = spyOn(chips.filtered, 'emit');
+		chips.onKeyEnter(event);
+		expect(emitSpy).toHaveBeenCalledWith(chips.filter);
+
+		// Verify that the hide() method was called
+		const hideSpy = spyOn(chips.autoComplete, 'hide');
+		chips.onKeyEnter(event);
+		expect(hideSpy).toHaveBeenCalled();
+	}));
+
 });

--- a/projects/systelab-components/src/lib/chips/chips.component.ts
+++ b/projects/systelab-components/src/lib/chips/chips.component.ts
@@ -54,6 +54,7 @@ export class ChipsComponent {
 			input.value = '';
 		}
 		this.filtered.emit(this.filter);
+		this.autoComplete.hide();
 	}
 }
 


### PR DESCRIPTION
# PR Details

Autocomplete Component bugfix.

## Description

Added autocomplete hiding functionality to Chips Component when 'Enter' key is pressed.

## Related Issue

https://github.com/systelab/systelab-components/issues/951

## Motivation and Context

User Interaction Improvement. Return key should act the same as a click selection.

## How Has This Been Tested

Locally in showcase application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
