### PR TITLE
Bug 1133 dropdown element selected master

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "21.1.0",
+  "version": "21.1.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -20,29 +20,29 @@ export class TestData {
 }
 
 @Component({
-    selector: 'systelab-combobox-test',
-    template: `
-                  <div class="container-fluid" style="height: 200px;">
-                      <div class="row mt-1">
-                          <label class="col-md-3 col-form-label" for="form-h-s">Test:</label>
-                          <div class="col-md-9">
-                              <systelab-select #combobox [withDeleteOption]="withDeleteOption"
-                                               [defaultIdValue]="defaultIdValue"
-                                               [withEmptyValue]="withEmptyValue"
-                                               [values]="valuesList"
-                                               [filter]="filter"
-                                               [deleteIconClass]="deleteIconClass">
-                              </systelab-select>
-                          </div>
-                      </div>
-                  </div>
-			  `,
-    standalone: false
+	selector:   'systelab-combobox-test',
+	template:   `
+                    <div class="container-fluid" style="height: 200px;">
+                        <div class="row mt-1">
+                            <label class="col-md-3 col-form-label" for="form-h-s">Test:</label>
+                            <div class="col-md-9">
+                                <systelab-select #combobox [withDeleteOption]="withDeleteOption"
+                                                 [defaultIdValue]="defaultIdValue"
+                                                 [withEmptyValue]="withEmptyValue"
+                                                 [values]="valuesList"
+                                                 [filter]="filter"
+                                                 [deleteIconClass]="deleteIconClass">
+                                </systelab-select>
+                            </div>
+                        </div>
+                    </div>
+				`,
+	standalone: false
 })
 export class ComboboxTestComponent {
 	@ViewChild('combobox') public combobox: ModulabSelect;
 	public filter = false;
-	public valuesList: TestData[] = [new TestData(0, 'Description 0'),new TestData('1', 'Description 1'), new TestData('2', 'Description 2')];
+	public valuesList: TestData[] = [new TestData(0, 'Description 0'), new TestData('1', 'Description 1'), new TestData('2', 'Description 2')];
 	public withEmptyValue = false;
 	public deleteIconClass = 'icon-close';
 	public defaultIdValue = undefined;
@@ -63,22 +63,19 @@ describe('Systelab Select Combobox', () => {
 				GridHeaderContextMenuComponent,
 				ComboBoxInputRendererComponent,
 				ModulabSelect,
-				ComboboxTestComponent,
+				ComboboxTestComponent
 			],
-			imports: [BrowserModule,
+			imports:      [BrowserModule,
 				BrowserAnimationsModule,
 				FormsModule,
 				OverlayModule,
 				ButtonModule,
 				SystelabTranslateModule,
 				SystelabPreferencesModule,
-				AgGridModule,
-			],
-			providers: [
-				provideHttpClient(withInterceptorsFromDi()),
-				provideZoneChangeDetection(),
-			]
-		}).compileComponents();
+				AgGridModule],
+			providers:    [provideHttpClient(withInterceptorsFromDi()), provideZoneChangeDetection()]
+		})
+			.compileComponents();
 	});
 
 	afterEach(() => {
@@ -122,46 +119,60 @@ describe('Systelab Select Combobox', () => {
 		expect(fixture.componentInstance.combobox._description).toEqual('Description 1');
 	});
 
-	it('should be able to focus in search input when the dropdown is opened and filter input is true', async ()  => {
+	it('should be able to focus in search input when the dropdown is opened and filter input is true', (done) => {
 		const fixture = setupWithFilter();
 		spyOn(fixture.componentInstance.combobox.filterInput.nativeElement, 'focus');
 		fixture.detectChanges();
 		clickButton(fixture);
-		await fixture.whenStable();
-		expect(fixture.componentInstance.combobox.filterInput.nativeElement.focus).toHaveBeenCalled();
+		fixture.whenStable()
+			.then(() => {
+				expect(fixture.componentInstance.combobox.filterInput.nativeElement.focus)
+					.toHaveBeenCalled();
+				done();
+			});
 	});
 
-	it('should not be able to focus in search input when the dropdown is opened and filter input is false', async () => {
+	it('should not be able to focus in search input when the dropdown is opened and filter input is false', (done) => {
 		const fixture = setupWithoutFilter();
 		fixture.detectChanges();
 		clickButton(fixture);
-		await fixture.whenStable();
-		expect(fixture.componentInstance.combobox.filterInput).toBeUndefined();
+		fixture.whenStable()
+			.then(() => {
+				expect(fixture.componentInstance.combobox.filterInput)
+					.toBeUndefined();
+				done();
+			});
 	});
 
-	it('should include an empty option when property withEmptyValue is set to true', async () => {
+	it('should include an empty option when property withEmptyValue is set to true', (done) => {
 		const fixture = setupWithoutFilter();
 		fixture.componentInstance.withEmptyValue = true;
 		fixture.detectChanges();
 		fixture.componentInstance.combobox.values = fixture.componentInstance.valuesList;
 		fixture.detectChanges();
 		clickButton(fixture);
-		await fixture.whenStable();
-		fixture.detectChanges();
-		expect(fixture.componentInstance.combobox._values.length).toEqual(4);
-
+		fixture.whenStable()
+			.then(() => {
+				fixture.detectChanges();
+				expect(fixture.componentInstance.combobox._values.length)
+					.toEqual(4);
+				done();
+			});
 	});
 
-	it('should not include an empty option when property withEmptyValue is set to false', async () => {
+	it('should not include an empty option when property withEmptyValue is set to false', (done) => {
 		const fixture = setupWithoutFilter();
 		clickButton(fixture);
 		fixture.detectChanges();
-		await fixture.whenStable();
-		expect(fixture.componentInstance.combobox._values.length).toEqual(3);
-
+		fixture.whenStable()
+			.then(() => {
+				expect(fixture.componentInstance.combobox._values.length)
+					.toEqual(3);
+				done();
+			});
 	});
 
-	it('should set delete icon to rubbish icon', async ()  => {
+	it('should set delete icon to rubbish icon', (done) => {
 		const fixture = setupWithoutFilter();
 		fixture.componentInstance.withEmptyValue = true;
 		fixture.componentInstance.defaultIdValue = 1;
@@ -171,12 +182,15 @@ describe('Systelab Select Combobox', () => {
 		clickButton(fixture);
 		fixture.componentInstance.selectValue('1');
 		fixture.detectChanges();
-		await fixture.whenStable();
-		expect(fixture.debugElement.nativeElement.querySelectorAll('.icon-trash').length).toEqual(1);
-
+		fixture.whenStable()
+			.then(() => {
+				expect(fixture.debugElement.nativeElement.querySelectorAll('.icon-trash').length)
+					.toEqual(1);
+				done();
+			});
 	});
 
-	it('should set the Description 0 element that has a zero number id', async () => {
+	it('should set the Description 0 element that has a zero number id', (done) => {
 		const fixture = setupWithoutFilter();
 		fixture.componentInstance.withEmptyValue = true;
 		fixture.componentInstance.defaultIdValue = '1';
@@ -185,8 +199,326 @@ describe('Systelab Select Combobox', () => {
 		clickButton(fixture);
 		fixture.componentInstance.selectValue(0);
 		fixture.detectChanges();
-		await fixture.whenStable();
-		expect(fixture.componentInstance.combobox._description).toEqual('Description 0');
+		fixture.whenStable()
+			.then(() => {
+				expect(fixture.componentInstance.combobox._description)
+					.toEqual('Description 0');
+				done();
+			});
+	});
+
+	describe('transferFocusToGrid', () => {
+
+		it('should deselect all rows when multipleSelection is false', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.deselectAll)
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should not deselect rows when multipleSelection is true', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = true;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.deselectAll)
+						.not
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should find and focus on the row matching the current id', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = '1';
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+
+					// Mock forEachNodeAfterFilterAndSort to simulate finding the row at index 1
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort')
+						.and
+						.callFake((callback: any) => {
+							// Simulate three rows, where the second one (index 1) matches the id '1'
+							callback({data: {id: 0}}, 0);
+							callback({data: {id: '1'}}, 1);
+							callback({data: {id: '2'}}, 2);
+						});
+
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.forEachNodeAfterFilterAndSort)
+						.toHaveBeenCalled();
+					expect(combobox.gridApi.setFocusedCell)
+						.toHaveBeenCalledWith(1, jasmine.anything());
+					done();
+				});
+		});
+
+		it('should ensure the selected row is visible when there are displayed rows', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = '1';
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([{isVisible: () => true}] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.ensureIndexVisible)
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should not ensure row visibility when there are no displayed rows', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(0);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.ensureIndexVisible)
+						.not
+						.toHaveBeenCalled();
+					done();
+				});
+		});
+
+		it('should scroll to the first visible column', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.ensureColumnVisible)
+						.toHaveBeenCalledWith(jasmine.anything());
+					done();
+				});
+		});
+
+		it('should set focus on the selected grid cell', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = '1';
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.setFocusedCell)
+						.toHaveBeenCalledWith(jasmine.any(Number), jasmine.anything());
+					done();
+				});
+		});
+
+		it('should focus on row index 0 when no id is set', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			clickButton(fixture);
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox._id = undefined;
+
+					// Ensure gridApi exists and has required methods
+					if (!combobox.gridApi) {
+						combobox.gridApi = {} as any;
+					}
+					const mockColumn = {isVisible: () => true};
+					combobox.gridApi.deselectAll = jasmine.createSpy('deselectAll');
+					combobox.gridApi.forEachNodeAfterFilterAndSort = jasmine.createSpy('forEachNodeAfterFilterAndSort');
+					combobox.gridApi.getDisplayedRowCount = jasmine.createSpy('getDisplayedRowCount')
+						.and
+						.returnValue(3);
+					combobox.gridApi.ensureIndexVisible = jasmine.createSpy('ensureIndexVisible');
+					combobox.gridApi.getColumns = jasmine.createSpy('getColumns')
+						.and
+						.returnValue([mockColumn] as any);
+					combobox.gridApi.ensureColumnVisible = jasmine.createSpy('ensureColumnVisible');
+					combobox.gridApi.setFocusedCell = jasmine.createSpy('setFocusedCell');
+
+					combobox['transferFocusToGrid']();
+
+					expect(combobox.gridApi.setFocusedCell)
+						.toHaveBeenCalledWith(0, jasmine.anything());
+					done();
+				});
+		});
+
+		it('should handle null gridApi gracefully', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox.gridApi = null;
+
+					expect(() => combobox['transferFocusToGrid']())
+						.not
+						.toThrow();
+					done();
+				});
+		});
+
+		it('should handle undefined gridApi gracefully', (done) => {
+			const fixture = setupWithoutFilter();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					combobox.multipleSelection = false;
+					combobox.gridApi = undefined;
+
+					expect(() => combobox['transferFocusToGrid']())
+						.not
+						.toThrow();
+					done();
+				});
+		});
+
 	});
 
 });

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -24,6 +24,7 @@ import { StylesUtilService } from '../utilities/styles.util.service';
 import { ComboboxFavouriteRendererComponent } from './renderer/combobox-favourite-renderer.component';
 import { PreferencesService } from 'systelab-preferences';
 import { AutosizeGridHelper, CalculatedGridState, initializeCalculatedGridState } from '../helper/autosize-grid-helper';
