### PR TITLE
bug-961

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.1",
+  "version": "20.2.2",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -15,7 +15,8 @@ import { ComboBoxInputRendererComponent } from './renderer/combobox-input-render
 import { ModulabSelect } from '../select/select.component';
 
 export class TestData {
-	constructor(public id: string | number, public description: string) {
+	constructor(public id: string | number, public description: string, public code: string = '') {
+		this.code = code || id?.toString() || '';
 	}
 }
 
@@ -504,6 +505,140 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['transferFocusToGrid']())
 						.not
 						.toThrow();
+					done();
+				});
+		});
+
+	});
+
+	describe('setDescriptionAndCodeWhenMultiple', () => {
+
+		it('should set description and code when value is a valid array with elements', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					const testValues = [
+						new TestData('1', 'Description 1'),
+						new TestData('2', 'Description 2')
+					];
+
+					combobox['setDescriptionAndCodeWhenMultiple'](testValues as any);
+
+					expect(combobox._description).toBe('Description 1; Description 2');
+					expect(combobox._code).toBe('1; 2');
+					done();
+				});
+		});
+
+		it('should set empty description and code when value is an empty array', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					combobox['setDescriptionAndCodeWhenMultiple']([]);
+
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should set empty description and code when value is null', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](null))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should set empty description and code when value is undefined', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](undefined))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should not throw error when value is not an array (string)', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple']('not an array' as any))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should not throw error when value is not an array (number)', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](123 as any))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should not throw error when value is not an array (object)', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple']({id: '1', description: 'Test'} as any))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should handle array with single element correctly', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					const testValues = [new TestData('1', 'Description 1')];
+
+					combobox['setDescriptionAndCodeWhenMultiple'](testValues as any);
+
+					expect(combobox._description).toBe('Description 1');
+					expect(combobox._code).toBe('1');
 					done();
 				});
 		});

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -246,16 +246,18 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	protected setDescriptionAndCodeWhenMultiple(value: Array<T>) {
 		this._description = '';
 		this._code = '';
-		for (const selectedItem of value) {
-			if (this._code !== '') {
-				this._code += '; ';
-			}
-			this._code += selectedItem[this.getCodeField()];
+		if (value && Array.isArray(value) && value.length > 0) {
+			for (const selectedItem of value) {
+				if (this._code !== '') {
+					this._code += '; ';
+				}
+				this._code += selectedItem[this.getCodeField()];
 
-			if (this._description !== '') {
-				this._description += '; ';
+				if (this._description !== '') {
+					this._description += '; ';
+				}
+				this._description += selectedItem[this.getDescriptionField()];
 			}
-			this._description += selectedItem[this.getDescriptionField()];
 		}
 	}
 


### PR DESCRIPTION
# PR Details

Added a guard clause to validate that the input value is defined, is an array, and contains elements before iterating over it. This prevents unnecessary processing and avoids potential runtime errors when handling empty or invalid inputs. The logic for concatenating code and description remains unchanged.


## Related Issue
https://github.com/systelab/systelab-components/issues/961

## Motivation and Context

Sometimes an error appears in the console when the combobox already has data selected and is opened while the backend request is still loading the data.

## How Has This Been Tested

Added unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
