### PR TITLE
Avoid undefined rowData

### DIFF
--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -63,7 +63,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	protected firstSizeToFitExecuted = false;
 	private calculatedGridState: CalculatedGridState;
 	private scrollTimeout;
-	private _rowData: Array<T>;
+	private _rowData: Array<T> = new Array<T>();
 
 	protected constructor(protected preferencesService: PreferencesService, protected i18nService: I18nService,
 						  protected dialogService: DialogService) {


### PR DESCRIPTION
# PR Details
Avoid undefined rowData of grid

## Description
To prevent the grid from displaying ‘no rows to show’ when it loads without data, and instead show ‘loading’, rowData must be different from undefined. For this reason, in this PR we initialize rowData as an empty array.

## Related Issue
https://github.com/systelab/systelab-components/issues/1060

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
