### PR TITLE
Bug 1147 search component

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.20",
+  "version": "20.1.21",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.1.21",
+  "version": "20.1.22",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
@@ -197,9 +197,11 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 							const favouriteComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(favouriteElement, 0);
 							nodeVector.push(favouriteComboNode);
 							const favouriteElements = this.getFavouriteElements(dataVector);
-							if(favouriteElements?.length > 0) {favouriteElements.forEach(currentFavouriteElement => {
-								const currentFavouriteNode: ComboTreeNode<T> = new ComboTreeNode<T>(currentFavouriteElement, 1);
-								nodeVector.push(currentFavouriteNode);});
+							if (favouriteElements?.length > 0) {
+								favouriteElements.forEach(currentFavouriteElement => {
+									const currentFavouriteNode: ComboTreeNode<T> = new ComboTreeNode<T>(currentFavouriteElement, 1);
+									nodeVector.push(currentFavouriteNode);
+								});
 							} else {
 								nodeVector.pop();
 							}
@@ -215,7 +217,7 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 					}
 
 					dataVector.forEach((element: T) => {
-						if (!previousParent || element[this.getLevelIdField(0)] !== previousParent) {
+						if (previousParent == undefined || element[this.getLevelIdField(0)] !== previousParent) {
 							previousParent = element[this.getLevelIdField(0)];
 							const parentComboNode: ComboTreeNode<T> = new ComboTreeNode<T>(element, 0);
 							nodeVector.push(parentComboNode);

--- a/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
@@ -28,7 +28,12 @@ export class SearcherTableComponent<T> extends AbstractApiGrid<T> implements OnI
 		super.ngOnInit();
 		this.gridOptions.enableBrowserTooltips = true;
 		this.gridOptions.suppressCellFocus = false;
-		this.gridOptions.onCellKeyDown = this.onEnterPressedCallback()
+		this.gridOptions.onCellKeyDown = this.onEnterPressedCallback();
+		if (!this.searcher.infiniteScroll) {
+			this.gridOptions.paginationPageSize = 100000;
+			this.gridOptions.cacheBlockSize = 100000;
+		}
+
 	}
 
 	protected getColumnDefs(): Array<any> {
@@ -37,14 +42,6 @@ export class SearcherTableComponent<T> extends AbstractApiGrid<T> implements OnI
 
 	protected override hideHeader(): boolean {
 		return this.searcher.hideHeader();
-	}
-
-	public override doGridReady(event: any) {
-		super.doGridReady(event);
-		this.gridReady.emit(true);
-		if (!this.searcher.infiniteScroll) {
-			this.gridApi.updateGridOptions({paginationPageSize: 100000, cacheBlockSize: 100000});
-		}
 	}
 
 	protected override getIsFullWidthRow(isFullWidthRowParams: IsFullWidthRowParams): boolean {


### PR DESCRIPTION
# PR Details

Avoid repeated calls to get data in searcher dialog

## Description

Removed grid event emit and update of gridoptions in the gridready that causes another getRow call

## Related Issue
https://github.com/systelab/systelab-components/issues/1147

## Motivation and Context

To do a better World

## How Has This Been Tested

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation 
- [] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x ] All new and existing tests passed
- [x ] A new branch needs to be created from master to evolve previous versions
- [x ] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
