### PR TITLE
Bug 961 master

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.5",
+  "version": "21.4.1",
   "license": "MIT",
   "keywords": [
     "Angular",
@@ -16,20 +16,20 @@
   },
   "private": false,
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
     "ag-grid-angular": "^34.0.0",
     "ag-grid-community": "^34.0.0",
-    "angular-split": "^20.0.0",
+    "angular-split": "^21.0.0",
     "bootstrap": "^4.6.2",
     "date-fns": "^4.1.0",
     "jquery": "^3.7.1",
     "mobile-drag-drop": "^3.0.0-rc.0",
     "popper.js": "^1.16.1",
     "primeicons": "^7.0.0",
-    "primeng": "~20.0.0",
-    "systelab-preferences": "^20.0.0",
-    "systelab-translate": "^20.0.0",
+    "primeng": "~21.0.0",
+    "systelab-preferences": "^21.0.0",
+    "systelab-translate": "^21.0.0",
     "interactjs": "^1.10.11"
   }
 }

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "21.3.0",
+  "version": "20.2.2",
   "license": "MIT",
   "keywords": [
     "Angular",
@@ -16,8 +16,8 @@
   },
   "private": false,
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0",
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0",
     "ag-grid-angular": "^34.0.0",
     "ag-grid-community": "^34.0.0",
     "angular-split": "^20.0.0",
@@ -27,9 +27,9 @@
     "mobile-drag-drop": "^3.0.0-rc.0",
     "popper.js": "^1.16.1",
     "primeicons": "^7.0.0",
-    "primeng": "~21.0.0",
-    "systelab-preferences": "^21.0.0",
-    "systelab-translate": "^21.0.0",
+    "primeng": "~20.0.0",
+    "systelab-preferences": "^20.0.0",
+    "systelab-translate": "^20.0.0",
     "interactjs": "^1.10.11"
   }
 }

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "21.4.0",
+  "version": "20.2.5",
   "license": "MIT",
   "keywords": [
     "Angular",
@@ -16,8 +16,8 @@
   },
   "private": false,
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0",
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0",
     "ag-grid-angular": "^34.0.0",
     "ag-grid-community": "^34.0.0",
     "angular-split": "^20.0.0",
@@ -27,9 +27,9 @@
     "mobile-drag-drop": "^3.0.0-rc.0",
     "popper.js": "^1.16.1",
     "primeicons": "^7.0.0",
-    "primeng": "~21.0.0",
-    "systelab-preferences": "^21.0.0",
-    "systelab-translate": "^21.0.0",
+    "primeng": "~20.0.0",
+    "systelab-preferences": "^20.0.0",
+    "systelab-translate": "^20.0.0",
     "interactjs": "^1.10.11"
   }
 }

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.2",
+  "version": "21.3.1",
   "license": "MIT",
   "keywords": [
     "Angular",
@@ -16,8 +16,8 @@
   },
   "private": false,
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
     "ag-grid-angular": "^34.0.0",
     "ag-grid-community": "^34.0.0",
     "angular-split": "^20.0.0",
@@ -27,9 +27,9 @@
     "mobile-drag-drop": "^3.0.0-rc.0",
     "popper.js": "^1.16.1",
     "primeicons": "^7.0.0",
-    "primeng": "~20.0.0",
-    "systelab-preferences": "^20.0.0",
-    "systelab-translate": "^20.0.0",
+    "primeng": "~21.0.0",
+    "systelab-preferences": "^21.0.0",
+    "systelab-translate": "^21.0.0",
     "interactjs": "^1.10.11"
   }
 }

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -20,7 +20,7 @@
     "@angular/core": "^21.0.0",
     "ag-grid-angular": "^34.0.0",
     "ag-grid-community": "^34.0.0",