+import { ComboTreeNode } from './tree/abstract-api-tree-combobox.component';
 
 declare let jQuery: any;
 
@@ -327,13 +328,17 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		this.gridOptions.enableBrowserTooltips = true;
 	}
 
-	protected getRowNodeId(item: GetRowIdParams): string | number | undefined {
+	protected getRowNodeId(item: GetRowIdParams | ComboTreeNode<T>): string | number | undefined {
 		const id = this.getIdField();
 		if (item) {
-			if (item[this.getIdField()] != null) {
-				return item[this.getIdField()];
+			if (item[id] != null) {
+				return item[id];
 			}
-			return this.getIdField() === '' ? '' : item.data ? item.data?.[this.getIdField()] : '';
+			if ('data' in item) {
+				return id === '' ? '' : item.data ? item.data?.[id] : '';
+			} else {
+				return '';
+			}
 		}
 		return '';
 	}
@@ -482,19 +487,31 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 
 	protected transferFocusToGrid(): void {
 		// remove previous selection
-		if(!this.multipleSelection) {
+		if (!this.multipleSelection) {
 			this.gridApi?.deselectAll();
-			if(this.gridApi?.getDisplayedRowCount() > 0) {
-				// scrolls to the first row
-				this.gridApi?.ensureIndexVisible(0);
+
+			// Find the row index of the currently selected item
+			let rowIndexToFocus = 0;
+			if (this._id) {
+				this.gridApi?.forEachNodeAfterFilterAndSort((node, index) => {
+					if (this.getRowNodeId(node.data) === this._id) {
+						rowIndexToFocus = index;
+					}
+				});
+			}
+
+			if (this.gridApi?.getDisplayedRowCount() > 0) {
+				// scrolls to the selected row
+				this.gridApi?.ensureIndexVisible(rowIndexToFocus);
 			}
 
 			// scrolls to the first column
-			const firstCol = this.gridApi?.getColumns()?.filter(col => col.isVisible())[0];
+			const firstCol = this.gridApi?.getColumns()
+				?.filter(col => col.isVisible())[0];
 			this.gridApi?.ensureColumnVisible(firstCol);
 
-			// sets focus into the first grid cell
-			this.gridApi?.setFocusedCell(0, firstCol);
+			// sets focus into the selected grid cell
+			this.gridApi?.setFocusedCell(rowIndexToFocus, firstCol);
 		}
 	}
 

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.spec.ts
@@ -1,0 +1,558 @@
+import { ChangeDetectorRef, Component, inject, Renderer2 } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PreferencesService } from 'systelab-preferences';
+import { AbstractApiTreeComboBox } from './abstract-api-tree-combobox.component';
+
+interface TestNode {
+	data: {
+		level: number;
+		nodeData: {
+			parentId?: number;
+			childId?: number;
+		};
+	};
+	isSelected?: () => boolean;
+	setSelected?: (value: boolean) => void;
+}
+
+/* =========================================================
+ * Clase concreta SOLO para test
+ * ========================================================= */
+class TestApiTreeComboBox extends AbstractApiTreeComboBox<{
+	parentId: number;
+	childId: number;
+	descParent: string;
+	descChild: string;
+}> {
+
+	constructor(
+		renderer: Renderer2,
+		cdr: ChangeDetectorRef,
+		prefs: PreferencesService
+	) {
+		super(renderer, cdr, prefs);
+	}
+
+	getData() {
+		return of([
+			{parentId: 1, childId: 10, descParent: 'P1', descChild: 'C1'},
+			{parentId: 1, childId: 11, descParent: 'P1', descChild: 'C2'},
+			{parentId: 2, childId: 20, descParent: 'P2', descChild: 'C3'}
+		]);
+	}
+
+	getTotalItems(): number {
+		return 3;
+	}
+
+	getLevelDescriptionField(level: number): string {
+		return level === 0 ? 'descParent' : 'descChild';
+	}
+
+	getLevelIdField(level: number): string {
+		return level === 0 ? 'parentId' : 'childId';
+	}
+
+	// Override getIdField to delegate to getLevelIdField for the tree structure
+	override getIdField(level?: number): string {
+		if (level !== undefined) {
+			return this.getLevelIdField(level);
+		}
+		return '';
+	}
+
+	getAllNodeId() {
+		return 'ALL';
+	}
+
+	getAllNodeDescription() {
+		return 'All';
+	}
+
+	getSelectionPrefix(): string {
+		return '#';
+	}
+
+	/* ===== Wrappers públicos para métodos protected ===== */
+
+	public testSelectUnselectChildTree(event: unknown) {
+		this.selectUnselectChildTree(event);
+	}
+
+	public testSelectUnselectParentTree(event: unknown) {
+		this.selectUnselectParentTree(event);
+	}
+
+	public testAddRemoveToMultipleSelectedItem(event: unknown) {
+		this.addRemoveToMultipleSelectedItem(event);
+	}
+}
+
+/* =========================================================
+ * Host component
+ * ========================================================= */
+@Component({
+	template:   '',
+	standalone: false
+})
+class TestHostComponent extends TestApiTreeComboBox {
+
+	constructor() {
+		super(
+			inject(Renderer2),
+			inject(ChangeDetectorRef),
+			inject(PreferencesService)
+		);
+	}
+}
+
+describe('AbstractApiTreeComboBox', () => {
+
+	let fixture: ComponentFixture<TestHostComponent>;
+	let component: TestHostComponent;
+	let preferences: jasmine.SpyObj<PreferencesService>;
+	let gridNodes: TestNode[];
+
+	beforeEach(() => {
+		preferences = jasmine.createSpyObj<PreferencesService>('PreferencesService', ['get', 'put']);
+		gridNodes = [];
+
+		TestBed.configureTestingModule({
+			declarations: [TestHostComponent],
+			providers:    [
+				{provide: PreferencesService, useValue: preferences}
+			]
+		});
+
+		fixture = TestBed.createComponent(TestHostComponent);
+		component = fixture.componentInstance;
+
+		// Mock ElementRef for comboboxElement and dropdownElement
+		component.comboboxElement = {
+			nativeElement: {
+				className:   '',
+				offsetWidth: 200
+			}
+		} as any;
+
+		component.dropdownElement = {
+			nativeElement: {
+				offsetWidth: 200
+			}
+		} as any;
+
+		component.gridApi = {
+			forEachNode:          (cb: (node: TestNode) => void) => gridNodes.forEach(cb),
+			hideOverlay:          jasmine.createSpy(),
+			redrawRows:           jasmine.createSpy(),
+			getDisplayedRowCount: () => gridNodes.length
+		} as unknown as typeof component.gridApi;
+	});
+
+	it('should create', () => {
+		expect(component)
+			.toBeTruthy();
+	});
+
+	it('should generate label with padding', () => {
+		const label = component.getLabelForLevel({
+			level:    2,
+			nodeData: {descChild: 'Child'} as any
+		});
+
+		expect(label)
+			.toContain('padding-left: 40px');
+		expect(label)
+			.toContain('Child');
+	});
+
+	it('should select children when parent is selected', () => {
+		const childNode: TestNode = {
+			data:        {level: 1, nodeData: {parentId: 1}},
+			setSelected: jasmine.createSpy()
+		};
+
+		gridNodes = [childNode];
+
+		component.testSelectUnselectChildTree({
+			node: {
+				isSelected: () => true,
+				data:       {nodeData: {parentId: 1}}
+			}
+		});
+
+		expect(childNode.setSelected)
+			.toHaveBeenCalledWith(true);
+	});
+
+	it('should add and remove from multipleSelectedItemList', () => {
+		component.multipleSelectedItemList = [];
+
+		const event = {
+			node: {
+				isSelected: () => true,
+				data:       {nodeData: {childId: 10}}
+			}
+		};
+
+		component.testAddRemoveToMultipleSelectedItem(event);
+		expect(component.multipleSelectedItemList.length)
+			.toBe(1);
+
+		event.node.isSelected = () => false;
+		component.testAddRemoveToMultipleSelectedItem(event);
+		expect(component.multipleSelectedItemList.length)
+			.toBe(0);
+	});
+
+	it('should call getData when getRows is executed', (done) => {
+		const getDataSpy = spyOn(component, 'getData')
+			.and
+			.callThrough();
+
+		component.getRows()
+			.subscribe(() => {
+				expect(getDataSpy)
+					.toHaveBeenCalled();
+				done();
+			});
+	});
+
+	it('should map getData result into ComboTreeNode structure', (done) => {
+		component.getRows()
+			.subscribe(nodes => {
+				const parent = nodes.find(n => n.level === 0 && n.nodeData.parentId === 1);
+				const child = nodes.find(n => n.level === 1 && n.nodeData.childId === 10);
+
+				expect(parent)
+					.toBeDefined();
+				expect(child)
+					.toBeDefined();
+				done();
+			});
+	});
+
+	it('should update internal flags when rows are loaded', (done) => {
+		component.isFirstTime = true;
+		component.totalItemsLoaded = false;
+
+		component.getRows()
+			.subscribe(() => {
+				expect(component.isFirstTime)
+					.toBeFalse();
+				expect(component.totalItemsLoaded)
+					.toBeTrue();
+				done();
+			});
+	});
+
+	it('should select parent when all children are selected', () => {
+		const parentNode: TestNode = {
+			data:        {
+				level:    0,
+				nodeData: {childId: 1}
+			},
+			isSelected:  jasmine.createSpy()
+							 .and
+							 .returnValue(false),
+			setSelected: jasmine.createSpy()
+		};
+
+		const child1: TestNode = {
+			data:        {
+				level:    1,
+				nodeData: {parentId: 1}
+			},
+			isSelected:  jasmine.createSpy()
+							 .and
+							 .returnValue(true),
+			setSelected: jasmine.createSpy()
+		};
+
+		const child2: TestNode = {
+			data:        {
+				level:    1,
+				nodeData: {parentId: 1}
+			},
+			isSelected:  jasmine.createSpy()
+							 .and
+							 .returnValue(true),
+			setSelected: jasmine.createSpy()
+		};
+
+		gridNodes = [child1, child2, parentNode];
+
+		component.testSelectUnselectParentTree({
+			node: {
+				data: {nodeData: {parentId: 1}}
+			}
+		});
+
+		expect(parentNode.setSelected)
+			.toHaveBeenCalledWith(true);
+	});
+
+	it('should unselect parent when not all children are selected', () => {
+		const parentNode: TestNode = {
+			data:        {
+				level:    0,
+				nodeData: {childId: 1}
+			},
+			isSelected:  jasmine.createSpy()
+							 .and
+							 .returnValue(true),
+			setSelected: jasmine.createSpy()
+		};
+
+		const child1: TestNode = {
+			data:        {
+				level:    1,
+				nodeData: {parentId: 1}
+			},
+			isSelected:  jasmine.createSpy()
+							 .and
+							 .returnValue(true),
+			setSelected: jasmine.createSpy()
+		};
+
+		const child2: TestNode = {
+			data:        {
+				level:    1,
+				nodeData: {parentId: 1}
+			},
+			isSelected:  jasmine.createSpy()
+							 .and
+							 .returnValue(false),
+			setSelected: jasmine.createSpy()
+		};
+
+		gridNodes = [child1, child2, parentNode];
+
+		component.testSelectUnselectParentTree({
+			node: {
+				data: {nodeData: {parentId: 1}}
+			}
+		});
+
+		expect(parentNode.setSelected)
+			.toHaveBeenCalledWith(false);
+	});
+
+	describe('transferFocusToGrid', () => {
+
+		it('should find and focus on the correct tree node matching the current id', () => {
+			component.multipleSelection = false;
+			component._id = 11; // childId to search for (number type to match the mock data)
+
+			// Create mock tree nodes - node.data should be the ComboTreeNode with level and nodeData
+			// The getRowNodeId method will first check item[idField] (e.g., item['childId'])
+			// For level 0: idField is 'parentId', for level 1: idField is 'childId'
+			const mockTreeNodes = [
+				{
+					data: {
+						level:    0,
+						nodeData: {parentId: 1, descParent: 'Parent 1', descChild: ''},
+						// For level 0, the id comes from parentId
+						parentId: 1
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 10, descParent: 'Parent 1', descChild: 'Child 1'},
+						// For level 1, the id comes from childId
+						childId: 10
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 11, descParent: 'Parent 1', descChild: 'Child 2'},
+						// For level 1, the id comes from childId - THIS SHOULD MATCH _id = 11
+						childId: 11
+					}
+				},
+				{
+					data: {
+						level:    0,
+						nodeData: {parentId: 2, descParent: 'Parent 2', descChild: ''},
+						// For level 0, the id comes from parentId
+						parentId: 2
+					}
+				}
+			];
+
+			const mockColumn = {isVisible: () => true};
+
+			// Setup gridApi with all required methods
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort')
+												   .and
+												   .callFake((callback: any) => {
+													   mockTreeNodes.forEach((node, index) => {
+														   callback(node, index);
+													   });
+												   }),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount')
+												   .and
+												   .returnValue(4),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns')
+												   .and
+												   .returnValue([mockColumn] as any),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			expect(component.gridApi.deselectAll)
+				.toHaveBeenCalled();
+
+			expect(component.gridApi.forEachNodeAfterFilterAndSort)
+				.toHaveBeenCalled();
+
+			expect(component.gridApi.ensureIndexVisible)
+				.toHaveBeenCalled();
+
+			expect(component.gridApi.ensureColumnVisible)
+				.toHaveBeenCalled();
+
+			// Verify setFocusedCell was called with index 2 (the third node, which has childId: 11)
+			expect(component.gridApi.setFocusedCell)
+				.toHaveBeenCalledWith(2, jasmine.anything());
+		});
+
+		it('should focus on row index 0 when no matching tree node id is found', () => {
+			component.multipleSelection = false;
+			component._id = 999; // Non-existent childId
+
+			const mockTreeNodes = [
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 10, descParent: 'Parent 1', descChild: 'Child 1'},
+						childId:  10
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 11, descParent: 'Parent 1', descChild: 'Child 2'},
+						childId:  11
+					}
+				}
+			];
+
+			const mockColumn = {isVisible: () => true};
+
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort')
+												   .and
+												   .callFake((callback: any) => {
+													   mockTreeNodes.forEach((node, index) => {
+														   callback(node, index);
+													   });
+												   }),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount')
+												   .and
+												   .returnValue(2),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns')
+												   .and
+												   .returnValue([mockColumn] as any),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			// Should focus on index 0 when no match is found
+			expect(component.gridApi.setFocusedCell)
+				.toHaveBeenCalledWith(0, jasmine.anything());
+		});
+
+		it('should handle tree nodes with parent-level ids correctly', () => {
+			component.multipleSelection = false;
+			component._id = 1; // parentId to search for
+
+			const mockTreeNodes = [
+				{
+					data: {
+						level:    0,
+						nodeData: {parentId: 1, descParent: 'Parent 1', descChild: ''},
+						parentId: 1
+					}
+				},
+				{
+					data: {
+						level:    1,
+						nodeData: {parentId: 1, childId: 10, descParent: 'Parent 1', descChild: 'Child 1'},
+						childId:  10
+					}
+				}
+			];
+
+			const mockColumn = {isVisible: () => true};
+
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort')
+												   .and
+												   .callFake((callback: any) => {
+													   mockTreeNodes.forEach((node, index) => {
+														   callback(node, index);
+													   });
+												   }),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount')
+												   .and
+												   .returnValue(2),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns')
+												   .and
+												   .returnValue([mockColumn] as any),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			// Should find the parent node at index 0
+			expect(component.gridApi.setFocusedCell)
+				.toHaveBeenCalledWith(0, jasmine.anything());
+		});
+
+		it('should not perform focus operations when multipleSelection is true', () => {
+			component.multipleSelection = true;
+			component._id = 11;
+
+			component.gridApi = {
+				deselectAll:                   jasmine.createSpy('deselectAll'),
+				forEachNodeAfterFilterAndSort: jasmine.createSpy('forEachNodeAfterFilterAndSort'),
+				getDisplayedRowCount:          jasmine.createSpy('getDisplayedRowCount'),
+				ensureIndexVisible:            jasmine.createSpy('ensureIndexVisible'),
+				getColumns:                    jasmine.createSpy('getColumns'),
+				ensureColumnVisible:           jasmine.createSpy('ensureColumnVisible'),
+				setFocusedCell:                jasmine.createSpy('setFocusedCell')
+			} as unknown as typeof component.gridApi;
+
+			component['transferFocusToGrid']();
+
+			// None of the methods should be called when multipleSelection is true
+			expect(component.gridApi.deselectAll)
+				.not
+				.toHaveBeenCalled();
+			expect(component.gridApi.forEachNodeAfterFilterAndSort)
+				.not
+				.toHaveBeenCalled();
+			expect(component.gridApi.setFocusedCell)
+				.not
+				.toHaveBeenCalled();
+		});
+
+	});
+
+});

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
@@ -3,7 +3,7 @@ import { AgRendererComponent } from 'ag-grid-angular';
 import { AbstractComboBox } from '../abstract-combobox.component';
 import { map, Observable } from 'rxjs';
 import { PreferencesService } from 'systelab-preferences';
