### PR TITLE
fix button styles

### DIFF
--- a/projects/systelab-components/sass/_variables.scss
+++ b/projects/systelab-components/sass/_variables.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 @use "sass:string";
-@use "bootstrap/scss/bootstrap" as *;
-@forward "./systelab-bootstrap-settings";
+@use "./systelab-bootstrap-settings" as bootstrap;
+@forward "./systelab-bootstrap-settings" hide size;
 @forward "./mixins";
 
 .ag-theme-alpine {
@@ -56,7 +56,7 @@ $slab-base-font-size: 15px !default;
 // Defines the application font size
 $slab-base-body-font-size: $slab-base-font-size string.unquote("/") math.ceil($slab-base-font-size * 1.25) !default;
 // Defines the application font family
-$slab-base-body-font-family: $font-family-base;
+$slab-base-body-font-family: bootstrap.$font-family-base;
 // Defines the application body color
 $slab-base-body-color: #3F3F3F !default;
 // Defines the minimum width of the body

--- a/projects/systelab-components/sass/systelab-bootstrap-settings.scss
+++ b/projects/systelab-components/sass/systelab-bootstrap-settings.scss
@@ -1,15 +1,21 @@
-// This variable affects the `.h-*` and `.w-*` classes.
-$sizes: (
-        25: 25%,
-        33: 33.333%,
-        50: 50%,
-        66: 66.666%,
-        75: 75%,
-        90: 90%,
-        100: 100%,
-        auto: auto
+@forward "bootstrap/scss/bootstrap" with (
+  // This variable affects the `.h-*` and `.w-*` classes.
+  $sizes: (
+          25: 25%,
+          33: 33.333%,
+          50: 50%,
+          66: 66.666%,
+          75: 75%,
+          90: 90%,
+          100: 100%,
+          auto: auto
+  ),
+  // Bootstrap redefinition:
+  $primary: rgb(21, 143, 239),
+  $success: #C2D95D,
+  $warning: #FFD236,
+  $danger: #FF4944,
+  $info: #B28CE8,
+  $secondary: #AAAAAA,
+  $border-color: #D8D8D8
 );
-
-// Bootstrap redefinition:
-
-$primary: rgb(21, 143, 239) !default;


### PR DESCRIPTION
# PR Details
Fix the bootstrap override styles for buttons

## Description
Due to the upgrade of angular, now we need to import the scss files using @use and @forward and due to that the override of the variables that are coming from bootstrap is over different way.

## Related Issue
https://github.com/systelab/systelab-components/issues/1056

## Motivation and Context
To keep the button styles as previous versions of systelab-components.

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
