### PR TITLE
Avoid An empty menu (box) remains visible when opening a three dots menu in one row in a grid without items

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/grid/contextmenu/grid-context-menu-cell-renderer.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/contextmenu/grid-context-menu-cell-renderer.component.spec.ts
@@ -11,6 +11,8 @@ import { SystelabPreferencesModule } from "systelab-preferences";
 import { SystelabTranslateModule } from "systelab-translate";
 import { Component } from "@angular/core";
 import { AbstractGrid } from "systelab-components";
+import { GridContextMenuComponent } from './grid-context-menu-component';
+import createSpyObj = jasmine.createSpyObj;
 
 
 interface TestData {
@@ -48,6 +50,7 @@ describe('GridContextMenuCellRendererComponent', () => {
     const containerMock = {
         removeSelectionOnOpenContextMenu: false,
         getSelectedRows: () => [{id: 16, row: 0}],
+        popupmenu: createSpyObj('popupmenu', ['closeDropDown']),
         dotsClicked: (rowIndex, selectedRows, event) => {
         },
         gridOptions: {
@@ -139,6 +142,11 @@ describe('GridContextMenuCellRendererComponent', () => {
             expect(containerMock.gridOptions.api.deselectAll).toHaveBeenCalled()
 
         })
+        it('Should to call closeDropDown of container when dotsClicked is called', () => {
+            component.agInit(paramsMock);
+            component.dotsClicked(eventMock);
+            expect((component['container'] as any).popupmenu.closeDropDown).toHaveBeenCalled();
+        });
     })
 
     describe('refresh', () => {

--- a/projects/systelab-components/src/lib/grid/contextmenu/grid-context-menu-cell-renderer.component.ts
+++ b/projects/systelab-components/src/lib/grid/contextmenu/grid-context-menu-cell-renderer.component.ts
@@ -22,7 +22,7 @@ export class GridContextMenuCellRendererComponent<T> implements AgRendererCompon
 
 	public dotsClicked(event: MouseEvent): void {
 		let selectedRows: T | Array<T> = this.data;
-
+		this.container?.popupmenu?.closeDropDown();
 		if (event.ctrlKey && !this.container.removeSelectionOnOpenContextMenu) {
 			selectedRows = this.container.getSelectedRows();
 		} else if (this.container.removeSelectionOnOpenContextMenu) {


### PR DESCRIPTION
# PR Details

Close box when user click grid three dots.

## Description

Close box when user click grid three dots in renderer.

## Related Issue
https://github.com/systelab/systelab-components/issues/929

## Motivation and Context
avoid that the empty menu will be sown

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
