### PR TITLE
bug-961-2

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.4",
+  "version": "20.2.5",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -643,6 +643,38 @@ describe('Systelab Select Combobox', () => {
 				});
 		});
 
+		describe('multipleSelectedItemList undefined handling', () => {
+
+			it('should not throw and should emit empty id list when multipleSelectedItemList is undefined', () => {
+				const fixture = setup();
+				const combobox = fixture.componentInstance.combobox;
+				const emitIdsSpy = spyOn(combobox.multipleSelectedIDListChange, 'emit');
+				emitIdsSpy.calls.reset();
+
+				expect(() => {
+					combobox.multipleSelectedItemList = undefined as any;
+				}).not.toThrow();
+				expect(combobox.multipleSelectedItemList).toEqual([]);
+				expect(emitIdsSpy).toHaveBeenCalledWith([]);
+			});
+
+			it('should return empty id list when selected list is undefined', () => {
+				const fixture = setup();
+				const combobox = fixture.componentInstance.combobox as any;
+				combobox._multipleSelectedItemList = undefined;
+
+				expect(combobox.selectionItemListToIDList()).toEqual([]);
+			});
+
+			it('should not throw in removeItem when selected list is undefined', () => {
+				const fixture = setup();
+				const combobox = fixture.componentInstance.combobox as any;
+				combobox._multipleSelectedItemList = undefined;
+
+				expect(() => combobox.removeItem(new TestData('1', 'Description 1'))).not.toThrow();
+			});
+		});
+
 	});
 
 });

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -178,8 +178,8 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 
 	@Input()
 	set multipleSelectedItemList(value: Array<T>) {
-		this._multipleSelectedItemList = value;
-		this.setDescriptionAndCodeWhenMultiple(value);
+		this._multipleSelectedItemList = Array.isArray(value) ? value : [];
+		this.setDescriptionAndCodeWhenMultiple(this._multipleSelectedItemList);
 		this.multipleSelectedItemListChange.emit(this._multipleSelectedItemList);
 		this.multipleSelectedIDListChange.emit(this.selectionItemListToIDList());
 	}
@@ -806,6 +806,9 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	public removeItem(item: T) {
+		if (!Array.isArray(this.multipleSelectedItemList)) {
+			return;
+		}
 		const index = this.multipleSelectedItemList.findIndex(it => it[this.getIdField()] === item[this.getIdField()]);
 		if (index !== -1) {
 			this.multipleSelectedItemList.splice(index, 1);
@@ -814,6 +817,9 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	private selectionItemListToIDList(): Array<string | number> {
+		if (!Array.isArray(this.multipleSelectedItemList)) {
+			return [];
+		}
 		return this.multipleSelectedItemList.map(item => item[this.getIdField()]);
 	}
 

--- a/projects/systelab-components/src/lib/listbox/abstract-api-listbox.component.spec.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-listbox.component.spec.ts
@@ -127,4 +127,41 @@ describe('Systelab Listbox', () => {
 		expect(fixture.componentInstance)
 			.toBeDefined();
 	});
+
+	it('should not throw and should emit empty id list when multipleSelectedItemList is undefined', () => {
+		const listbox = fixture.componentInstance.listbox;
+		const emitIdsSpy = spyOn(listbox.multipleSelectedIDListChange, 'emit');
+		emitIdsSpy.calls.reset();
+
+		expect(() => {
+			listbox.multipleSelectedItemList = undefined as any;
+		}).not.toThrow();
+		expect(listbox.multipleSelectedItemList).toEqual([]);
+		expect(emitIdsSpy).toHaveBeenCalledWith([]);
+	});
+
+	it('should return empty id list when selected list is undefined', () => {
+		const listbox = fixture.componentInstance.listbox as any;
+		listbox._multipleSelectedItemList = undefined;
+
+		expect(listbox.selectionItemListToIDList()).toEqual([]);
+	});
+
+	it('should not throw in onRowSelected when selected list is undefined and showAll is true', () => {
+		const listbox = fixture.componentInstance.listbox as any;
+		listbox.multipleSelection = true;
+		listbox.showAll = true;
+		listbox.isDisabled = false;
+		listbox._multipleSelectedItemList = undefined;
+
+		const event: any = {
+			node: {
+				data: {[listbox.getIdField()]: listbox.getAllFieldID()},
+				isSelected: () => true
+			}
+		};
+
+		expect(() => listbox.onRowSelected(event)).not.toThrow();
+		expect(listbox.multipleSelectedItemList.length).toBe(1);
+	});
 });

--- a/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-listbox.component.ts
@@ -44,14 +44,14 @@ export abstract class AbstractListBox<T> implements OnInit {
 	@Input() public showAll = false;
 	@Input() public hideChecks = false;
 
-	protected _multipleSelectedItemList: Array<T>;
+	protected _multipleSelectedItemList: Array<T> = [];
 
 	private calculatedGridState: CalculatedGridState = initializeCalculatedGridState();
 	private scrollTimeout;
 
 	@Input()
 	set multipleSelectedItemList(value: Array<T>) {
-		this._multipleSelectedItemList = value;
+		this._multipleSelectedItemList = Array.isArray(value) ? value : [];
 		this.selectItemInGrid();
 		this.multipleSelectedItemListChange.emit(this._multipleSelectedItemList);
 		this.multipleSelectedIDListChange.emit(this.selectionItemListToIDList());
@@ -236,6 +236,7 @@ export abstract class AbstractListBox<T> implements OnInit {
 					}
 				} else {
 					if (this.showAll && (event.node.data[this.getIdField()] === this.getAllFieldID())) {
+						this.multipleSelectedItemList = [];
 						this.multipleSelectedItemList.push(event.node.data);
 						this.unselectAllNodes();
 					} else {
@@ -291,6 +292,9 @@ export abstract class AbstractListBox<T> implements OnInit {
 	}
 
 	private selectionItemListToIDList(): Array<string | number> {
+		if (!Array.isArray(this.multipleSelectedItemList)) {
+			return [];
+		}
 		const idList = new Array<string | number>();
 		for (const item of this.multipleSelectedItemList) {
 			idList.push(item[this.getIdField()]);


### PR DESCRIPTION
# PR Details

Added a guard clause to validate that the input value is defined, is an array, and contains elements before iterating over it. This prevents unnecessary processing and avoids potential runtime errors when handling empty or invalid inputs. The logic for concatenating code and description remains unchanged.


## Related Issue
https://github.com/systelab/systelab-components/issues/961

## Motivation and Context

Sometimes an error appears in the console when the combobox already has data selected and is opened while the backend request is still loading the data.

## How Has This Been Tested

Added unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
