### PR TITLE
fix width rows of tree listbox

### DIFF
--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -196,9 +196,8 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 
 		this.gridOptions.getRowId = (item: GetRowIdParams) => this.getRowNodeId(item)
 			?.toString();
-
+		this.addSuppressSizeToFitToColumnsWithWidthDefined(this.columnDefs);
 		this.gridOptions.columnDefs = this.columnDefs;
-
 	}
 
 	protected override getRowNodeId(item: GetRowIdParams): string | number | undefined {


### PR DESCRIPTION
# PR Details
call to method addSuppressSizeToFitToColumnsWithWidthDefined from tree listbox configuration.

## Description
The tree-type listbox is running its own ngOnInit, which creates its own grid without executing the parent’s one. When it creates the columns, it does not apply suppressSizeToFit to columns that do not have a width defined. We need to set true in suppressSizeToFit when the column haven't width.

## Related Issue
https://github.com/systelab/systelab-components/issues/1097

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [ ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
