### PR TITLE
save the accordion state in to preferences

### DIFF
--- a/projects/systelab-components/src/lib/accordion/accordion.component.html
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.html
@@ -1,6 +1,12 @@
 <div class="slab-flex-1 d-flex flex-column">
-    <div class="accordion-header d-flex align-items-center font-weight-bold px-3" [ngStyle]="{'backgroundColor': headerColor}" (click)="isCollapsed = !isCollapsed">
-        <i class="d-flex justify-content-center align-items-center position-relative" [class.icon-chevron-circle-up]="!isCollapsed" [class.icon-chevron-circle-down]="isCollapsed" [ngClass]="{'text-primary': !iconColor}" [ngStyle]="{'color': iconColor}"></i>
+    <div class="accordion-header d-flex align-items-center font-weight-bold px-3" [ngStyle]="{'backgroundColor': headerColor}">
+        <button class="bg-transparent border-0" (click)="toggleAccordion()">
+            <i class="d-flex justify-content-center align-items-center position-relative"
+               [class.icon-chevron-circle-up]="!isCollapsed"
+               [class.icon-chevron-circle-down]="isCollapsed"
+               [ngClass]="{'text-primary': !iconColor}"
+               [ngStyle]="{'color': iconColor}"></i>
+        </button>
         <span class="d-block ml-3">{{ headerTitle }}</span>
     </div>
     <div class="collapsible-content d-flex" [class.collapsed]="isCollapsed"

--- a/projects/systelab-components/src/lib/accordion/accordion.component.spec.ts
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.spec.ts
@@ -48,24 +48,6 @@ describe('Systelab Accordion', () => {
 		expect(maxHeight).toEqual(component.contentMaxHeight);
 	});
 
-	it('should be collapsed if is expanded and clicks icon button', async () => {
-		component.isCollapsed = false;
-		const collapseExpandIcon = fixture.debugElement.query(By.css('.accordion-header'));
-		collapseExpandIcon.triggerEventHandler('click', null);
-		fixture.detectChanges();
-		await fixture.whenStable();
-		expect(component.isCollapsed).toBeTrue();
-	});
-
-	it('should be expanded if is collapsed and clicks icon button', async () => {
-		component.isCollapsed = true;
-		const collapseExpandIcon = fixture.debugElement.query(By.css('.accordion-header'));
-		collapseExpandIcon.triggerEventHandler('click', null);
-		fixture.detectChanges();
-		await fixture.whenStable();
-		expect(component.isCollapsed).toBeFalse();
-	});
-
 	it('should be get isCollapsed value from preferences id flag preferenceName exists', async () => {
 		const valueReturned: boolean = true;
 		const initialPreferenceName = 'testName';
@@ -79,5 +61,47 @@ describe('Systelab Accordion', () => {
 		expect(preferenceServiceGetSpy).toHaveBeenCalledWith(component.preferenceName, false);
 		expect(component.isCollapsed).toEqual(valueReturned);
 		expect(preferenceServicePutSpy).toHaveBeenCalledWith(component.preferenceName, valueReturned);
+	});
+
+	it('should to be collapsed if preferenceName is not defined', async () => {
+		component.isCollapsed = false;
+		component.preferenceName = undefined;
+		const preferenceServiceGetSpy = spyOn<any>(component['preferenceService'], 'get').and.callThrough();
+		const preferenceServicePutSpy = spyOn<any>(component['preferenceService'], 'put').and.callThrough();
+		component.ngOnInit();
+		await fixture.whenStable();
+		expect(component.isCollapsed).toBeFalse();
+		expect(preferenceServiceGetSpy).not.toHaveBeenCalled();
+		expect(preferenceServicePutSpy).not.toHaveBeenCalled();
+	});
+	it('should to call put method of preferences service when toggleAccordion is called', async () => {
+		const initialPreferenceName = 'testName';
+		component.preferenceName = initialPreferenceName;
+		component.ngOnInit();
+		await fixture.whenStable();
+		const preferenceServicePutSpy = spyOn<any>(component['preferenceService'], 'put').and.callThrough();
+		component.toggleAccordion();
+		await fixture.whenStable();
+		expect(preferenceServicePutSpy).toHaveBeenCalledWith(`${initialPreferenceName}.${component['preferenceSuffix']}`, component.isCollapsed);
+	});
+	it('should to collapse or uncollapse the accordion when click collapse button', async () => {
+		const initialPreferenceName = 'testName';
+		const isCollapsed = false;
+		component.isCollapsed = isCollapsed;
+		component.preferenceName = initialPreferenceName;
+		component.ngOnInit();
+		await fixture.whenStable();
+		const preferenceServicePutSpy = spyOn<any>(component['preferenceService'], 'put').and.callThrough();
+		component.toggleAccordion();
+		await fixture.whenStable();
+		expect(component.isCollapsed).toBe(!isCollapsed);
+	});
+	it('should to call toggleAccordion method when clicks icon button', async () => {
+		const collapseExpandButton = fixture.debugElement.query(By.css('.accordion-header button'));
+		const toggleAccordionSpy = spyOn(component, 'toggleAccordion').and.callThrough();
+		collapseExpandButton.triggerEventHandler('click', null);
+		fixture.detectChanges();
+		await fixture.whenStable();
+		expect(toggleAccordionSpy).toHaveBeenCalled();
 	});
 });

--- a/projects/systelab-components/src/lib/accordion/accordion.component.ts
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.ts
@@ -27,4 +27,11 @@ export class Accordion implements OnInit {
 			this.preferenceService.put(this.preferenceName, this.isCollapsed);
 		}
 	}
+
+	public toggleAccordion() {
+		this.isCollapsed = !this.isCollapsed;
+		if (this.preferenceName) {
+			this.preferenceService.put(this.preferenceName, this.isCollapsed);
+		}
+	}
 }


### PR DESCRIPTION
# PR Details

When the user collapse or expand the accordion, if He has configured a preferenceName , should be save the state of the accordion to preferences.

## Description

- I have to replaced div for button in order to use the click event correctly.
- I have to create a method to save thre accordion state into preferences if the user has configure preference name.

## Related Issue
https://github.com/systelab/systelab-components/issues/1001

## Motivation and Context
The user must be able to save the state of the accordion in preferences.

## How Has This Been Tested

- With UnitTest
- Manual

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
