### PR TITLE
Bug 1191 combobox aggrid

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.7",
+  "version": "20.2.8",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-api-combobox.component.ts
@@ -28,7 +28,10 @@ export abstract class AbstractApiComboBox<T> extends AbstractComboBox<T> impleme
 		this.gridOptions.cacheOverflowSize = 2;
 		this.gridOptions.maxConcurrentDatasourceRequests = 1;
 		this.gridOptions.maxBlocksInCache = 100;
-
+		// headerCheckbox is not supported with the infinite row model (AG Grid error #129)
+		if (this.gridOptions.rowSelection) {
+			(this.gridOptions.rowSelection as any).headerCheckbox = false;
+		}
 	}
 
 	protected override configGridData() {

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.spec.ts
@@ -677,4 +677,49 @@ describe('Systelab Select Combobox', () => {
 
 	});
 
+	describe('getSelectedRow', () => {
+
+			it('should return undefined without calling getSelectedRows when grid is destroyed', (done) => {
+				const fixture = setup();
+				fixture.detectChanges();
+				clickButton(fixture);
+				fixture.whenStable()
+					.then(() => {
+						const combobox = fixture.componentInstance.combobox;
+						const getSelectedRowsSpy = jasmine.createSpy('getSelectedRows');
+						combobox.gridApi = {
+							isDestroyed:     () => true,
+							getSelectedRows: getSelectedRowsSpy
+						} as any;
+
+						const result = combobox.getSelectedRow();
+
+						expect(result).toBeUndefined();
+						expect(getSelectedRowsSpy).not.toHaveBeenCalled();
+						done();
+					});
+			});
+
+			it('should return the first selected row when grid is alive', (done) => {
+				const fixture = setup();
+				fixture.detectChanges();
+				clickButton(fixture);
+				fixture.whenStable()
+					.then(() => {
+						const combobox = fixture.componentInstance.combobox;
+						const mockRow = {id: '1', description: 'Test'};
+						combobox.gridApi = {
+							isDestroyed:     () => false,
+							getSelectedRows: jasmine.createSpy('getSelectedRows').and.returnValue([mockRow])
+						} as any;
+
+						const result = combobox.getSelectedRow();
+
+						expect(result).toEqual(mockRow as any);
+						done();
+					});
+			});
+
+	});
+
 });

--- a/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/abstract-combobox.component.ts
@@ -309,6 +309,11 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 		this.configGridData();
 
 		this.gridOptions.enableBrowserTooltips = true;
