### PR TITLE
(fix)(#972) The scroll does not work in the searchers once an item ha…

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "18.0.3",
+  "version": "18.0.4",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
@@ -96,7 +96,6 @@ export class SearcherTableComponent<T> extends AbstractApiGrid<T> implements OnI
 			this.gridOptions.api.forEachNode(node => {
 				if (node.data && node.data[this.searcher.getIdField()] === this.searcher.id) {
 					node.selectThisNode(true);
-					this.gridOptions.api.ensureNodeVisible(node);
 				}
 			});
 		}


### PR DESCRIPTION
# PR Details

Remove ensureIndex method in onModelChange event.

## Description

I remove the ensureIndexVisible method from the OnModelChange event because it causes the scroll to return to the selected element every time this event is triggered. This means that if we have the first element selected and scroll down, when changing pages and OnModelChange is triggered, the scroll automatically returns to the first element.

## Related Issue
https://github.com/systelab/systelab-components/issues/972

## Motivation and Context

avoid the issue 972

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