-    "angular-split": "^21.0.0",
+    "angular-split": "^20.0.0",
     "bootstrap": "^4.6.2",
     "date-fns": "^4.1.0",
     "jquery": "^3.7.1",

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -15,7 +15,8 @@ import { ComboBoxInputRendererComponent } from './renderer/combobox-input-render
 import { ModulabSelect } from '../select/select.component';
 
 export class TestData {
-	constructor(public id: string | number, public description: string) {
+	constructor(public id: string | number, public description: string, public code: string = '') {
+		this.code = code || id?.toString() || '';
 	}
 }
 
@@ -515,6 +516,140 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['transferFocusToGrid']())
 						.not
 						.toThrow();
+					done();
+				});
+		});
+
+	});
+
+	describe('setDescriptionAndCodeWhenMultiple', () => {
+
+		it('should set description and code when value is a valid array with elements', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					const testValues = [
+						new TestData('1', 'Description 1'),
+						new TestData('2', 'Description 2')
+					];
+
+					combobox['setDescriptionAndCodeWhenMultiple'](testValues as any);
+
+					expect(combobox._description).toBe('Description 1; Description 2');
+					expect(combobox._code).toBe('1; 2');
+					done();
+				});
+		});
+
+		it('should set empty description and code when value is an empty array', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					combobox['setDescriptionAndCodeWhenMultiple']([]);
+
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should set empty description and code when value is null', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](null))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should set empty description and code when value is undefined', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](undefined))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should not throw error when value is not an array (string)', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple']('not an array' as any))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should not throw error when value is not an array (number)', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](123 as any))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should not throw error when value is not an array (object)', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+
+					expect(() => combobox['setDescriptionAndCodeWhenMultiple']({id: '1', description: 'Test'} as any))
+						.not
+						.toThrow();
+					expect(combobox._description).toBe('');
+					expect(combobox._code).toBe('');
+					done();
+				});
+		});
+
+		it('should handle array with single element correctly', (done) => {
+			const fixture = setup();
+			fixture.detectChanges();
+			fixture.whenStable()
+				.then(() => {
+					const combobox = fixture.componentInstance.combobox;
+					const testValues = [new TestData('1', 'Description 1')];
+
+					combobox['setDescriptionAndCodeWhenMultiple'](testValues as any);
+
+					expect(combobox._description).toBe('Description 1');
+					expect(combobox._code).toBe('1');
 					done();
 				});
 		});

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -654,6 +654,38 @@ describe('Systelab Select Combobox', () => {
 				});
 		});
 
