### PR TITLE
[230] - Disable checkboxes to be selected/unselected when abstract-li…

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "18.0.4",
+  "version": "18.0.5",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
@@ -143,7 +143,8 @@ export abstract class AbstractListBox<T> implements OnInit {
 				suppressSizeToFit: true,
 				resizable:         false,
 				suppressMovable:   true,
-				pinned:            'left'
+				pinned:            'left',
+				cellStyle: this.isDisabled ? {'pointer-events': 'none'} : ''
 			});
 		}
 		this.addSuppressSizeToFitToColumnsWithWidthDefined(colDefs);


### PR DESCRIPTION
When an abstract-listbox has checkboxes (checkboxSelection=true) and is displayed as disabled (isDisabled=true), the checkboxes can be selected/unselected.

# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Control that if the listbox has a checkbox column and the grid is disabled, those checkboxes are not able to be select or unselect.

## Description

<!--- Describe your changes in detail. Do not repeat the Issue description. -->
I have added cellStyle: this.isDisabled ? {'pointer-events': 'none'} : '' in checkbox column if isDisabled=true.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/systelab/systelab-components/issues/230

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Could be very dangerous that if the list is disabled the user could select or unselect some rows and save this new state of the list.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this changes in systelab-gender-listbox in the showcase-listbox component and in a permission-listbox in modulab, adding [isDisabled]="true". Now the checkbox is not able to be selected or unselected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the **CONTRIBUTING** document
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
