### PR TITLE
[968] - added new parameter useIdInMultipleSelectionGrid to use id as…

### DIFF
--- a/projects/systelab-components/src/lib/searcher/README.md
+++ b/projects/systelab-components/src/lib/searcher/README.md
@@ -298,20 +298,21 @@ Once you have your component, you can use it in your templates.
 
 ## Properties
 
-| Name | Type | Default | Description |
-| ---- |:----:|:-------:| ----------- |
-| **id** | string | | Identifier of selected item |
-| **description** | string | | Description or name of selected item that will be shown in the label of the searcher |
-| **code** | string | | Short code of selected item that will be shown in the input of the searcher  |
-| **multipleSelectedItemList** | Array<T> | | Array with selected elements for searchers with multiple selection|
+| Name | Type | Default | Description                                                                               |
+| ---- |:----:|:-------:|-------------------------------------------------------------------------------------------|
+| **id** | string | | Identifier of selected item                                                               |
+| **description** | string | | Description or name of selected item that will be shown in the label of the searcher      |
+| **code** | string | | Short code of selected item that will be shown in the input of the searcher               |
+| **multipleSelectedItemList** | Array<T> | | Array with selected elements for searchers with multiple selection                        |
 | multipleSelection | boolean | false | Enable to select multiple elements. A checkbox will be rendered in front of each element. |
-| fontFamily | string | | Font Family |
-| fontSize | string | | Font size in pixels |
-| fontWeight | string | | normal, bold, bolder, lighter, number, initial or inherit |
-| fontStyle | string | | normal, italic, oblique, initial or inherit |
-| isDisabled | boolean | false | If true the combo is disabled|
-| withButton | boolean | true | Shows or not ? button|
-| height | number | | Height of the form component in px|
+| useIdInMultipleSelectionGrid | boolean | false | If true use as a unique identifier the id of the element instead of the code.             |
+| fontFamily | string | | Font Family                                                                               |
+| fontSize | string | | Font size in pixels                                                                       |
+| fontWeight | string | | normal, bold, bolder, lighter, number, initial or inherit                                 |
+| fontStyle | string | | normal, italic, oblique, initial or inherit                                               |
+| isDisabled | boolean | false | If true the combo is disabled                                                             |
+| withButton | boolean | true | Shows or not ? button                                                                     |
+| height | number | | Height of the form component in px                                                        |
 
 In black the Two-Way Data Binding properties.
 

--- a/projects/systelab-components/src/lib/searcher/abstract-searcher.ts
+++ b/projects/systelab-components/src/lib/searcher/abstract-searcher.ts
@@ -11,6 +11,7 @@ export abstract class AbstractSearcher<T> {
 	public multipleSelection: boolean = false;
 	public treeSearcher: boolean = false;
 	public parentSelectable: boolean = false;
+	public useIdInMultipleSelectionGrid = false
 
 	protected constructor() {
 

--- a/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
@@ -86,7 +86,7 @@ export class SearcherTableComponent<T> extends AbstractApiGrid<T> implements OnI
 				this.gridOptions.api.forEachNode(node => {
 					if (this.searcher.multipleSelectedItemList
 						.filter((selectedItem) => {
-							return (selectedItem && node.data && selectedItem[this.searcher.getCodeField()] === node.data[this.searcher.getCodeField()]);
+							return (selectedItem && node.data && selectedItem[this.getSelectionField()] === node.data[this.getSelectionField()]);
 						}).length > 0) {
 						node.selectThisNode(true);
 					}
@@ -102,19 +102,23 @@ export class SearcherTableComponent<T> extends AbstractApiGrid<T> implements OnI
 		}
 	}
 
+	private getSelectionField() {
+		return this.searcher.useIdInMultipleSelectionGrid ? this.searcher.getIdField() : this.searcher.getCodeField();
+	}
+
 	// overrides
 	public override onRowSelected(event: any): void {
 		if (this.multipleSelection) {
 			if (event.node && event.node.data && event.node.data[this.searcher.getIdField()] !== undefined) {
 				if (this.searcher.multipleSelectedItemList) {
 					const element = this.searcher.multipleSelectedItemList.find((item) => {
-						return item[this.searcher.getCodeField()] === event.node.data[this.searcher.getCodeField()];
+						return item[this.getSelectionField()] === event.node.data[this.getSelectionField()];
 					});
 					if (event.node.selected && !element) {
 						this.addElementToMultipleSelectedItemList(event.node.data);
 					} else if (!event.node.selected && element) {
 						this.searcher.multipleSelectedItemList = this.searcher.multipleSelectedItemList
-							.filter((item) => item[this.searcher.getCodeField()] !== element[this.searcher.getCodeField()]);
+							.filter((item) => item[this.getSelectionField()] !== element[this.getSelectionField()]);
 					}
 				} else {
 					this.addElementToMultipleSelectedItemList(event.node.data);


### PR DESCRIPTION
Systelab searcher multiple selection add new paramater to use id instead of code

# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Add an attribute to determine if the identifier of the element will be by id or by code.

## Description

<!--- Describe your changes in detail. Do not repeat the Issue description. -->
I have added an attribute to determine if the identifier of the element is the id or the code. By default it will be the code in order to not modify the current behaviour.

## Related Issue

https://github.com/systelab/systelab-components/issues/968

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In Modulab we have a search dialog of Services. If is multiple selection, as a service can have or not a code, if there are some services without code, when you select one of these services without code, the searcher do not know which one of theses services you selected, because the identifier is not unique. 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this change in the show case Combo Multiselect Searcher. I have added the new parameter in the constructor inner-searcher.ts this.useIdInMultipleSelectionGrid = true;

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the **CONTRIBUTING** document
- [ x] My code follows the code style of this project
- [ x] My change requires a change to the documentation 
- [ x] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ x] All new and existing tests passed
- [ x] A new branch needs to be created from master to evolve previous versions
- [ x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