+		// Clear the gridApi reference when the grid is destroyed so that guards using `?.`
+		// prevent calls on a stale destroyed instance before the next doGridReady fires.
+		this.gridOptions.onGridPreDestroyed = () => {
+			this.gridApi = null;
+		};
 	}
 
 	protected getRowNodeId(item: GetRowIdParams | ComboTreeNode<T>): string | number | undefined {
@@ -584,7 +589,10 @@ export abstract class AbstractComboBox<T> implements AgRendererComponent, OnInit
 	}
 
 	public getSelectedRow(): T {
-		const selectedRow: Array<T> = this.gridApi?.getSelectedRows();
+		if (!this.gridApi || this.gridApi.isDestroyed()) {
+			return undefined;
+		}
+		const selectedRow: Array<T> = this.gridApi.getSelectedRows();
 		if (selectedRow != null) {
 			return selectedRow[0];
 		}

--- a/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/autocomplete/autocomplete-api-combobox.component.ts
@@ -125,12 +125,18 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 			this.getData(page, this.gridOptions.paginationPageSize, this.startsWith)
 				.subscribe({
 						next:  (v: Array<T>) => {
+							if (!this.gridApi || this.gridApi.isDestroyed()) {
+								return;
+							}
 							this.gridApi.setGridOption("loading", false);
 							this.gridApi.hideOverlay();
 							this.totalItemsLoaded = true;
 							params.successCallback(v, this.getTotalItems());
 						},
 						error: () => {
+							if (!this.gridApi || this.gridApi.isDestroyed()) {
+								return;
+							}
 							this.gridApi.setGridOption("loading", false);
 							this.gridApi.hideOverlay();
 							params.failCallback();
@@ -180,7 +186,8 @@ export abstract class AutocompleteApiComboBox<T> extends AbstractApiComboBox<T> 
 
 	public onEnterDoSelect(event: KeyboardEvent) {
 		if (this.isDropdownOpened) {
-			this.gridApi.getDisplayedRowAtIndex(0).setSelected(true);
+			this.gridApi.getDisplayedRowAtIndex(0)
+				.setSelected(true);
 		}
 	}
 

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.spec.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Component, inject, Renderer2 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { PreferencesService } from 'systelab-preferences';
 import { AbstractApiTreeComboBox } from './abstract-api-tree-combobox.component';
 
@@ -551,6 +551,43 @@ describe('AbstractApiTreeComboBox', () => {
 			expect(component.gridApi.setFocusedCell)
 				.not
 				.toHaveBeenCalled();
+		});
+
+	});
+
+	describe('doGridReady with destroyed grid', () => {
+
+		it('should not call hideOverlay or redrawRows in next callback when grid is destroyed', () => {
+			const hideOverlaySpy = jasmine.createSpy('hideOverlay');
+			const redrawRowsSpy  = jasmine.createSpy('redrawRows');
+			const mockEvent      = {
+				api: {
+					isDestroyed:          () => true,
+					hideOverlay:          hideOverlaySpy,
+					redrawRows:           redrawRowsSpy,
+					getDisplayedRowCount: () => 0
+				}
+			} as any;
+
+			component.doGridReady(mockEvent);
+
+			expect(hideOverlaySpy).not.toHaveBeenCalled();
+			expect(redrawRowsSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not call hideOverlay in error callback when grid is destroyed', () => {
+			const hideOverlaySpy = jasmine.createSpy('hideOverlay');
+			spyOn(component, 'getRows').and.returnValue(throwError(() => new Error('load error')));
+			const mockEvent = {
+				api: {
+					isDestroyed: () => true,
+					hideOverlay: hideOverlaySpy
+				}
+			} as any;
+
+			component.doGridReady(mockEvent);
+
+			expect(hideOverlaySpy).not.toHaveBeenCalled();
 		});
 
 	});

--- a/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
+++ b/projects/systelab-components/src/lib/combobox/tree/abstract-api-tree-combobox.component.ts
@@ -117,6 +117,9 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 		this.getRows()
 			.subscribe({
 				next:  (nodeVector) => {
+					if (this.gridApi.isDestroyed()) {
+						return;
+					}
 					if (this.multipleSelection) {
 						this.isAllSelectable = false;
 						this.allElement = false;
@@ -133,7 +136,9 @@ export abstract class AbstractApiTreeComboBox<T> extends AbstractComboBox<ComboT
 					}
 				},
 				error: () => {
-					this.gridApi.hideOverlay();
+					if (!this.gridApi.isDestroyed()) {
+						this.gridApi.hideOverlay();
+					}
 				}
 			})
 	}

--- a/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-api-grid.component.spec.ts
@@ -418,4 +418,17 @@ describe('Systelab Grid', () => {
 
 		expect(fixture.componentInstance.grid.startCellEditorWithTab).toBeTrue();
 	})
+
+	it('should not call getDisplayedRowAtIndex in selectRow timer when grid is destroyed', async () => {
+		await fixture.whenStable();
+		const grid = fixture.componentInstance.grid;
+		spyOn(grid.gridApi, 'ensureIndexVisible').and.stub();
+		const getDisplayedRowAtIndexSpy = spyOn(grid.gridApi, 'getDisplayedRowAtIndex');
+		spyOn(grid.gridApi, 'isDestroyed').and.returnValue(true);
+
+		grid.selectRow(0);
+		await new Promise(resolve => setTimeout(resolve, 250));
+
+		expect(getDisplayedRowAtIndexSpy).not.toHaveBeenCalled();
+	});
 });

