### PR TITLE
avoid to re-create the rowData

### DIFF
--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -78,7 +78,7 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 			this.overlayLoadingTemplate = this.loadingText;
 		}
 		this.calculatedGridState = initializeCalculatedGridState(this.autoSizeColumnsToContent);
-		if(this.gridOptions.rowModelType === AbstractGrid.clientSideRowModelType) {
+		if(this.gridOptions.rowModelType === AbstractGrid.clientSideRowModelType && this._rowData == undefined) {
 			this._rowData = new Array<T>();
 		}
 	}


### PR DESCRIPTION
# PR Details
avoid to re-create the rowData for clientSide grids

## Description
If we have a clientSide grid and need to put data from outside by rowData, need to be sure that we not re-create rowData in ngOnInit because the @inputs are called before and the rowData is cleaned in ngOnInit.

## Related Issue
https://github.com/systelab/systelab-components/issues/1074

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
