### PR TITLE
Datepicker opened randomly

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.18",
+  "version": "20.1.19",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.html
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.html
@@ -1,57 +1,60 @@
 <p-datepicker #calendar [(ngModel)]="currentDate" [showIcon]="false"
-  [dateFormat]="language.dateFormatValue"
-  [firstDayOfWeek]="language.firstDayOfWeek"
-  (onFocus)="saveEventOnFocus($event)"
-  (onBlur)="changeDate()"
-  (onSelect)="selectDate()"
-  (onInput)="onInput($event)"
-  [showOtherMonths]="showOtherMonths"
-  [selectOtherMonths]="selectOtherMonths"
-  [minDate]="minDate"
-  [focusTrap]="false"
-  [maxDate]="maxDate"
-  [inline]="inline"
-  [keepInvalid]="keepInvalid"
-  [required]="required"
-  [disabled]="disabled"
-  [readonlyInput]="isTablet"
-  [style.font-size.px]="inputFontSize"
-  [showTime]="withIntegratedTime"
-  [timeOnly]="onlyTime"
-  [showTransitionOptions]="'1ms linear'"
-  [hideTransitionOptions]="'1ms linear'"
-  appendTo="body"
-  [tabindex]="tabindex"
-  [ngClass]="{'date-error': formatError || error || (required && !currentDate), 'is-disabled': disabled, 'warning-date': tooFarDate || previousAfterDate, 'input-expand-height':inputExpandHeight}">
-  @if (!onlyTime) {
-    <ng-template pTemplate="header">
-      <div id="{{datepickerId}}" class="slab-datepicker-header">
-        <div class="left-buttons">
-          <a id="previousYear" class="icon-angle-double-left slab-icon-medium" (click)="prevYear()"></a>
-          <a id="previousMonth" class="icon-angle-left slab-icon-medium" (click)="prevMonth()"></a>
-        </div>
-        <div class="p-datepicker-title d-flex align-items-center justify-content-center">
-          <span class="p-datepicker-year">{{ currentCalendar.currentYear }}</span>
-          <span class="p-datepicker-month">{{ language.translations.monthNames[currentCalendar.currentMonth] }}</span>
-        </div>
-        <div class="right-buttons">
-          <a id="nextMonth" class="icon-angle-right slab-icon-medium" (click)="nextMonth()"></a>
-          <a id="nextYear" class="icon-angle-double-right slab-icon-medium" (click)="nextYear()"></a>
-        </div>
-      </div>
-    </ng-template>
-  }
-  <ng-template pTemplate="footer">
-    @if (!inline) {
-      <div class="slab-datepicker-buttonbar p-3 d-flex border-top">
-        @if (showTodayButton) {
-          <systelab-button id="today" size="small" class="mr-auto"
-          (click)="setTodayDate()">{{ 'COMMON_TODAY' | translate | async }}</systelab-button>
-        }
-        <systelab-button id="clear" size="small" type="danger" class="ml-auto"
-        (click)="clearDate($event)">{{ 'COMMON_CLEAR' | translate | async }}</systelab-button>
-      </div>
+              [dateFormat]="language.dateFormatValue"
+              [firstDayOfWeek]="language.firstDayOfWeek"
+              (onFocus)="saveEventOnFocus($event)"
+              (onBlur)="changeDate()"
+              (onSelect)="selectDate()"
+              (onInput)="onInput($event)"
+              [showOtherMonths]="showOtherMonths"
+              [selectOtherMonths]="selectOtherMonths"
+              [minDate]="minDate"
+              [focusTrap]="false"
+              [autofocus]="autofocus"
+              [maxDate]="maxDate"
+              [inline]="inline"
+              [keepInvalid]="keepInvalid"
+              [required]="required"
+              [disabled]="disabled"
+              [readonlyInput]="isTablet"
+              [style.font-size.px]="inputFontSize"
+              [showTime]="withIntegratedTime"
+              [timeOnly]="onlyTime"
+              [showTransitionOptions]="'1ms linear'"
+              [hideTransitionOptions]="'1ms linear'"
+              appendTo="body"
+              [tabindex]="tabindex"
+              [ngClass]="{'date-error': formatError || error || (required && !currentDate), 'is-disabled': disabled, 'warning-date': tooFarDate || previousAfterDate, 'input-expand-height':inputExpandHeight}">
+    @if (!onlyTime) {
+        <ng-template pTemplate="header">
+            <div id="{{datepickerId}}" class="slab-datepicker-header">
+                <div class="left-buttons">
+                    <a id="previousYear" class="icon-angle-double-left slab-icon-medium" (click)="prevYear()"></a>
+                    <a id="previousMonth" class="icon-angle-left slab-icon-medium" (click)="prevMonth()"></a>
+                </div>
+                <div class="p-datepicker-title d-flex align-items-center justify-content-center">
+                    <span class="p-datepicker-year">{{ currentCalendar.currentYear }}</span>
+                    <span class="p-datepicker-month">{{ language.translations.monthNames[currentCalendar.currentMonth] }}</span>
+                </div>
+                <div class="right-buttons">
+                    <a id="nextMonth" class="icon-angle-right slab-icon-medium" (click)="nextMonth()"></a>
+                    <a id="nextYear" class="icon-angle-double-right slab-icon-medium" (click)="nextYear()"></a>
+                </div>
+            </div>
+        </ng-template>
     }
-  </ng-template>
+    <ng-template pTemplate="footer">
+        @if (!inline) {
+            <div class="slab-datepicker-buttonbar p-3 d-flex border-top">
+                @if (showTodayButton) {
+                    <systelab-button id="today" size="small" class="mr-auto"
+                                     (click)="setTodayDate()">{{ 'COMMON_TODAY' | translate | async }}
+                    </systelab-button>
+                }
+                <systelab-button id="clear" size="small" type="danger" class="ml-auto"
+                                 (click)="clearDate($event)">{{ 'COMMON_CLEAR' | translate | async }}
+                </systelab-button>
+            </div>
+        }
+    </ng-template>
 </p-datepicker>
 

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -1,15 +1,4 @@
-import {
-	AfterViewInit,
-	Component,
-	DoCheck,
-	ElementRef,
-	EventEmitter,
-	Input,
-	OnInit,
-	Output,
-	Renderer2,
-	ViewChild
-} from '@angular/core';
+import { AfterViewInit, Component, DoCheck, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
 import { addDays } from 'date-fns';
 import { DatePicker } from 'primeng/datepicker';
 import { I18nService } from 'systelab-translate';
@@ -17,10 +6,10 @@ import { DataTransformerService } from './date-transformer.service';
 import { PrimeNG } from 'primeng/config';
 
 @Component({
-    selector: 'systelab-datepicker',
-    templateUrl: 'datepicker.component.html',
-    providers: [DataTransformerService],
-    standalone: false
+	selector:    'systelab-datepicker',
+	templateUrl: 'datepicker.component.html',
+	providers:   [DataTransformerService],
+	standalone:  false
 })
 export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 
@@ -104,18 +93,19 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		if (!this.inline) {
 			this.addIconToDatepicker();
 		}
-		
+
 		if (this.currentCalendar && this.autofocus) {
 			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
 			if (inputElement) {
 				inputElement.focus();
 			}
 		}
-		
-		if (this.tabindex && this.currentCalendar) {
+
+		if (this.currentCalendar) {
 			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
 			if (inputElement) {
-				inputElement.setAttribute('tabindex', this.tabindex.toString());
+				const tabindexValue = this.tabindex ?? 0;
+				inputElement.setAttribute('tabindex', tabindexValue.toString());
 			}
 		}
 	}
@@ -126,7 +116,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		}
 
 		const datepickerElement = this.currentCalendar.el.nativeElement;
-		
+
 		// Función que intenta agregar el icono
 		const attemptAddIcon = (): boolean => {
 			const inputElement = datepickerElement.querySelector('input');
@@ -135,7 +125,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 			}
 
 			const parentWrapper = inputElement.parentElement;
-			
+
 			// Verificar si ya existe un icono
 			if (parentWrapper.querySelector('i.icon-calendar, i.icon-clock')) {
 				return true;
@@ -144,12 +134,12 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 			// Crear y configurar el icono
 			const iconElement = document.createElement('i');
 			iconElement.className = this.onlyTime ? 'icon-clock' : 'icon-calendar';
-			
+
 			// Configurar el contenedor
 			parentWrapper.classList.add('slab-form-icon', 'w-100');
 			parentWrapper.style.position = 'relative';
 			parentWrapper.appendChild(iconElement);
-			
+
 			return true;
 		};
 
@@ -172,8 +162,8 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 
 		// Observar cambios en el elemento datepicker
 		observer.observe(datepickerElement, {
-			childList: true,
-			subtree: true,
+			childList:  true,
+			subtree:    true,
 			attributes: true
 		});
 
@@ -226,7 +216,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 										this.infereDate(dateStr);
 										break;
 									case 2:
-										const hourPosition = splitDateByHours[0].length-2;
+										const hourPosition = splitDateByHours[0].length - 2;
 										const dateString = splitDateByHours[0].substring(0, hourPosition);
 										this.infereDate(dateString);
 										this.parseTime(+splitDateByHours[0].substring(hourPosition), +splitDateByHours[1]);
@@ -291,7 +281,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	public repositionateCalendar(element?: ElementRef): void {
 
 		try {
-			const { inputElementTop, inputElementHeight, datepickerElementHeight } = this.inputElement.nativeElement.getBoundingClientRect();
+			const {inputElementTop, inputElementHeight, datepickerElementHeight} = this.inputElement.nativeElement.getBoundingClientRect();
 			if (inputElementTop + inputElementHeight + datepickerElementHeight > window.innerHeight) {
 				const newTop: number = inputElementTop + inputElementHeight - (datepickerElementHeight + inputElementHeight + 10);
 				this.myRenderer.setAttribute(element.nativeElement, 'top', newTop + 'px');


### PR DESCRIPTION
# PR Details

Sometimes the calendar of datepicker is opened without aparently reason, and sometimes in a componente below of a dialog

## Description

In the new version of primeng the autofocus is true by default. I added the parameter false by default to avoid some strange behaviours. Not sure if this is the cause of the random open calendars, but it's clear that the parameter has to be false by default.
I only added [autofocus]="autofocus" to the template, it seems more due to a intellij automatic format 

The tabindex is initialized to 0 if is not informed, this is to avoid tabindex=NaN that we can see inspecting the DOM, maybe this could cause some weird behaviour.

## Related Issue
https://github.com/systelab/systelab-components/issues/1130