--- a/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
+++ b/projects/systelab-components/src/lib/grid/abstract-grid.component.ts
@@ -448,7 +448,11 @@ export abstract class AbstractGrid<T> implements OnInit, GridRowMenuActionHandle
 	public selectRow(index: number): void {
 		this.gridApi.ensureIndexVisible(index);
 		timer(200)
-			.subscribe(() => this.gridApi.getDisplayedRowAtIndex(index).setSelected(true));
+			.subscribe(() => {
+				if (this.gridApi && !this.gridApi.isDestroyed()) {
+					this.gridApi.getDisplayedRowAtIndex(index).setSelected(true);
+				}
+			});
 	}
 
 	public doClick(event: any): void {

--- a/projects/systelab-components/src/lib/helper/autosize-grid-helper.ts
+++ b/projects/systelab-components/src/lib/helper/autosize-grid-helper.ts
@@ -90,6 +90,10 @@ export class AutosizeGridHelper {
 	//This is only necessary for sizeColumnsToFit, autoSizeColumns does it correctly.
 	public static sizeColumnsToFit(gridApi: GridApi) {
 		if(!gridApi.isDestroyed()) {
+			const range = gridApi.getHorizontalPixelRange();
+			if (!range || range.right === 0) {
+				return;
+			}
 			gridApi.sizeColumnsToFit();
 			const cols: Column[] = gridApi.getColumns() || [];
 			for(let i: number = cols.length - 1; i >= 0; i--) {

--- a/projects/systelab-components/src/lib/listbox/abstract-api-listbox.component.ts
+++ b/projects/systelab-components/src/lib/listbox/abstract-api-listbox.component.ts
@@ -24,6 +24,10 @@ export abstract class AbstractApiListBox<T> extends AbstractListBox<T> implement
 		options.maxBlocksInCache= 15;
 		options.datasource = this;
 		options.loading = false;
+		// headerCheckbox is not supported with the infinite row model (AG Grid error #129)
+		if (options.rowSelection) {
+			(options.rowSelection as any).headerCheckbox = false;
+		}
 		return options;
 	}
 

--- a/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
+++ b/projects/systelab-components/src/lib/searcher/searcher.table.component.ts
@@ -100,10 +100,10 @@ export class SearcherTableComponent<T> extends AbstractApiGrid<T> implements OnI
 				});
 			}
 		} else if (this.searcher && this.searcher.id && this.searcher.id !== undefined) {
-			this.gridApi.forEachNode(node => {
+			this.gridApi?.forEachNode(node => {
 				if (node.data && node.data[this.searcher.getIdField()] === this.searcher.id) {
 					node.setSelected(true);
-					this.gridApi.ensureNodeVisible(node);
+					this.gridApi?.ensureNodeVisible(node);
 				}
 			});
 		}


### PR DESCRIPTION
# PR Details

Fix multiple AG Grid runtime errors in combobox and listbox components  

## Description

**AG Grid error #26** — API calls on destroyed grid instances                                                                                                                                                                       
                                                                                                                                                                                                                                   
The combobox components embed an AG Grid inside a dropdown overlay. When the dropdown closes, the grid is destroyed but  this.gridApi  still holds a stale reference. The optional chaining operator ( ?. ) only guards against null / undefined , not against a destroyed instance. 

The root fix is registering  onGridPreDestroyed  in  configGrid()  to set  gridApi = null  at the moment of destruction. This makes all existing  ?.  guards immediately effective and eliminates the window between destruction and the next  doGridReady  call — which was the cause of errors on the second open of a combobox.  

Additionally, specific async call sites needed explicit  isDestroyed()  checks because they capture  gridApi  in a closure before the Observable or timer resolves: the  getRows()  callback in  autocomplete-api-combobox ,    ┃
   the  doGridReady()  Observable callback in  abstract-api-tree-combobox , the  onModelUpdated()  path in  searcher-table , and the  timer(200)  callback in  abstract-grid.selectRow() .                                         ┃
                                                                                                                                                                                                                                      **AG Grid error #29** —  sizeColumnsToFit()  called with zero grid width                                                                                                                                                                sizeColumnsToFit()  was being called synchronously during dropdown open, before the browser had rendered the overlay and assigned a real width to the grid container. The fix adds a width check via                           ┃
    getHorizontalPixelRange()  in  AutosizeGridHelper.sizeColumnsToFit()  and skips the call if the grid has no visible width yet.                                                                                                 
                                                                                                                                                                                                                                   
**AG Grid error #129** —  headerCheckbox  not supported with infinite row model                                                                                                                                                     

AbstractListBox  configures  headerCheckbox  for multiple-selection grids, but  AbstractApiListBox  overrides the row model to  infinite , which does not support  headerCheckbox . The fix explicitly disables it in          ┃
    AbstractApiListBox.getInitialGridOptions()  after calling the parent.     


## Related Issue

https://github.com/systelab/systelab-components/issues/1191

## Motivation and Context

To do a better World

## How Has This Been Tested

Manually
Added unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [x] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
