### PR TITLE
bug-1130-datepicker-2

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.4",
+  "version": "20.2.5",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.6",
+  "version": "20.2.7",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.5",
+  "version": "20.2.6",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
@@ -150,6 +150,14 @@ describe('Systelab DatepickerComponent', () => {
 		fixture.destroy();
 	});
 
+	it('should close datepicker when window is resized', () => {
+		AuxFunctionClass.clickOnInput(fixture);
+		const datepickerComponent = fixture.debugElement.query(By.css('systelab-datepicker')).componentInstance as DatepickerComponent;
+		spyOn(datepickerComponent, 'closeDatepicker');
+		datepickerComponent.onWindowResize();
+		expect(datepickerComponent.closeDatepicker).toHaveBeenCalled();
+	});
+
 	it('should instantiate', () => {
 		expect(fixture.componentInstance)
 			.toBeDefined();

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, DoCheck, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, DoCheck, ElementRef, EventEmitter, HostListener, Input, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
 import { addDays } from 'date-fns';
 import { DatePicker } from 'primeng/datepicker';
 import { I18nService } from 'systelab-translate';
@@ -65,7 +65,6 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	public tooFarDate = false;
 	public language: any;
 
-	public currentDocSize: number;
 	public currentLanguage: string;
 	public inputElement: ElementRef;
 	public focusEvt: FocusEvent;
@@ -81,7 +80,6 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	public ngOnInit() {
 		this.getLanguage();
 
-		this.currentDocSize = window.innerWidth;
 		this.currentLanguage = this.i18nService.getCurrentLanguage();
 
 		if (navigator.userAgent.indexOf('iPad') > -1 || navigator.userAgent.indexOf('Android') > -1) {
@@ -108,6 +106,11 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 				inputElement.setAttribute('tabindex', tabindexValue.toString());
 			}
 		}
+	}
+
+	@HostListener('window:resize')
+	public onWindowResize(): void {
+		this.closeDatepicker();
 	}
 
 	private addIconToDatepicker(): void {
@@ -172,11 +175,6 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	}
 
 	public ngDoCheck() {
-		if (window.innerWidth !== this.currentDocSize) {
-			this.currentDocSize = window.innerWidth;
-			this.closeDatepicker();
-		}
-
 		if (this.headerElement !== document.getElementById(this.datepickerId)) {
 			this.headerElement = document.getElementById(this.datepickerId);
 			if (this.headerElement) {
@@ -340,6 +338,10 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	public closeDatepicker(): void {
 		if (this.currentCalendar) {
 			this.currentCalendar.hideOverlay();
+			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
+			if (inputElement) {
+				inputElement.blur();
+			}
 			this.currentCalendar.el.nativeElement.blur();
 		}
 	}


### PR DESCRIPTION
# PR Details

Prevent open date picker after resize a window and focus again in the window

## Description

  When the user resized the browser window and then switched focus to another application and back, the datepicker modal would reopen automatically. 

Root cause: The resize detection was done inside  ngDoCheck  by polling  window.innerWidth  on every change detection cycle. When  closeDatepicker()  was called, it only blurred the component's wrapper element — not the  inner  <input>  — leaving the input as the last focused element. When the user returned to the Angular app, the browser restored focus to that input, causing PrimeNG to reopen the overlay.          

## Motivation and Context
To do a better World

## Related Issue

https://github.com/systelab/systelab-components/pull/1131


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
