### PR TITLE
fix In the datepicker, the current day isn’t being highlighted #1119

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.16",
+  "version": "20.1.17",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/components/_datepicker.scss
+++ b/projects/systelab-components/sass/components/_datepicker.scss
@@ -9,6 +9,7 @@ $icon-margin-left: 40px;
 
 p-datepicker {
 
+
   .p-datepicker-input-wrapper,
   .p-inputwrapper {
     input::-ms-clear {
@@ -139,8 +140,8 @@ p-datepicker {
 }
 
 .p-datepicker-panel.p-component {
-  color: #333;
-  background-color: white !important;
+  color: var(--secondary);
+  background-color: var(--slab_background_primary) !important;
   z-index: 100000 !important;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   border: 1px solid #ddd !important;
@@ -195,33 +196,25 @@ p-datepicker {
               line-height: 28px;
               text-align: center;
               border: none !important;
-              background: transparent !important;
-              color: #333;
               font-weight: 400;
               margin: 0 auto;
               font-size: 13px;
 
-              &:hover {
-                background-color: #f5f5f5 !important;
-                color: #333;
-              }
-
-              &.p-datepicker-day-selected {
-                background-color: var(--primary) !important;
-                color: white !important;
-                font-weight: 500;
-              }
-
-              &.p-datepicker-today {
-                background-color: var(--primary) !important;
-                color: white !important;
-                font-weight: 500;
-              }
-
               &.p-disabled {
                 opacity: 0.3;
                 background-color: transparent !important;
-                color: #ccc;
+                color: var(--text-color-secondary);
+              }
+              &.p-datepicker-day-selected {
+                background-color: var(--primary) !important;
+                color: var(--text-color-secondary) !important;
+                font-weight: 500;
+                &:hover {
+                  color: var(--slab_foreground_primary) !important;
+                }
+              }
+              &:not(.p-datepicker-day-selected):not(.p-disabled):hover {
+                background: var(--slab_table_row_hover_background);
               }
             }
           }
@@ -409,8 +402,8 @@ p-datepicker {
     
     a {
       cursor: pointer;
-      color: var(--primary) !important;
-      border: 2px solid var(--primary);
+      color: var(--text-color) !important;
+      border: 2px solid var(--text-color);
       border-radius: 50%;
       width: 28px;
       height: 28px;
@@ -471,8 +464,8 @@ systelab-datepicker {
 
   .p-inputtext,
   .p-datepicker-input {
-    color: #333;
-    background: #fff;
+    color: var(--ag-foreground-color);
+    background: var(--slab_background_primary);
     border-radius: 0.25rem;
     padding: 1px .25em;
     width: 100%;


### PR DESCRIPTION
# PR Details
Fix styles of datepicker to allow to mark the current date when the user leaves in blank the input.

## Description
fix datepicker.scss styles

## Related Issue
https://github.com/systelab/systelab-components/issues/1119


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