-import { GridOptions, GridReadyEvent } from 'ag-grid-community';
+import { GetRowIdParams, GridOptions, GridReadyEvent } from 'ag-grid-community';
 
 declare var jQuery: any;
 
@@ -28,6 +28,7 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 	public totalItemsLoaded = false;
 	public isFirstTime = true;
 	public override isTree = true;
+	public modelUpdated = false;
 
 	protected constructor(public override myRenderer: Renderer2, public chref: ChangeDetectorRef, public override preferencesService?: PreferencesService) {
 		super(myRenderer, chref, preferencesService);
@@ -46,7 +47,9 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 				colId:        'itemDescription',
 				cellRenderer: (params: any) => {
 					return this.getLabelForLevel(params.data);
-				}
+				},
+				cellStyle:    () => this.multipleSelection ? ({paddingLeft: '0px'}) : null,
+				width:        '100%'
 			}
 		];
 
@@ -57,9 +60,9 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 		this.gridOptions.rowHeight = AbstractComboBox.ROW_HEIGHT;
 		this.gridOptions.headerHeight = 0;
 		this.gridOptions.rowSelection = {
-			checkboxes: false,
-			mode: 'singleRow',
-			enableClickSelection: true
+			checkboxes:           this.multipleSelection,
+			mode:                 this.multipleSelection ? 'multiRow' : 'singleRow',
+			enableClickSelection: !this.multipleSelection
 		};
 	}
 