+		describe('multipleSelectedItemList undefined handling', () => {
+
+			it('should not throw and should emit empty id list when multipleSelectedItemList is undefined', () => {
+				const fixture = setup();
+				const combobox = fixture.componentInstance.combobox;
+				const emitIdsSpy = spyOn(combobox.multipleSelectedIDListChange, 'emit');
+				emitIdsSpy.calls.reset();
+
+				expect(() => {
+					combobox.multipleSelectedItemList = undefined as any;
+				}).not.toThrow();
+				expect(combobox.multipleSelectedItemList).toEqual([]);
+				expect(emitIdsSpy).toHaveBeenCalledWith([]);
+			});
+
+			it('should return empty id list when selected list is undefined', () => {
+				const fixture = setup();
+				const combobox = fixture.componentInstance.combobox as any;
+				combobox._multipleSelectedItemList = undefined;
+
+				expect(combobox.selectionItemListToIDList()).toEqual([]);
+			});
+
+			it('should not throw in removeItem when selected list is undefined', () => {
+				const fixture = setup();
+				const combobox = fixture.componentInstance.combobox as any;
+				combobox._multipleSelectedItemList = undefined;
+
+				expect(() => combobox.removeItem(new TestData('1', 'Description 1'))).not.toThrow();
+			});
+		});
+
 	});
 
 });

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -37,7 +37,7 @@ export class TestData {
                             </div>
                         </div>
                     </div>
-				`,
+	            `,
 	standalone: false
 })
 export class ComboboxTestComponent {
@@ -117,7 +117,8 @@ describe('Systelab Select Combobox', () => {
 		fixture.detectChanges();
 		await fixture.whenStable();
 
-		expect(fixture.componentInstance.combobox._description).toEqual('Description 1');
+		expect(fixture.componentInstance.combobox._description)
+			.toEqual('Description 1');
 	});
 
 	it('should be able to focus in search input when the dropdown is opened and filter input is true', (done) => {
@@ -525,7 +526,7 @@ describe('Systelab Select Combobox', () => {
 	describe('setDescriptionAndCodeWhenMultiple', () => {
 
 		it('should set description and code when value is a valid array with elements', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -537,14 +538,16 @@ describe('Systelab Select Combobox', () => {
 
 					combobox['setDescriptionAndCodeWhenMultiple'](testValues as any);
 
-					expect(combobox._description).toBe('Description 1; Description 2');
-					expect(combobox._code).toBe('1; 2');
+					expect(combobox._description)
+						.toBe('Description 1; Description 2');
+					expect(combobox._code)
+						.toBe('1; 2');
 					done();
 				});
 		});
 
 		it('should set empty description and code when value is an empty array', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -552,14 +555,16 @@ describe('Systelab Select Combobox', () => {
 
 					combobox['setDescriptionAndCodeWhenMultiple']([]);
 
-					expect(combobox._description).toBe('');
-					expect(combobox._code).toBe('');
+					expect(combobox._description)
+						.toBe('');
+					expect(combobox._code)
+						.toBe('');
 					done();
 				});
 		});
 
 		it('should set empty description and code when value is null', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -568,14 +573,16 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](null))
 						.not
 						.toThrow();
-					expect(combobox._description).toBe('');
-					expect(combobox._code).toBe('');
+					expect(combobox._description)
+						.toBe('');
+					expect(combobox._code)
+						.toBe('');
 					done();
 				});
 		});
 
 		it('should set empty description and code when value is undefined', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -584,14 +591,16 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](undefined))
 						.not
 						.toThrow();
-					expect(combobox._description).toBe('');
-					expect(combobox._code).toBe('');
+					expect(combobox._description)
+						.toBe('');
+					expect(combobox._code)
+						.toBe('');
 					done();
 				});
 		});
 
 		it('should not throw error when value is not an array (string)', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -600,14 +609,16 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['setDescriptionAndCodeWhenMultiple']('not an array' as any))
 						.not
 						.toThrow();
-					expect(combobox._description).toBe('');
-					expect(combobox._code).toBe('');
+					expect(combobox._description)
+						.toBe('');
+					expect(combobox._code)
+						.toBe('');
 					done();
 				});
 		});
 
 		it('should not throw error when value is not an array (number)', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -616,14 +627,16 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['setDescriptionAndCodeWhenMultiple'](123 as any))
 						.not
 						.toThrow();
