### PR TITLE
bug-1133-dropdown-element-selected

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.20",
+  "version": "20.1.21",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.19",
+  "version": "20.1.20",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -9,14 +9,10 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { SystelabTranslateModule } from 'systelab-translate';
 import { SystelabPreferencesModule } from 'systelab-preferences';
 import { AgGridModule } from 'ag-grid-angular';
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
 import { GridHeaderContextMenuComponent } from '../grid/contextmenu/grid-header-context-menu-renderer.component';
 import { GridContextMenuCellRendererComponent } from '../grid/contextmenu/grid-context-menu-cell-renderer.component';
 import { ComboBoxInputRendererComponent } from './renderer/combobox-input-renderer.component';
 import { ModulabSelect } from '../select/select.component';
-
-// Register AG Grid modules
-ModuleRegistry.registerModules([AllCommunityModule]);
 
 export class TestData {
 	constructor(public id: string | number, public description: string) {

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -9,10 +9,14 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { SystelabTranslateModule } from 'systelab-translate';
 import { SystelabPreferencesModule } from 'systelab-preferences';
 import { AgGridModule } from 'ag-grid-angular';
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
 import { GridHeaderContextMenuComponent } from '../grid/contextmenu/grid-header-context-menu-renderer.component';
 import { GridContextMenuCellRendererComponent } from '../grid/contextmenu/grid-context-menu-cell-renderer.component';
 import { ComboBoxInputRendererComponent } from './renderer/combobox-input-renderer.component';
 import { ModulabSelect } from '../select/select.component';
+
+// Register AG Grid modules
+ModuleRegistry.registerModules([AllCommunityModule]);
 
 export class TestData {
 	constructor(public id: string | number, public description: string) {
@@ -20,29 +24,29 @@ export class TestData {
 }
 
 @Component({
-    selector: 'systelab-combobox-test',
-    template: `
-                  <div class="container-fluid" style="height: 200px;">
-                      <div class="row mt-1">
-                          <label class="col-md-3 col-form-label" for="form-h-s">Test:</label>
-                          <div class="col-md-9">
-                              <systelab-select #combobox [withDeleteOption]="withDeleteOption"
-                                               [defaultIdValue]="defaultIdValue"
-                                               [withEmptyValue]="withEmptyValue"
-                                               [values]="valuesList"
-                                               [filter]="filter"
-                                               [deleteIconClass]="deleteIconClass">
-                              </systelab-select>
-                          </div>
-                      </div>
-                  </div>
-			  `,
-    standalone: false
+	selector:   'systelab-combobox-test',
+	template:   `
+                    <div class="container-fluid" style="height: 200px;">
+                        <div class="row mt-1">
+                            <label class="col-md-3 col-form-label" for="form-h-s">Test:</label>
+                            <div class="col-md-9">
+                                <systelab-select #combobox [withDeleteOption]="withDeleteOption"
+                                                 [defaultIdValue]="defaultIdValue"
+                                                 [withEmptyValue]="withEmptyValue"
+                                                 [values]="valuesList"
+                                                 [filter]="filter"
+                                                 [deleteIconClass]="deleteIconClass">
+                                </systelab-select>
+                            </div>
+                        </div>
+                    </div>
+				`,
+	standalone: false
 })
 export class ComboboxTestComponent {
 	@ViewChild('combobox') public combobox: ModulabSelect;
 	public filter = false;
-	public valuesList: TestData[] = [new TestData(0, 'Description 0'),new TestData('1', 'Description 1'), new TestData('2', 'Description 2')];
+	public valuesList: TestData[] = [new TestData(0, 'Description 0'), new TestData('1', 'Description 1'), new TestData('2', 'Description 2')];
 	public withEmptyValue = false;
 	public deleteIconClass = 'icon-close';
 	public defaultIdValue = undefined;
@@ -58,23 +62,23 @@ describe('Systelab Select Combobox', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-    declarations: [
-        GridContextMenuCellRendererComponent,
-        GridHeaderContextMenuComponent,
-        ComboBoxInputRendererComponent,
-        ModulabSelect,
-        ComboboxTestComponent
-    ],
-    imports: [BrowserModule,
-        BrowserAnimationsModule,
-        FormsModule,
-        OverlayModule,
-        ButtonModule,
-        SystelabTranslateModule,
-        SystelabPreferencesModule,
-        AgGridModule],
-    providers: [provideHttpClient(withInterceptorsFromDi())]
-})
+			declarations: [
+				GridContextMenuCellRendererComponent,
+				GridHeaderContextMenuComponent,
+				ComboBoxInputRendererComponent,
+				ModulabSelect,
+				ComboboxTestComponent
+			],
+			imports:      [BrowserModule,
+				BrowserAnimationsModule,
+				FormsModule,
+				OverlayModule,
+				ButtonModule,
+				SystelabTranslateModule,
+				SystelabPreferencesModule,
+				AgGridModule],
+			providers:    [provideHttpClient(withInterceptorsFromDi())]
+		})
 			.compileComponents();
 	});
 
