### PR TITLE
#966 modified slab buttons styles to equal bootstrap

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/modern/_button.scss
+++ b/projects/systelab-components/sass/modern/_button.scss
@@ -74,9 +74,9 @@ systelab-button {
     border-radius: 3em;
     cursor: pointer;
     display: inline-block;
-    line-height: 1;
+    line-height: 1.5;
     font-size: 1rem;
-    padding: 9px 12px;
+    padding: 0.375rem 0.75rem;
     border: none;
   }
 
@@ -87,15 +87,15 @@ systelab-button {
 
   .slab-btn-small {
     font-size: 0.875rem;
-    padding: 7px 11px;
+    padding: 0.35rem 0.65rem;
   }
   .slab-btn-medium {
     font-size: 1rem;
-    padding: 9px 12px;
+    padding: 0.375rem 0.75rem;
   }
   .slab-btn-large {
     font-size: 1.25rem;
-    padding: 14px 16px;
+    padding: 0.6rem 1rem;
   }
 
 


### PR DESCRIPTION
# PR Details

Modified slab-button styles to be aligned with systelab-toggle-buttons and normal buttons 

## Description

Systelab Toggle Buttons follow the .btn class which has its own properties:
padding: 0.375rem 0.75rem;
font-size: 1rem;
line-height: 1.5;
Systelab Buttons follow the .slab-btn class with the .slab-btn-medium as default.
They had different values for padding, font-size and line-height and it has been aligned.
Also the dimensions small and large have been modified accordingly following a logic relation.

## Related Issue

#966 

## Motivation and Context

This Issue was motivated when developing Image Viewer and noticing that consequent buttons were not aligned (being a group of systelab-toggle-buttons / systelab-buttons / buttons).

## How Has This Been Tested

Locally within Showcase Project.
Locally within Quantalink Project.
Checked HH and ML Projects to see if there were breaking changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
