### PR TITLE
1177 cannot select searcher items without code blur clears the selection

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "21.4.0",
+  "version": "21.4.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/searcher/abstract-searcher.component.html
+++ b/projects/systelab-components/src/lib/searcher/abstract-searcher.component.html
@@ -2,6 +2,7 @@
   <div class="input-group" style="width: 120px;">
     <input #valueToSearch type="input" class="form-control"
       [(ngModel)]="code"
+      (input)="onUserInput()"
       (blur)="doSearch()"
       [tabindex]="tabindex"
       [disabled]="isDisabled"

--- a/projects/systelab-components/src/lib/searcher/abstract-searcher.component.spec.ts
+++ b/projects/systelab-components/src/lib/searcher/abstract-searcher.component.spec.ts
@@ -150,6 +150,17 @@ export class SearcherTestComponent {
 	public description: string;
 }
 
+@Component({
+    selector: 'systelab-searcher-single-test',
+    template: `<systelab-searcher-example [(code)]="code" [(id)]="id" [(description)]="description"></systelab-searcher-example>`,
+    standalone: false
+})
+export class SearcherSingleTestComponent {
+	public id: string;
+	public code: string;
+	public description: string;
+}
+
 const clickHelpButton = (fixture: ComponentFixture<SearcherTestComponent>) => {
 	const button = fixture.debugElement.nativeElement.querySelector('.btn');
 	button.click();
@@ -206,7 +217,7 @@ describe('Systelab Searcher', () => {
 				ComboBoxInputRendererComponent,
 				SystelabSearcherComponent,
 				SearcherTestComponent,
-				GridContextMenuComponent,
+				SearcherSingleTestComponent,GridContextMenuComponent,
 				GridHeaderContextMenu,
 				SearcherTableComponent,
 				ButtonComponent,
@@ -264,6 +275,46 @@ describe('Systelab Searcher', () => {
 		fixture.detectChanges();
 		await fixture.whenStable();
 		expect(isSearchInputFocused()).toBeTruthy();
+	});
+
+	it('should not clear id/description/code on blur when input is empty and user did not manually edit it', async () => {
+		const singleFixture = TestBed.createComponent(SearcherSingleTestComponent);
+		singleFixture.detectChanges();
+		singleFixture.componentInstance.id = '42';
+		singleFixture.componentInstance.description = 'Item without code';
+		singleFixture.componentInstance.code = undefined;
+		singleFixture.detectChanges();
+		await singleFixture.whenStable();
+
+		const input = singleFixture.debugElement.query(By.css('.form-control')).nativeElement;
+		input.dispatchEvent(new Event('blur'));
+		singleFixture.detectChanges();
+		await singleFixture.whenStable();
+
+		expect(singleFixture.componentInstance.id).toEqual('42');
+		expect(singleFixture.componentInstance.description).toEqual('Item without code');
+	});
+
+	it('should clear id/description/code on blur when user manually empties the input', async () => {
+		const singleFixture = TestBed.createComponent(SearcherSingleTestComponent);
+		singleFixture.detectChanges();
+		singleFixture.componentInstance.id = '42';
+		singleFixture.componentInstance.description = 'Existing';
+		singleFixture.componentInstance.code = 'ABC';
+		singleFixture.detectChanges();
+		await singleFixture.whenStable();
+
+		const input = singleFixture.debugElement.query(By.css('.form-control')).nativeElement;
+		input.value = '';
+		input.dispatchEvent(new Event('input'));
+		singleFixture.detectChanges();
+		input.dispatchEvent(new Event('blur'));
+		singleFixture.detectChanges();
+		await singleFixture.whenStable();
+
+		expect(singleFixture.componentInstance.id).toBeUndefined();
+		expect(singleFixture.componentInstance.description).toBeUndefined();
+		expect(singleFixture.componentInstance.code).toBeUndefined();
 	});
 
 	it('should show counter with the selected items number in the submit button', async () => {

--- a/projects/systelab-components/src/lib/searcher/abstract-searcher.component.ts
+++ b/projects/systelab-components/src/lib/searcher/abstract-searcher.component.ts
@@ -20,6 +20,8 @@ export abstract class AbstractSearcherComponent<T> extends AbstractGenericSearch
 	@Input() public isManagement = false;
 	@Input() public height;
 
+	private userEdited = false;
+
 	protected constructor(public override dialogService: DialogService, public override abstractSearcher: AbstractSearcher<T>) {
 		super(dialogService, abstractSearcher)
 	}
@@ -83,6 +85,10 @@ export abstract class AbstractSearcherComponent<T> extends AbstractGenericSearch
 			);
 	}
 
+	public onUserInput(): void {
+		this.userEdited = true;
+	}
+
 	public doSearch(): void {
 		if (this.code) {
 			this.abstractSearcher.getData(this.code, 1, this.multipleSelection ? 0 : 1, true)
@@ -105,14 +111,18 @@ export abstract class AbstractSearcherComponent<T> extends AbstractGenericSearch
 									}
 								}
 							}
+							this.userEdited = false;
 						},
 						error: (error) => {
 							console.error(`Communication error: ${error}`);
-
+							this.userEdited = false;
 						}
 					}
 				);
 		} else {
+			if (!this.userEdited) {
+				return;
+			}
 			this.id = undefined;
 			this.description = undefined;
 			this.code = undefined;
@@ -120,6 +130,7 @@ export abstract class AbstractSearcherComponent<T> extends AbstractGenericSearch
 				this.multipleSelectedItemList = [];
 			}
 			this.upDateField(undefined);