@@ -194,6 +198,320 @@ describe('Systelab Select Combobox', () => {
 					.toEqual('Description 0');
 				done();
 			});
+	});
+
+	describe('transferFocusToGrid', () => {
+
+		it('should deselect all rows when multipleSelection is false', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.deselectAll)
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should not deselect rows when multipleSelection is true', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = true;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.deselectAll)
+						.not
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should find and focus on the row matching the current id', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = '1';
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+
+					// Mock forEachNodeAfterFilterAndSort to simulate finding the row at index 1
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort')
+						.and
+						.callFake((callback: any) => {
+							// Simulate three rows, where the second one (index 1) matches the id '1'
+							callback({data: {id: 0}}, 0);
+							callback({data: {id: '1'}}, 1);
+							callback({data: {id: '2'}}, 2);
+						});
+
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.forEachNodeAfterFilterAndSort)
+						.toHaveBeenCalled();
+					expect(combobox.gridApi.setFocusedCell)
+						.toHaveBeenCalledWith(1, jasmine.anything());
+					done();
+				});
+		});
+
+		it('should ensure the selected row is visible when there are displayed rows', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = '1';
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([{isVisible: () => true}] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.ensureIndexVisible)
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should not ensure row visibility when there are no displayed rows', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(0);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.ensureIndexVisible)
+						.not
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should scroll to the first visible column', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.ensureColumnVisible)
+						.toHaveBeenCalledWith(jasmine.anything());
+					done();
+				});
+		});
+
+		it('should set focus on the selected grid cell', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = '1';
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.setFocusedCell)
+						.toHaveBeenCalledWith(jasmine.any(Number), jasmine.anything());
+					done();
+				});
+		});
+
+		it('should focus on row index 0 when no id is set', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = undefined;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.setFocusedCell)
+						.toHaveBeenCalledWith(0, jasmine.anything());
+					done();
+				});
+		});
+
+		it('should handle null gridApi gracefully', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox.gridApi = null;
+
+					expect(() => combobox['transferFocusToGrid']())
+						.not
+						.toThrow();
+					done();
+				});
+		});
+
+		it('should handle undefined gridApi gracefully', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox.gridApi = undefined;
+
+					expect(() => combobox['transferFocusToGrid']())
+						.not
+						.toThrow();
+					done();
+				});
+		});
+
 	});
 
 });

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -5,6 +5,7 @@ import { StylesUtilService } from '../utilities/styles.util.service';
 import { ComboboxFavouriteRendererComponent } from './renderer/combobox-favourite-renderer.component';
 import { PreferencesService } from 'systelab-preferences';
 import { AutosizeGridHelper, CalculatedGridState, initializeCalculatedGridState } from '../helper/autosize-grid-helper';
+import { ComboTreeNode } from './tree/abstract-api-tree-combobox.component';
 
 declare var jQuery: any;
 
@@ -308,13 +309,17 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		this.gridOptions.enableBrowserTooltips = true;
 	}
 
