### PR TITLE
1189 Fix multiselection tree list checkbox spaces

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.8",
+  "version": "20.2.9",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.5",
+  "version": "20.2.7",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -173,7 +173,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		if (this.multipleSelection) {
 			this.gridOptions.rowSelection.enableClickSelection = false;
 			this.gridOptions.rowSelection.mode = 'multiRow';
-			this.gridOptions.selectionColumnDef = {width: 0, maxWidth: 0, suppressSizeToFit: true} as ColDef;
+			this.gridOptions.selectionColumnDef = {...this.gridOptions.selectionColumnDef, width: 0, maxWidth: 0, suppressSizeToFit: true} as ColDef;
 		} else {
 			this.gridOptions.rowSelection.enableClickSelection = !this.isDisabled;
 		}

--- a/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-tree-listbox.component.ts
@@ -3,7 +3,7 @@ import { AbstractTreeListboxRendererComponent } from './renderer/abstract-tree-l
 import { StylesUtilService } from '../utilities/styles.util.service';
 import { AbstractListBox } from './abstract-listbox.component';
 import { Observable } from 'rxjs';
-import { GetRowIdParams, RowSelectionOptions } from 'ag-grid-community';
+import { GetRowIdParams, RowSelectionOptions, ColDef } from 'ag-grid-community';
 
 export class TreeListBoxElement<T> {
 	public nodeData: T;
@@ -173,6 +173,7 @@ export abstract class AbstractApiTreeListBox<T> extends AbstractListBox<TreeList
 		if (this.multipleSelection) {
 			this.gridOptions.rowSelection.enableClickSelection = false;
 			this.gridOptions.rowSelection.mode = 'multiRow';
+			this.gridOptions.selectionColumnDef = {width: 0, maxWidth: 0, suppressSizeToFit: true} as ColDef;
 		} else {
 			this.gridOptions.rowSelection.enableClickSelection = !this.isDisabled;
 		}


### PR DESCRIPTION
# PR Details

Prevent left space in the multiselection tree list

## Description

In AG Grid 33, when  rowSelection.mode  is set to  multiRow , the grid unconditionally creates a native  SelectionColumn  even when  checkboxes: false  is configured. This resulted in a ~50px empty space appearing on the left side of the tree listbox component when  multipleSelection=true .

The alternative approach considered was migrating to AG Grid 33's native  selectionColumnDef  with a fixed-width pinned checkbox column. However, this was discarded because  selectionColumnDef  is a single fixed-width column shared across all rows — it cannot dynamically indent per tree level. This means the tree hierarchy visual effect (level 0 at 0px, level 1 at 20px, etc.) cannot be achieved with that column, as checkboxes at deeper levels would require a wider column, leaving empty space at shallower levels.

The chosen fix collapses the native selection column to zero width via  selectionColumnDef: { width: 0, maxWidth: 0, suppressSizeToFit: true }  when  multipleSelection  is active, preserving the existing renderer-based checkbox approach which correctly renders checkboxes indented per tree level. No changes to selection logic or renderer.


## Related Issue

https://github.com/systelab/systelab-components/issues/1189


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
