### PR TITLE
Using Keyboard Tab or Escape in forms wrong focus behaviour #1047

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.10",
+  "version": "20.1.11",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -5,7 +5,6 @@ import {
 	ElementRef,
 	EventEmitter,
 	Input,
-	OnDestroy,
 	OnInit,
 	Output,
 	Renderer2,
@@ -23,7 +22,7 @@ import { PrimeNG } from 'primeng/config';
     providers: [DataTransformerService],
     standalone: false
 })
-export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck, OnDestroy {
+export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 
 	@Input() public disabled = false;
 	@Input() public error = false;
@@ -79,10 +78,6 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck, OnDe
 
 	public currentDocSize: number;
 	public currentLanguage: string;
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	public destroyWheelListener: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	public destroyKeyListener: Function;
 	public inputElement: ElementRef;
 	public focusEvt: FocusEvent;
 	public isTablet = false;
@@ -100,7 +95,6 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck, OnDe
 		this.currentDocSize = window.innerWidth;
 		this.currentLanguage = this.i18nService.getCurrentLanguage();
 
-		this.addListeners();
 		if (navigator.userAgent.indexOf('iPad') > -1 || navigator.userAgent.indexOf('Android') > -1) {
 			this.isTablet = true;
 		}
@@ -204,11 +198,6 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck, OnDe
 			this.currentLanguage = this.i18nService.getCurrentLanguage();
 			this.getLanguage();
 		}
-	}
-
-	public ngOnDestroy() {
-		this.destroyKeyListener?.();
-		this.destroyWheelListener?.();
 	}
 
 	public selectDate(): void {
@@ -431,17 +420,5 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck, OnDe
 		}
 
 		this.config.setTranslation(this.language.translations);
-	}
-
-	private addListeners(): void {
-		this.destroyWheelListener = this.myRenderer.listen('window', 'wheel', () => {
-			// this.closeDatepicker();
-		});
-
-		this.destroyKeyListener = this.myRenderer.listen('document', 'keydown', (evt: KeyboardEvent) => {
-			if (evt.key === 'Escape' || evt.key === 'Tab') {
-				this.closeDatepicker();
-			}
-		});
 	}
 }


### PR DESCRIPTION
# PR Details

Fix Using Keyboard Tab or Escape in forms wrong focus behaviour #1047
Error related to datepicker primeng version upgrade.
Current listeners were wrongly implemented listening to document, but also it seems they are not needed anymore in current datepicker versions,

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
