### PR TITLE
Save the accordion state in to preferences

### DIFF
--- a/projects/systelab-components/src/lib/accordion/accordion.component.html
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.html
@@ -1,6 +1,12 @@
 <div class="slab-flex-1 d-flex flex-column">
-    <div class="accordion-header d-flex align-items-center font-weight-bold px-3" [ngStyle]="{'backgroundColor': headerColor}" (click)="isCollapsed = !isCollapsed">
-        <i class="d-flex justify-content-center align-items-center position-relative" [class.icon-chevron-circle-up]="!isCollapsed" [class.icon-chevron-circle-down]="isCollapsed" [ngClass]="{'text-primary': !iconColor}" [ngStyle]="{'color': iconColor}"></i>
+    <div class="accordion-header d-flex align-items-center font-weight-bold px-3" [ngStyle]="{'backgroundColor': headerColor}">
+        <button class="bg-transparent border-0" (click)="toggleAccordion()">
+            <i class="d-flex justify-content-center align-items-center position-relative"
+               [class.icon-chevron-circle-up]="!isCollapsed"
+               [class.icon-chevron-circle-down]="isCollapsed"
+               [ngClass]="{'text-primary': !iconColor}"
+               [ngStyle]="{'color': iconColor}"></i>
+        </button>
         <span class="d-block ml-3">{{ headerTitle }}</span>
     </div>
     <div class="collapsible-content d-flex" [class.collapsed]="isCollapsed"

--- a/projects/systelab-components/src/lib/accordion/accordion.component.ts
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.ts
@@ -27,4 +27,11 @@ export class Accordion implements OnInit {
 			this.preferenceService.put(this.preferenceName, this.isCollapsed);
 		}
 	}
+
+	public toggleAccordion() {
+		this.isCollapsed = !this.isCollapsed;
+		if (this.preferenceName) {
+			this.preferenceService.put(this.preferenceName, this.isCollapsed);
+		}
+	}
 }


### PR DESCRIPTION
# PR Details

When the user collapse or expand the accordion, if He has configured a preferenceName , should be save the state of the accordion to preferences.

## Description

- I have to replaced div for button in order to use the click event correctly.
- I have to create a method to save thre accordion state into preferences if the user has configure preference name.

## Related Issue
https://github.com/systelab/systelab-components/issues/1001

## Motivation and Context
The user must be able to save the state of the accordion in preferences.

## How Has This Been Tested

- With UnitTest
- Manual

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