-					expect(combobox._description).toBe('');
-					expect(combobox._code).toBe('');
+					expect(combobox._description)
+						.toBe('');
+					expect(combobox._code)
+						.toBe('');
 					done();
 				});
 		});
 
 		it('should not throw error when value is not an array (object)', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -632,14 +645,16 @@ describe('Systelab Select Combobox', () => {
 					expect(() => combobox['setDescriptionAndCodeWhenMultiple']({id: '1', description: 'Test'} as any))
 						.not
 						.toThrow();
-					expect(combobox._description).toBe('');
-					expect(combobox._code).toBe('');
+					expect(combobox._description)
+						.toBe('');
+					expect(combobox._code)
+						.toBe('');
 					done();
 				});
 		});
 
 		it('should handle array with single element correctly', (done) => {
-			const fixture = setup();
+			const fixture = setupWithoutFilter();
 			fixture.detectChanges();
 			fixture.whenStable()
 				.then(() => {
@@ -648,8 +663,10 @@ describe('Systelab Select Combobox', () => {
 
 					combobox['setDescriptionAndCodeWhenMultiple'](testValues as any);
 
-					expect(combobox._description).toBe('Description 1');
-					expect(combobox._code).toBe('1');
+					expect(combobox._description)
+						.toBe('Description 1');
+					expect(combobox._code)
+						.toBe('1');
 					done();
 				});
 		});
@@ -657,32 +674,39 @@ describe('Systelab Select Combobox', () => {
 		describe('multipleSelectedItemList undefined handling', () => {
 
 			it('should not throw and should emit empty id list when multipleSelectedItemList is undefined', () => {
-				const fixture = setup();
+				const fixture = setupWithoutFilter();
 				const combobox = fixture.componentInstance.combobox;
 				const emitIdsSpy = spyOn(combobox.multipleSelectedIDListChange, 'emit');
 				emitIdsSpy.calls.reset();
 
 				expect(() => {
 					combobox.multipleSelectedItemList = undefined as any;
-				}).not.toThrow();
-				expect(combobox.multipleSelectedItemList).toEqual([]);
-				expect(emitIdsSpy).toHaveBeenCalledWith([]);
+				})
+					.not
+					.toThrow();
+				expect(combobox.multipleSelectedItemList)
+					.toEqual([]);
+				expect(emitIdsSpy)
+					.toHaveBeenCalledWith([]);
 			});
 
 			it('should return empty id list when selected list is undefined', () => {
-				const fixture = setup();
+				const fixture = setupWithoutFilter();
 				const combobox = fixture.componentInstance.combobox as any;
 				combobox._multipleSelectedItemList = undefined;
 
-				expect(combobox.selectionItemListToIDList()).toEqual([]);
+				expect(combobox.selectionItemListToIDList())
+					.toEqual([]);
 			});
 
 			it('should not throw in removeItem when selected list is undefined', () => {
-				const fixture = setup();
+				const fixture = setupWithoutFilter();
 				const combobox = fixture.componentInstance.combobox as any;
 				combobox._multipleSelectedItemList = undefined;
 
-				expect(() => combobox.removeItem(new TestData('1', 'Description 1'))).not.toThrow();
+				expect(() => combobox.removeItem(new TestData('1', 'Description 1')))
+					.not
+					.toThrow();
 			});
 		});
 

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -265,16 +265,18 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	protected setDescriptionAndCodeWhenMultiple(value: Array<T>) {
 		this._description = '';
 		this._code = '';
-		for (const selectedItem of value) {
-			if (this._code !== '') {
-				this._code += '; ';
-			}
-			this._code += selectedItem[this.getCodeField()];
+		if (value && Array.isArray(value) && value.length > 0) {
+			for (const selectedItem of value) {
+				if (this._code !== '') {
+					this._code += '; ';
+				}
+				this._code += selectedItem[this.getCodeField()];
 
-			if (this._description !== '') {
-				this._description += '; ';
+				if (this._description !== '') {
+					this._description += '; ';
+				}
+				this._description += selectedItem[this.getDescriptionField()];
 			}
-			this._description += selectedItem[this.getDescriptionField()];
 		}
 	}
 

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -197,8 +197,8 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 
 	@Input()
 	set multipleSelectedItemList(value: Array<T>) {
-		this._multipleSelectedItemList = value;
-		this.setDescriptionAndCodeWhenMultiple(value);
+		this._multipleSelectedItemList = Array.isArray(value) ? value : [];
+		this.setDescriptionAndCodeWhenMultiple(this._multipleSelectedItemList);
 		this.multipleSelectedItemListChange.emit(this._multipleSelectedItemList);
 		this.multipleSelectedIDListChange.emit(this.selectionItemListToIDList());
 	}
@@ -826,6 +826,9 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	public removeItem(item: T) {
+		if (!Array.isArray(this.multipleSelectedItemList)) {
+			return;
+		}
 		const index = this.multipleSelectedItemList.findIndex(it => it[this.getIdField()] === item[this.getIdField()]);
 		if (index !== -1) {
 			this.multipleSelectedItemList.splice(index, 1);
@@ -834,6 +837,9 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	private selectionItemListToIDList(): Array<string | number> {
+		if (!Array.isArray(this.multipleSelectedItemList)) {
+			return [];
+		}
 		return this.multipleSelectedItemList.map(item => item[this.getIdField()]);
 	}
 

--- a/projects/systelab-components/src/lib/listbox/abstract-api-listbox.component.spec.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-listbox.component.spec.ts
@@ -130,4 +130,41 @@ describe('Systelab Listbox', () => {
 		expect(fixture.componentInstance)
 			.toBeDefined();
 	});
+
+	it('should not throw and should emit empty id list when multipleSelectedItemList is undefined', () => {
+		const listbox = fixture.componentInstance.listbox;
+		const emitIdsSpy = spyOn(listbox.multipleSelectedIDListChange, 'emit');
+		emitIdsSpy.calls.reset();
+
+		expect(() => {
+			listbox.multipleSelectedItemList = undefined as any;
+		}).not.toThrow();
+		expect(listbox.multipleSelectedItemList).toEqual([]);
+		expect(emitIdsSpy).toHaveBeenCalledWith([]);
+	});
+
+	it('should return empty id list when selected list is undefined', () => {
+		const listbox = fixture.componentInstance.listbox as any;
+		listbox._multipleSelectedItemList = undefined;
+
+		expect(listbox.selectionItemListToIDList()).toEqual([]);
+	});
+
+	it('should not throw in onRowSelected when selected list is undefined and showAll is true', () => {
+		const listbox = fixture.componentInstance.listbox as any;
+		listbox.multipleSelection = true;
+		listbox.showAll = true;
+		listbox.isDisabled = false;
+		listbox._multipleSelectedItemList = undefined;
+
+		const event: any = {
+			node: {
+				data: {[listbox.getIdField()]: listbox.getAllFieldID()},
+				isSelected: () => true
+			}
+		};
+
+		expect(() => listbox.onRowSelected(event)).not.toThrow();
+		expect(listbox.multipleSelectedItemList.length).toBe(1);
+	});
 });

--- a/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
@@ -44,14 +44,14 @@ export abstract class AbstractListBox<T> implements OnInit {
 	@Input() public showAll = false;
 	@Input() public hideChecks = false;
 
-	protected _multipleSelectedItemList: Array<T>;
+	protected _multipleSelectedItemList: Array<T> = [];
 
 	private calculatedGridState : CalculatedGridState = initializeCalculatedGridState();
 	private scrollTimeout;
 
 	@Input()
 	set multipleSelectedItemList(value: Array<T>) {
-		this._multipleSelectedItemList = value;
+		this._multipleSelectedItemList = Array.isArray(value) ? value : [];
 		this.selectItemInGrid();
 		this.multipleSelectedItemListChange.emit(this._multipleSelectedItemList);
 		this.multipleSelectedIDListChange.emit(this.selectionItemListToIDList());
@@ -238,6 +238,7 @@ export abstract class AbstractListBox<T> implements OnInit {
 					}
 				} else {
 					if (this.showAll && (event.node.data[this.getIdField()] === this.getAllFieldID())) {
+						this.multipleSelectedItemList = [];
 						this.multipleSelectedItemList.push(event.node.data);
 						this.unselectAllNodes();
 					} else {
@@ -293,6 +294,9 @@ export abstract class AbstractListBox<T> implements OnInit {
 	}
 
 	private selectionItemListToIDList(): Array<string | number> {
+		if (!Array.isArray(this.multipleSelectedItemList)) {
+			return [];
+		}
 		const idList = new Array<string | number>();
 		for (const item of this.multipleSelectedItemList) {
 			idList.push(item[this.getIdField()]);


### PR DESCRIPTION
# PR Details

Added a guard clause to validate that the input value is defined, is an array, and contains elements before iterating over it. This prevents unnecessary processing and avoids potential runtime errors when handling empty or invalid inputs. The logic for concatenating code and description remains unchanged.


## Related Issue
https://github.com/systelab/systelab-components/issues/961

## Motivation and Context

Sometimes an error appears in the console when the combobox already has data selected and is opened while the backend request is still loading the data.

## How Has This Been Tested

Added unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
