### PR TITLE
fix issue abstract-listbox invalid event clickRow (17.4.x)

### DIFF
--- a/projects/systelab-components/src/lib/listbox/abstract-listbox.component.html
+++ b/projects/systelab-components/src/lib/listbox/abstract-listbox.component.html
@@ -8,8 +8,7 @@
                      (rowDragEnd)="onRowDragEnd($event)"
                      (gridReady)="doGridReady($event)"
                      (gridSizeChanged)="doGridSizeChanged($event)"
-                     (cellClicked)="doClick($event)"
-                     (clickRow)="doClick($event)"
+                     (rowClicked)="doClick($event)"
                      (rowSelected)="onRowSelected($event)"
                      (modelUpdated)="onModelUpdated($event)">
     </ag-grid-angular>


### PR DESCRIPTION
# PR Details
We need to emit the correct rowClicked event.

## Description

The clickRow event does not exist in AG Grid. The correct event that is emitted when a user clicks on a row is rowClicked

## Related Issue
https://github.com/systelab/systelab-components/issues/1183

## Motivation and Context

We need the value of simple lists (those that are not multi-select) to be emitted when the user clicks on a row, rather than only when clicking on the field itself.

## How Has This Been Tested
Unit

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [ ] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
