### PR TITLE
Bugfix 867 - Layout fixes in component action buttons

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
+++ b/projects/systelab-components/src/lib/image-viewer/image-viewer.component.html
@@ -3,8 +3,8 @@
 <div class="d-flex flex-column slab-flex-1" id="imageViewerHeader"
      [ngClass]="transparentBackgroundForButtons ? 'bg-color-transparent' : 'bg-color-primary'"
      data-test-id="imageViewerHeader">
-    <div class="d-flex">
-        <div class="ml-1">
+    <div class="d-flex align-items-center">
+        <div class="d-flex ml-1">
             @for (actionButton of actionButtons; track actionButton.label) {
                 <ng-container>
                     <systelab-toggle-button *ngIf="actionButton.type===actionButtonType.TOGGLE_BUTTON" class="mr-2"
@@ -38,7 +38,7 @@
             }
         </div>
         <div class="d-flex slab-flex-1" id="OverImageArea"></div>
-        <div class="ml-auto">
+        <div class="d-flex ml-auto">
             <a [href]="imageSrc" download="{{imageTitle}}">
                 <systelab-button *ngIf="showSaveButton" data-test-id="SaveBtn"
                              systelabTooltip="{{ 'COMMON_SAVE' | translate | async }}">
@@ -59,7 +59,6 @@
                          [min]="sliderZoomMin"
                          [max]="sliderZoomMax"
                          [step]="sliderZoomStep"></systelab-slider>
-
     </div>
     <div class="d-flex justify-content-end" *ngIf="showZoomScale">
         <div id="zoomScale" class="m-2" [style.width]="zoomScale.totalWidth+'px'">

--- a/projects/systelab-components/src/lib/signature-canvas/signature-canvas.component.html
+++ b/projects/systelab-components/src/lib/signature-canvas/signature-canvas.component.html
@@ -3,7 +3,7 @@
         {{ 'SIGN_TEXT_EXPLANATION' | translate | async }}
     </div>
     <canvas class="border rounded" #signature></canvas>
-    <div class="text-right mt-2" [style.width.px]="width" *ngIf="!verificationActive">
+    <div class="d-flex justify-content-end mt-2" [style.width.px]="width" *ngIf="!verificationActive">
         <systelab-button class="mr-1" (click)="cleanCanvas()">{{ 'SIGN_CLEAN' | translate | async }}</systelab-button>
         <a href="#" *ngIf="isDownloadable" class="btn btn-outline-primary mr-1" [attr.download]="downPath" [attr.href]="href" id="btn-download"
             (click)="downloadImage()">{{ 'SIGN_DOWNLOAD' | translate | async }}</a>


### PR DESCRIPTION
Added display flex in row aligned buttons to: 
- Image Viewer Component
- Signature Canvas Component

# PR Details

Bug fix for layout purposes in row buttons in Image Viewer Component. Added also layout fix in Signature Canvas Component.

## Description

Action buttons in mentioned components were not aligned in a flex layout. It is required so they can fit correctly in the layout.

## Related Issue

#867 

## Motivation and Context

Layout fixing purposes

## How Has This Been Tested

Locally within Showcase Project.
Locally in Quantalink Project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