+			this.userEdited = false;
 		}
 	}
 


### PR DESCRIPTION
# PR Details
 
 ## Description
 
 Adds a `userEdited` flag in `AbstractSearcherComponent` that is set to `true` only when the user physically types in the searcher input (via the native DOM `(input)` event, which does not fire on programmatic `[(ngModel)]` writes). The `doSearch()` method, invoked on `blur`, now bails out of the clearing branch when the code is empty and `userEdited` is `false`, leaving `id`, `description`, `code` and `multipleSelectedItemList` untouched. The flag is reset after every completed search or manual clear so each focus/edit/blur cycle is evaluated independently. Existing behavior for actual manual edits (typing a code, or typing and then deleting it) is preserved.
 
 Files touched:
 - `projects/systelab-components/src/lib/searcher/abstract-searcher.component.html` — added `(input)="onUserInput()"` on `#valueToSearch`.
 - `projects/systelab-components/src/lib/searcher/abstract-searcher.component.ts` — new `userEdited` flag, `onUserInput()` handler, guarded empty-code branch in `doSearch()`, flag reset in `next`/`error`/manual-clear paths.
 - `projects/systelab-components/src/lib/searcher/abstract-searcher.component.spec.ts` — added a single-selection host component and two new specs covering both scenarios.
 
 ## Related Issue
 https://github.com/systelab/systelab-components/issues/1177
 
 ## Motivation and Context
 
 The searcher was making it impossible to select items without a `code` from the dialog and was also wiping externally-assigned `id`/`description` values after any focus/blur cycle. The previous implementation cleared the model unconditionally whenever the input was empty on `blur`, regardless of whether the emptiness came from user typing or from a programmatic assignment / dialog selection. This change scopes the clearing logic to genuine manual edits, which is the only case where clearing is semantically correct.
 
 ## How Has This Been Tested
 
 Added two Jasmine/Karma specs in `abstract-searcher.component.spec.ts` using a new `SearcherSingleTestComponent` host (`multipleSelection = false`) to isolate the single-selection path:
 
 1. `should not clear id/description/code on blur when input is empty and user did not manually edit it` — sets `id`/`description` programmatically with empty `code`, dispatches a `blur` on the input, and asserts values remain intact.
 2. `should clear id/description/code on blur when user manually empties the input` — preloads values, simulates the user deleting the input contents (native `input` event with empty value + `blur`), and asserts everything is cleared.
 
 
 ## Types of changes
 
 - [ ] Docs change / refactoring / dependency upgrade
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
 ## Checklist
 
 - [x] I have read the **CONTRIBUTING** document
 - [x] My code follows the code style of this project
 - [ ] My change requires a change to the documentation
 - [ ] I have updated the documentation accordingly (README.md for each UI component)
 - [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
 - [x] All new and existing tests passed
 - [ ] A new branch needs to be created from master to evolve previous versions
 - [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
 - [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
 - [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