-	protected getRowNodeId(item: GetRowIdParams): string | number | undefined {
+	protected getRowNodeId(item: GetRowIdParams | ComboTreeNode<T>): string | number | undefined {
 		const id = this.getIdField();
 		if (item) {
-			if (item[this.getIdField()] != null) {
-				return item[this.getIdField()];
+			if (item[id] != null) {
+				return item[id];
 			}
-			return this.getIdField() === '' ? '' : item.data ? item.data?.[this.getIdField()] : '';
+			if ('data' in item) {
+				return id === '' ? '' : item.data ? item.data?.[id] : '';
+			} else {
+				return '';
+			}
 		}
 		return '';
 	}

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -214,7 +214,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	public isDropdownOpened = false;
 	public windowScrollHandler: any;
 
-	private calculatedGridState : CalculatedGridState = initializeCalculatedGridState();
+	private calculatedGridState: CalculatedGridState = initializeCalculatedGridState();
 	private scrollTimeout;
 
 	constructor(public myRenderer: Renderer2, public chRef: ChangeDetectorRef, public preferencesService?: PreferencesService) {
@@ -274,7 +274,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 				colId:              'itemDescription',
 				id:                 this.getIdField(),
 				field:              this.getDescriptionField(),
-				tooltipField: 		this.getDescriptionField(),
+				tooltipField:       this.getDescriptionField(),
 				cellRenderer:       ComboboxFavouriteRendererComponent,
 				cellRendererParams: {
 					favouriteList: this.favouriteList
@@ -282,10 +282,10 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 			}
 		] : [
 			{
-				colId:             	'itemDescription',
-				field:             	this.getDescriptionField(),
-				tooltipField: 		this.getDescriptionField(),
-				cellStyle: () => this.multipleSelection ? ({ paddingLeft: '0px' }) : null
+				colId:        'itemDescription',
+				field:        this.getDescriptionField(),
+				tooltipField: this.getDescriptionField(),
+				cellStyle:    () => this.multipleSelection ? ({paddingLeft: '0px'}) : null
 			}
 		];
 		this.gridOptions = {};
@@ -296,8 +296,8 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		this.gridOptions.headerHeight = 0;
 		this.gridOptions.suppressCellFocus = false;
 		this.gridOptions.rowSelection = {
-			checkboxes: this.multipleSelection,
-			mode: this.multipleSelection ? 'multiRow' : 'singleRow',
+			checkboxes:           this.multipleSelection,
+			mode:                 this.multipleSelection ? 'multiRow' : 'singleRow',
 			enableClickSelection: !this.multipleSelection
 		} as RowSelectionOptions;
 		this.gridOptions.getRowId = (item: GetRowIdParams) => this.getRowNodeId(item)
@@ -395,7 +395,6 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		}
 	}
 
