### PR TITLE
Fix the listbox tree rendered

### DIFF
--- a/projects/showcase/src/app/components/listbox/showcase-inner-tree-listbox.component.ts
+++ b/projects/showcase/src/app/components/listbox/showcase-inner-tree-listbox.component.ts
@@ -34,26 +34,22 @@ export class ShowcaseInnerTreeListBox extends AbstractApiTreeListBox<TreeListBox
 	}
 
 	protected getData(): Observable<Array<any>> {
-		const testList = [];
-		testList.push({
-			'centerID':           1,
-			'centerDescription':  'Center',
-			'serviceID':          1,
-			'serviceDescription': 'Service 1'
-		});
-		testList.push({
-			'centerID':           1,
-			'centerDescription':  'Center',
-			'serviceID':          2,
-			'serviceDescription': 'Service 2'
-		});
-		testList.push({
-			'centerID':           1,
-			'centerDescription':  'Center',
-			'serviceID':          3,
-			'serviceDescription': 'Service 3'
-		});
-		return of(testList);
+		return of(this.getListBoxValues());
+	}
+
+	private getListBoxValues(): any[] {
+		const values = [];
+		for(let i = 1; i <= 20; i++) {
+			for(let j = 1; j <= 5; j++) {
+				values.push({
+					'centerID':           i,
+					'centerDescription':  'Center ' + i,
+					'serviceID':          j,
+					'serviceDescription': 'Service ' + j + ' of Center ' + i
+				});
+			}
+		}
+		return values;
 	}
 
 	protected getSelectionPrefix(level: number): string {

--- a/projects/showcase/src/app/components/listbox/showcase-listbox.component.html
+++ b/projects/showcase/src/app/components/listbox/showcase-listbox.component.html
@@ -19,3 +19,11 @@
                                      (selectedTreeItemChange)="onSelectedItemChange($event)"></showcase-inner-tree-listbox>
     </form>
 </div>
+<div class="container-fluid mt-2">
+    <form class="position-relative" style="height: 200px;">
+        <showcase-inner-tree-listbox [(selectedTreeItem)]="selectedTreeItem"
+                                     [isParentSelectable]="false"
+                                     [multipleSelection]="true"
+                                     (selectedTreeItemChange)="onSelectedItemChange($event)"></showcase-inner-tree-listbox>
+    </form>
+</div>

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.12",
+  "version": "20.1.13",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -201,8 +201,8 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 	}
 
 	protected override getRowNodeId(item: GetRowIdParams): string | number | undefined {
-		if (item?.data?.nodeData[this.getIdField(1)]) {
-			return item.level + '-' + item.data.nodeData[this.getIdField(1)];
+		if (item?.data?.nodeData[this.getIdField(item?.data?.level)]) {
+			return item.level + '-' + item.data.nodeData[this.getIdField(item?.data?.level)];
 		} else {
 			return null;
 		}
@@ -214,8 +214,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 				next:  (dataVector: Array<T>) => {
 					this.loadValues(dataVector);
 					this.gridApi.hideOverlay();
-					this.rowData = this.treeValues;
-					this.gridApi.redrawRows();
+					this.rowData = [...this.treeValues];
 					if (this.multipleSelection) {
 						this.initSelectionList();
 					} else if (this.selectedTreeItem) {


### PR DESCRIPTION
# PR Details
The ColId must be unique with aggrid 33

## Description
the method to get row node id has changed and the multiselector tree listbox is added to showcase.

## Related Issue
https://github.com/systelab/systelab-components/issues/1099

## How Has This Been Tested
Unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