@@ -67,15 +70,15 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 		return new ComboTreeNode<T>();
 	}
 
-	getDescriptionField(): string {
+	getDescriptionField(level?): string {
 		return '';
 	}
 
-	getCodeField(): string {
+	getCodeField(level?): string {
 		return '';
 	}
 
-	getIdField(): string {
+	getIdField(level?): string {
 		return '';
 	}
 
@@ -111,21 +114,42 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 
 	public override doGridReady(event: GridReadyEvent) {
 		super.doGridReady(event);
-		this.getRows().subscribe({
-			next: (nodeVector) => {
-				this.gridApi.hideOverlay();
-				this.rowData = nodeVector;
-				this.gridApi.redrawRows();
-				if (this.totalItemsLoaded) {
-					this.setDropdownHeight(nodeVector.length);
-					this.setDropdownPosition();
-					this.transferFocusToGrid();
+		this.getRows()
+			.subscribe({
+				next:  (nodeVector) => {
+					if (this.multipleSelection) {
+						this.isAllSelectable = false;
+						this.allElement = false;
+					}
+					this.gridApi.hideOverlay();
+					this.rowData = nodeVector;
+					this.gridApi.redrawRows();
+					if (this.totalItemsLoaded) {
+						this.setDropdownHeight(nodeVector.length);
+						this.setDropdownPosition();
+						setTimeout(() => {
+							this.transferFocusToGrid();
+						});
+					}
+				},
+				error: () => {
+					this.gridApi.hideOverlay();
 				}
-			},
-			error: () => {
-				this.gridApi.hideOverlay();
+			})
+	}
+
+	public override onModelUpdated(): void {
+		if (this.multipleSelection) {
+			if (this.multipleSelectedItemList && this.multipleSelectedItemList.length > 0) {
+				this.gridApi?.forEachNode(node => {
+					if (this.multipleSelectedItemList.some((item) =>
+						(item !== undefined && node.data.nodeData !== undefined && item[this.getIdField(1)] === node.data.nodeData[this.getIdField(1)]))) {
+						node.setSelected(true);
+						this.modelUpdated = true;
+					}
+				});
 			}
-		})
+		}
 	}
 
 	// Override
@@ -152,56 +176,59 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 	public getRows(): Observable<ComboTreeNode<T>[]> {
 		this.totalItemsLoaded = false;
 		this.isFirstTime = false;
-		return this.getData().pipe(
-			map((dataVector: Array<T>) => {
-				const nodeVector: Array<ComboTreeNode<T>> = [];
-				let previousParent: number | string;
+		return this.getData()
+			.pipe(
+				map((dataVector: Array<T>) => {
+					const nodeVector: Array<ComboTreeNode<T>> = [];
+					let previousParent: number | string;
 
-				if (this.emptyElement) {
-					const emptyElement: T = {} as T;
-					emptyElement[this.getLevelIdField(0)] = '';
-					emptyElement[this.getLevelDescriptionField(0)] = '';
-					const emptyElementNode: ComboTreeNode<T> = new ComboTreeNode<T>(emptyElement, 0);
-					nodeVector.push(emptyElementNode);
-				}
-
-				if (this.withFavourites) {
-					this.initializeFavouriteList();
-					if (this.favouriteList.length > 0) {
-						const favouriteElement: T = {} as T;
-						favouriteElement[this.getLevelIdField(0)] = AbstractApiTreeComboBox.FAVOURITEID;
-						favouriteElement[this.getLevelDescriptionField(0)] = this.getFavouriteText();
-						const favouriteComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(favouriteElement, 0);
-						nodeVector.push(favouriteComboNode);
-						const favouriteElements = this.getFavouriteElements(dataVector);
-						favouriteElements.forEach(currentFavouriteElement => {
-							const currentFavouriteNode: ComboTreeNode<T> = new ComboTreeNode<T>(currentFavouriteElement, 1);
-							nodeVector.push(currentFavouriteNode);
-						});
+					if (this.emptyElement) {
+						const emptyElement: T = {} as T;
+						emptyElement[this.getLevelIdField(0)] = '';
+						emptyElement[this.getLevelDescriptionField(0)] = '';
+						const emptyElementNode: ComboTreeNode<T> = new ComboTreeNode<T>(emptyElement, 0);
+						nodeVector.push(emptyElementNode);
 					}
-				}
 
-				if (this.isAllSelectable) {
-					const allElement: T = {} as T;
-					allElement[this.getLevelIdField(0)] = this.getAllNodeId();
-					allElement[this.getLevelDescriptionField(0)] = this.getAllNodeDescription();
-					const allComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(allElement, 0);
-					nodeVector.push(allComboNode);
-				}
-
-				dataVector.forEach((element: T) => {
-					if (!previousParent || element[this.getLevelIdField(0)] !== previousParent) {
-						previousParent = element[this.getLevelIdField(0)];
-						const parentComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(element, 0);
-						nodeVector.push(parentComboNode);
+					if (this.withFavourites) {
+						this.initializeFavouriteList();
+						if (this.favouriteList.length > 0) {
+							const favouriteElement: T = {} as T;
+							favouriteElement[this.getLevelIdField(0)] = AbstractApiTreeComboBox.FAVOURITEID;
+							favouriteElement[this.getLevelDescriptionField(0)] = this.getFavouriteText();
+							const favouriteComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(favouriteElement, 0);
+							nodeVector.push(favouriteComboNode);
+							const favouriteElements = this.getFavouriteElements(dataVector);
+							if(favouriteElements?.length > 0) {favouriteElements.forEach(currentFavouriteElement => {
+								const currentFavouriteNode: ComboTreeNode<T> = new ComboTreeNode<T>(currentFavouriteElement, 1);
+								nodeVector.push(currentFavouriteNode);});
+							} else {
+								nodeVector.pop();
+							}
+						}
 					}
-					const comboNode: ComboTreeNode<T> = new ComboTreeNode<T>(element, 1);
-					nodeVector.push(comboNode);
-				});
-				this.totalItemsLoaded = true;
-				return nodeVector;
-			})
-		)
+
+					if (this.isAllSelectable) {
+						const allElement: T = {} as T;
+						allElement[this.getLevelIdField(0)] = this.getAllNodeId();
+						allElement[this.getLevelDescriptionField(0)] = this.getAllNodeDescription();
+						const allComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(allElement, 0);
+						nodeVector.push(allComboNode);
+					}
+
+					dataVector.forEach((element: T) => {
+						if (!previousParent || element[this.getLevelIdField(0)] !== previousParent) {
+							previousParent = element[this.getLevelIdField(0)];
+							const parentComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(element, 0);
+							nodeVector.push(parentComboNode);
+						}
+						const comboNode: ComboTreeNode<T> = new ComboTreeNode<T>(element, 1);
+						nodeVector.push(comboNode);
+					});
+					this.totalItemsLoaded = true;
+					return nodeVector;
+				})
+			)
 	}
 
 	// Overrides
@@ -235,43 +262,108 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 
 	// Overrides
 	public override onRowSelected(event: any) {
-		if (event.node.selected) {
-			if (this.isParentSelectable && event.node.data.nodeData[this.getLevelIdField(0)] !== AbstractApiTreeComboBox.FAVOURITEID) {
-				jQuery('#' + this.comboId)
-					.dropdown('toggle');
-			} else if (this.isAllSelectable && event.node && event.node.data && event.node.data.level === 0) {
-				if (event.node.data.nodeData[this.getLevelIdField(0)] === this.getAllNodeId()) {
-					jQuery('#' + this.comboId)
-						.dropdown('toggle');
-				} else {
-					event.node.setSelected(false);
-				}
-			} else if (event.node && event.node.data && event.node.data.level > 0) {
+		if (this.multipleSelection) {
+			if (this.modelUpdated && event.source === 'api') {
+				return;
+			} else if (event.source !== 'api') {
+				this.modelUpdated = false;
+			}
+
+			this.addRemoveToMultipleSelectedItem(event);
+
+			if (event.source === 'api') {
+				return;
+			}
+			if (event.node.data.level === 0) {
+				this.selectUnselectChildTree(event);
+			} else {
+				this.selectUnselectParentTree(event);
+			}
+
+		} else if (event.node.selected) {
+			const isParent = this.isParentSelectable && event.node.data.nodeData[this.getLevelIdField(0)] !== AbstractApiTreeComboBox.FAVOURITEID;
+			const isAll = this.isAllSelectable && event.node.data.level === 0 && event.node.data.nodeData[this.getLevelIdField(0)] === this.getAllNodeId();
+			const isChild = event.node.data.level > 0;
+
+			if (isParent || isAll || isChild) {
 				jQuery('#' + this.comboId)
 					.dropdown('toggle');
 			} else {
-				if (event.node) {
-					event.node.setSelected(false);
-				}
+				event.node.setSelected(false);
 			}
 		}
 	}
 
+	protected addRemoveToMultipleSelectedItem(event: any) {
+		const elementIndexInSelectedList: number = this.multipleSelectedItemList.findIndex((item) => {
+			return item[this.getIdField(1)] === event.node.data.nodeData[this.getIdField(1)];
+		});
+		if (event.node.isSelected()) {
+			if (elementIndexInSelectedList < 0) {
+				this.multipleSelectedItemList.push(event.node.data.nodeData);
+				this.multipleSelectedItemList = this.multipleSelectedItemList.slice();
+			}
+		} else if (elementIndexInSelectedList >= 0) {
+			this.multipleSelectedItemList.splice(elementIndexInSelectedList, 1);
+			this.multipleSelectedItemList = this.multipleSelectedItemList.slice();
+		}
+
+	}
+
+	protected selectUnselectChildTree(event: any) {
+		this.gridApi?.forEachNode(node => {
+			if (node?.data.level === 1 && node.data.nodeData[this.getIdField(0)] === event.node.data.nodeData[this.getIdField(0)]) {
+				node.setSelected(event.node.isSelected());
+			}
+		});
+	}
+
+	protected selectUnselectParentTree(event: any) {
+		const parentId = event.node?.data?.nodeData[this.getIdField(0)];
+		let allChildrenSelected = true;
+
+		this.gridApi?.forEachNode(node => {
+			if (
+				node?.data.level === 1 &&
+				node.data.nodeData[this.getIdField(0)] === parentId
+			) {
+				if (!node.isSelected()) {
+					allChildrenSelected = false;
+				}
+			}
+		});
+
+		this.gridApi?.forEachNode(node => {
+			if (
+				node?.data.level === 0 &&
+				node.data.nodeData[this.getIdField(1)] === parentId
+			) {
+				if (node.isSelected() !== allChildrenSelected) {
+					node.setSelected(allChildrenSelected);
+				}
+			}
+		});
+	}
+
 	// Overrides
 	public override onSelectionChanged(event: any) {
-		const selectedRow = this.getSelectedRow();
-		if (selectedRow !== null && selectedRow !== undefined) {
-			this.id = selectedRow.nodeData[this.getLevelIdField(selectedRow.level)];
-			this.description = selectedRow.nodeData[this.getLevelDescriptionField(selectedRow.level)];
-			this.currentSelected = selectedRow.nodeData;
-			this.level = selectedRow.level;
-			if (selectedRow.level > 0
-				|| (this.isAllSelectable && selectedRow.nodeData[this.getLevelIdField(0)] === this.getAllNodeId())
-				|| this.isParentSelectable) {
-				this.change.emit(selectedRow.nodeData);
-				this.idChange.emit(this.id);
-				this.closeDropDown();
+		if (!this.multipleSelection) {
+			const selectedRow = this.getSelectedRow();
+			if (selectedRow !== null && selectedRow !== undefined) {
+				this.id = selectedRow.nodeData[this.getLevelIdField(selectedRow.level)];
+				this.description = selectedRow.nodeData[this.getLevelDescriptionField(selectedRow.level)];
+				this.currentSelected = selectedRow.nodeData;
+				this.level = selectedRow.level;
+				if (selectedRow.level > 0
+					|| (this.isAllSelectable && selectedRow.nodeData[this.getLevelIdField(0)] === this.getAllNodeId())
+					|| this.isParentSelectable) {
+					this.change.emit(selectedRow.nodeData);
+					this.idChange.emit(this.id);
+					this.closeDropDown();
+				}
 			}
+		} else {
+			this.selectionChanged = true;
 		}
 	}
 
@@ -285,5 +377,22 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 	private getFavouriteElements(dataVector: Array<T>): Array<T> {
 		return dataVector.filter((data: T) => this.favouriteList.map(String)
 			.includes(data[this.getLevelIdField(1)].toString()));
+	}
+
+	protected override getRowNodeId(item: GetRowIdParams | ComboTreeNode<ComboTreeNode<T>>): string | number | undefined {
+
+		if ('nodeData' in item) {
+			const id = this.getLevelIdField(item.level);
+
+			if (item[id] != null) {
+				return item[id];
+			}
+
+			return id === ''
+				? ''
+				: item.nodeData?.[id] ?? '';
+		}
+
+		return '';
 	}
 }

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.html
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.html
@@ -9,6 +9,7 @@
   [selectOtherMonths]="selectOtherMonths"
   [minDate]="minDate"
   [focusTrap]="false"
+              [autofocus]="autofocus"
   [maxDate]="maxDate"
   [inline]="inline"
   [keepInvalid]="keepInvalid"

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -1,15 +1,4 @@
-import {
-	AfterViewInit,
-	Component,
-	DoCheck,
-	ElementRef,
-	EventEmitter,
-	Input,
-	OnInit,
-	Output,
-	Renderer2,
-	ViewChild
-} from '@angular/core';
+import { AfterViewInit, Component, DoCheck, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
 import { addDays } from 'date-fns';
 import { DatePicker } from 'primeng/datepicker';
 import { I18nService } from 'systelab-translate';
@@ -17,10 +6,10 @@ import { DataTransformerService } from './date-transformer.service';
 import { PrimeNG } from 'primeng/config';
 
 @Component({
-    selector: 'systelab-datepicker',
-    templateUrl: 'datepicker.component.html',
-    providers: [DataTransformerService],
-    standalone: false
+	selector:    'systelab-datepicker',
+	templateUrl: 'datepicker.component.html',
+	providers:   [DataTransformerService],
+	standalone:  false
 })
 export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 
@@ -104,18 +93,19 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		if (!this.inline) {
 			this.addIconToDatepicker();
 		}
-		
+
 		if (this.currentCalendar && this.autofocus) {
 			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
 			if (inputElement) {
 				inputElement.focus();
 			}
 		}
-		
-		if (this.tabindex && this.currentCalendar) {
+
+		if (this.currentCalendar) {
 			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
 			if (inputElement) {
-				inputElement.setAttribute('tabindex', this.tabindex.toString());
+				const tabindexValue = this.tabindex ?? 0;
+				inputElement.setAttribute('tabindex', tabindexValue.toString());
 			}
 		}
 	}
@@ -126,7 +116,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		}
 
 		const datepickerElement = this.currentCalendar.el.nativeElement;
-		
+
 		// Función que intenta agregar el icono
 		const attemptAddIcon = (): boolean => {
 			const inputElement = datepickerElement.querySelector('input');
@@ -135,7 +125,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 			}
 
 			const parentWrapper = inputElement.parentElement;
-			
+
 			// Verificar si ya existe un icono
 			if (parentWrapper.querySelector('i.icon-calendar, i.icon-clock')) {
 				return true;
@@ -144,12 +134,12 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 			// Crear y configurar el icono
 			const iconElement = document.createElement('i');
 			iconElement.className = this.onlyTime ? 'icon-clock' : 'icon-calendar';
-			
+
 			// Configurar el contenedor
 			parentWrapper.classList.add('slab-form-icon', 'w-100');
 			parentWrapper.style.position = 'relative';
 			parentWrapper.appendChild(iconElement);
-			
+
 			return true;
 		};
 
@@ -172,8 +162,8 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 
 		// Observar cambios en el elemento datepicker
 		observer.observe(datepickerElement, {
-			childList: true,
-			subtree: true,
+			childList:  true,
+			subtree:    true,
 			attributes: true
 		});
 
@@ -226,7 +216,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 										this.infereDate(dateStr);
 										break;
 									case 2:
-										const hourPosition = splitDateByHours[0].length-2;
+										const hourPosition = splitDateByHours[0].length - 2;
 										const dateString = splitDateByHours[0].substring(0, hourPosition);
 										this.infereDate(dateString);
 										this.parseTime(+splitDateByHours[0].substring(hourPosition), +splitDateByHours[1]);
@@ -291,7 +281,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	public repositionateCalendar(element?: ElementRef): void {
 
 		try {
-			const { inputElementTop, inputElementHeight, datepickerElementHeight } = this.inputElement.nativeElement.getBoundingClientRect();
+			const {inputElementTop, inputElementHeight, datepickerElementHeight} = this.inputElement.nativeElement.getBoundingClientRect();
 			if (inputElementTop + inputElementHeight + datepickerElementHeight > window.innerHeight) {
 				const newTop: number = inputElementTop + inputElementHeight - (datepickerElementHeight + inputElementHeight + 10);
 				this.myRenderer.setAttribute(element.nativeElement, 'top', newTop + 'px');


### PR DESCRIPTION
# PR Details

Some pending updates to master from 20.1.x

Added autofocus to false by default to prevent some random openings of the datepicker.
In comboboxes after open the dropdown always the first element is selected even if there is some element previous selected


## Description

Changed transferFocusToGrid to select grid node of the element is there is some element selected, otherwise the first element is selected
Remove the favourite node if it is empty

## Related Issues

https://github.com/systelab/systelab-components/issues/1133
https://github.com/systelab/systelab-components/issues/1130
https://github.com/systelab/systelab-components/issues/1135

## Motivation and Context

Trying to do a better world

## How Has This Been Tested

Testing in showcase:

Before:
<img width="397" height="524" alt="image" src="https://github.com/user-attachments/assets/48ba78af-36cc-4a58-aa34-361d596d7854" />

After:
<img width="321" height="458" alt="image" src="https://github.com/user-attachments/assets/ceea5833-dc29-4b96-8363-1d6ba140c2e1" />



Added unittests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