-
 	public onComboKeyArrowUp(event: any) {
 		event.preventDefault();
 		event.stopPropagation();
@@ -463,19 +462,31 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 
 	protected transferFocusToGrid(): void {
 		// remove previous selection
-		if(!this.multipleSelection) {
+		if (!this.multipleSelection) {
 			this.gridApi?.deselectAll();
-			if(this.gridApi?.getDisplayedRowCount() > 0) {
-				// scrolls to the first row
-				this.gridApi?.ensureIndexVisible(0);
+
+			// Find the row index of the currently selected item
+			let rowIndexToFocus = 0;
+			if (this._id) {
+				this.gridApi?.forEachNodeAfterFilterAndSort((node, index) => {
+					if (this.getRowNodeId(node.data) === this._id) {
+						rowIndexToFocus = index;
+					}
+				});
+			}
+
+			if (this.gridApi?.getDisplayedRowCount() > 0) {
+				// scrolls to the selected row
+				this.gridApi?.ensureIndexVisible(rowIndexToFocus);
 			}
 
 			// scrolls to the first column
-			const firstCol = this.gridApi?.getColumns()?.filter(col => col.isVisible())[0];
+			const firstCol = this.gridApi?.getColumns()
+				?.filter(col => col.isVisible())[0];
 			this.gridApi?.ensureColumnVisible(firstCol);
 
-			// sets focus into the first grid cell
-			this.gridApi?.setFocusedCell(0, firstCol);
+			// sets focus into the selected grid cell
+			this.gridApi?.setFocusedCell(rowIndexToFocus, firstCol);
 		}
 	}
 
@@ -766,7 +777,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	protected addGridScrollHandler() {
-		if(this.gridApi && !this.gridApi.isDestroyed()) {
+		if (this.gridApi && !this.gridApi.isDestroyed()) {
 			this.gridApi.removeEventListener('bodyScroll', this.onBodyScroll.bind(this));
 
 			this.calculatedGridState = initializeCalculatedGridState();
@@ -777,7 +788,7 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	protected removeGridScrollHandler() {
-		if(this.gridApi) {
+		if (this.gridApi) {
 			this.gridApi.removeEventListener('bodyScroll', this.onBodyScroll.bind(this));
 		}
 	}

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.spec.ts
@@ -54,6 +54,14 @@ class TestApiTreeComboBox extends AbstractApiTreeComboBox<{
 		return level === 0 ? 'parentId' : 'childId';
 	}
 
+	// Override getIdField to delegate to getLevelIdField for the tree structure
+	override getIdField(level?: number): string {
+		if (level !== undefined) {
+			return this.getLevelIdField(level);
+		}
+		return '';
+	}
+
 	getAllNodeId() {
 		return 'ALL';
 	}
@@ -119,6 +127,20 @@ describe('AbstractApiTreeComboBox', () => {
 
 		fixture = TestBed.createComponent(TestHostComponent);
 		component = fixture.componentInstance;
+
+		// Mock ElementRef for comboboxElement and dropdownElement
+		component.comboboxElement = {
+			nativeElement: {
+				className:   '',
+				offsetWidth: 200
+			}
+		} as any;
+
+		component.dropdownElement = {
+			nativeElement: {
+				offsetWidth: 200
+			}
+		} as any;
 
 		component.gridApi = {
 			forEachNode:          (cb: (node: TestNode) => void) => gridNodes.forEach(cb),
@@ -315,6 +337,222 @@ describe('AbstractApiTreeComboBox', () => {
 
 		expect(parentNode.setSelected)
 			.toHaveBeenCalledWith(false);
+	});
+
+	describe('transferFocusToGrid', () => {
+
+		it('should find and focus on the correct tree node matching the current id', () => {
+			component.multipleSelection = false;
+			component._id = 11; // childId to search for (number type to match the mock data)
+
+			// Create mock tree nodes - node.data should be the ComboTreeNode with level and nodeData
+			// The getRowNodeId method will first check item[idField] (e.g., item['childId'])
+			// For level 0: idField is 'parentId', for level 1: idField is 'childId'
+			const mockTreeNodes = [
+				{
+					data: {
+						level:    0,
+						nodeData: {parentId: 1, descParent: 'Parent 1', descChild: ''},
+						// For level 0, the id comes from parentId
+						parentId: 1
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 10, descParent: 'Parent 1', descChild: 'Child 1'},
+						// For level 1, the id comes from childId
+						childId: 10
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 11, descParent: 'Parent 1', descChild: 'Child 2'},
+						// For level 1, the id comes from childId - THIS SHOULD MATCH _id = 11
+						childId: 11
+					}
+				},
+				{
+					data: {
+						level:    0,
+						nodeData: {parentId: 2, descParent: 'Parent 2', descChild: ''},
+						// For level 0, the id comes from parentId
+						parentId: 2
+					}
+				}
+			];
+
+			const mockColumn = {isVisible: () => true};
+
+			// Setup gridApi with all required methods
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort')
+												   .and
+												   .callFake((callback: any) => {
+													   mockTreeNodes.forEach((node, index) => {
+														   callback(node, index);
+													   });
+												   }),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount')
+												   .and
+												   .returnValue(4),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns')
+												   .and
+												   .returnValue([mockColumn] as any),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			expect(component.gridApi.deselectAll)
+				.toHaveBeenCalled();
+
+			expect(component.gridApi.forEachNodeAfterFilterAndSort)
+				.toHaveBeenCalled();
+
+			expect(component.gridApi.ensureIndexVisible)
+				.toHaveBeenCalled();
+
+			expect(component.gridApi.ensureColumnVisible)
+				.toHaveBeenCalled();
+
+			// Verify setFocusedCell was called with index 2 (the third node, which has childId: 11)
+			expect(component.gridApi.setFocusedCell)
+				.toHaveBeenCalledWith(2, jasmine.anything());
+		});
+
+		it('should focus on row index 0 when no matching tree node id is found', () => {
+			component.multipleSelection = false;
+			component._id = 999; // Non-existent childId
+
+			const mockTreeNodes = [
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 10, descParent: 'Parent 1', descChild: 'Child 1'},
+						childId:  10
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 11, descParent: 'Parent 1', descChild: 'Child 2'},
+						childId:  11
+					}
+				}
+			];
+
+			const mockColumn = {isVisible: () => true};
+
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort')
+												   .and
+												   .callFake((callback: any) => {
+													   mockTreeNodes.forEach((node, index) => {
+														   callback(node, index);
+													   });
+												   }),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount')
+												   .and
+												   .returnValue(2),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns')
+												   .and
+												   .returnValue([mockColumn] as any),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			// Should focus on index 0 when no match is found
+			expect(component.gridApi.setFocusedCell)
+				.toHaveBeenCalledWith(0, jasmine.anything());
+		});
+
+		it('should handle tree nodes with parent-level ids correctly', () => {
+			component.multipleSelection = false;
+			component._id = 1; // parentId to search for
+
+			const mockTreeNodes = [
+				{
+					data: {
+						level:    0,
+						nodeData: {parentId: 1, descParent: 'Parent 1', descChild: ''},
+						parentId: 1
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 10, descParent: 'Parent 1', descChild: 'Child 1'},
+						childId:  10
+					}
+				}
+			];
+
+			const mockColumn = {isVisible: () => true};
+
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort')
+												   .and
+												   .callFake((callback: any) => {
+													   mockTreeNodes.forEach((node, index) => {
+														   callback(node, index);
+													   });
+												   }),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount')
+												   .and
+												   .returnValue(2),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns')
+												   .and
+												   .returnValue([mockColumn] as any),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			// Should find the parent node at index 0
+			expect(component.gridApi.setFocusedCell)
+				.toHaveBeenCalledWith(0, jasmine.anything());
+		});
+
+		it('should not perform focus operations when multipleSelection is true', () => {
+			component.multipleSelection = true;
+			component._id = 11;
+
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort'),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount'),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns'),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			// None of the methods should be called when multipleSelection is true
+			expect(component.gridApi.deselectAll)
+				.not
+				.toHaveBeenCalled();
+			expect(component.gridApi.forEachNodeAfterFilterAndSort)
+				.not
+				.toHaveBeenCalled();
+			expect(component.gridApi.setFocusedCell)
+				.not
+				.toHaveBeenCalled();
+		});
+
 	});
 
 });

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
@@ -127,7 +127,9 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 					if (this.totalItemsLoaded) {
 						this.setDropdownHeight(nodeVector.length);
 						this.setDropdownPosition();
-						this.transferFocusToGrid();
+						setTimeout(() => {
+							this.transferFocusToGrid();
+						});
 					}
 				},
 				error: () => {
@@ -378,7 +380,7 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 	protected override getRowNodeId(item: GetRowIdParams | ComboTreeNode<ComboTreeNode<T>>): string | number | undefined {
 
 		if ('nodeData' in item) {
-			const id = this.getIdField(item.level);
+			const id = this.getLevelIdField(item.level);
 
 			if (item[id] != null) {
 				return item[id];

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
@@ -3,7 +3,7 @@ import { AgRendererComponent } from 'ag-grid-angular';
 import { AbstractComboBox } from '../abstract-combobox.component';
 import { map, Observable } from 'rxjs';
 import { PreferencesService } from 'systelab-preferences';
-import { GridOptions, GridReadyEvent } from 'ag-grid-community';
+import { GetRowIdParams, GridOptions, GridReadyEvent } from 'ag-grid-community';
 
 declare var jQuery: any;
 
@@ -373,5 +373,22 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 	private getFavouriteElements(dataVector: Array<T>): Array<T> {
 		return dataVector.filter((data: T) => this.favouriteList.map(String)
 			.includes(data[this.getLevelIdField(1)].toString()));
+	}
+
+	protected override getRowNodeId(item: GetRowIdParams | ComboTreeNode<ComboTreeNode<T>>): string | number | undefined {
+
+		if ('nodeData' in item) {
+			const id = this.getIdField(item.level);
+
+			if (item[id] != null) {
+				return item[id];
+			}
+
+			return id === ''
+				? ''
+				: item.nodeData?.[id] ?? '';
+		}
+
+		return '';
 	}
 }


### PR DESCRIPTION
# PR Details

In comboboxes after open the dropdown always the first element is selected even if there is some element previous selected

## Description

Changed transferFocusToGrid to select grid node of the element is there is some element selected, otherwise the first element is selected

## Related Issue

https://github.com/systelab/systelab-components/issues/1133


Before:
<img width="397" height="524" alt="image" src="https://github.com/user-attachments/assets/48ba78af-36cc-4a58-aa34-361d596d7854" />

After:
<img width="321" height="458" alt="image" src="https://github.com/user-attachments/assets/ceea5833-dc29-4b96-8363-1d6ba140c2e1" />



