### PR TITLE
Replace the PrimeNG datepicker with a new systelab-datepicker-calendar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,60 @@ npm publish
 
 # Breaking changes
 
+## Version 21.5.0
+
+The **datepicker** (`systelab-datepicker` and `systelab-date-time`) does not use PrimeNG anymore. It is now implemented
+with plain Angular and TypeScript by the new `systelab-datepicker-calendar` component, which is the engine of both.
+
+`DatepickerCalendarComponent` keeps its state in **signals**, derives the rendered month, the week day names and the
+text of the input with `computed()`, and runs with `ChangeDetectionStrategy.OnPush`, so an open calendar is only
+refreshed when something it shows really changes. Every input and every state member is still a plain property (backed
+by a signal through an accessor), so both template bindings and imperative assignment keep working — and both are now
+reactive. `DatepickerComponent` and `DatepickerTimeComponent` keep the default change detection on purpose, because
+their `currentDate` is often modified in place by the applications.
+
+- All the `@Input()`, `@Output()` and public methods are kept, so no change is needed in the applications. The only
+  removed member is the `PrimeNG` config service that `DatepickerComponent` and `DatepickerTimeComponent` received as the
+  **fourth constructor argument**: any class extending them must drop it from its `super(...)` call.
+- **The `p-` prefixed class names are gone**: the markup now uses the `slab-` prefix of the library. Applications with
+  their own styles or end to end selectors over the calendar have to rename them:
+
+| Before | Now |
+| ------ | --- |
+| `p-datepicker` (on the host) | *removed*, use the `systelab-datepicker-calendar` element |
+| `p-datepicker-input-wrapper`, `p-inputwrapper` | `slab-datepicker-input-wrapper` |
+| `p-datepicker-input`, `p-inputtext` | `slab-datepicker-input` |
+| `p-inputwrapper-focus` | `slab-datepicker-input-focus` |
+| `p-datepicker-panel` (+ `p-component`) | `slab-datepicker-panel` |
+| `p-datepicker-panel-inline`, `p-datepicker-inline` | `slab-datepicker-panel-inline` |
+| `p-datepicker-timeonly` | `slab-datepicker-panel-timeonly` |
+| `p-disabled` (on the panel) | `slab-datepicker-panel-disabled` |
+| `p-datepicker-calendar-container` | `slab-datepicker-calendar-container` |
+| `p-datepicker-calendar` | `slab-datepicker-calendar` |
+| `p-datepicker-day-view` | `slab-datepicker-day-view` |
+| `p-datepicker-weekday-cell`, `p-datepicker-weekday` | `slab-datepicker-weekday-cell`, `slab-datepicker-weekday` |
+| `p-datepicker-day-cell`, `p-datepicker-day` | `slab-datepicker-day-cell`, `slab-datepicker-day` |
+| `p-datepicker-day-selected` | `slab-datepicker-day-selected` |
+| `p-disabled` (on a day) | `slab-datepicker-day-disabled` |
+| `p-datepicker-today`, `p-datepicker-other-month` | `slab-datepicker-today`, `slab-datepicker-other-month` |
+| `p-datepicker-title`, `p-datepicker-year`, `p-datepicker-month` | `slab-datepicker-title`, `slab-datepicker-year`, `slab-datepicker-month` |
+| `p-datepicker-time-picker` | `slab-datepicker-time-picker` |
+| `p-datepicker-hour-picker`, `p-datepicker-minute-picker` | `slab-datepicker-hour-picker`, `slab-datepicker-minute-picker` |
+| `p-datepicker-increment-button`, `p-datepicker-decrement-button` | `slab-datepicker-increment-button`, `slab-datepicker-decrement-button` |
+| `p-datepicker-separator` | `slab-datepicker-separator` |
+
+  `slab-datepicker-header`, `date-error`, `warning-date`, `is-disabled` and `input-expand-height` do not change.
+- `DatepickerComponent.currentCalendar` is now a `DatepickerCalendarComponent` instead of a PrimeNG `DatePicker`. It
+  keeps the members the datepicker relied on (`currentMonth`, `currentYear`, `dateFormat`, `inputfieldViewChild`, `el`,
+  `value`, `clear()`, `hideOverlay()`, `navForward()`, `navBackward()`, `isSelectable()`, `isDateDisabled()`, ...) and
+  adds `navYearForward()` / `navYearBackward()`.
+- The calendar panel is no longer appended to `body`: it is rendered inside the component as a `position: fixed`
+  element (the same approach as the combobox). Tests looking for the panel outside the component must be updated.
+- `DatepickerComponent` subscribes to the language changes of the translate service instead of checking the current
+  language on every change detection cycle. It still falls back to the check when no `TranslateService` is provided.
+- Enabled days now take their color from `--slab_foreground_primary` and the current day its background from
+  `--slab_table_row_even_background`, instead of the PrimeNG theme palette, so the calendar also honours the dark theme.
+
 ## Version 21.x.x - Angular 21
 
 [Angular 21 news](https://blog.angular.dev/announcing-angular-v21-57946c34f14b)

--- a/projects/showcase/src/app/components/datepicker/showcase-datepicker.component.html
+++ b/projects/showcase/src/app/components/datepicker/showcase-datepicker.component.html
@@ -136,6 +136,14 @@
         </div>
     </div>
     <div class="row mt-1">
+        <label class="col-md-3 col-form-label" for="form-h-s">Datepicker inline</label>
+        <div class="col-md-4">
+            <systelab-datepicker
+                    [inline]="true"
+                    [(currentDate)]="myDate"></systelab-datepicker>
+        </div>
+    </div>
+    <div class="row mt-1">
         <label class="col-md-3 col-form-label" for="form-h-s">Datepicker language with dateDormat</label>
         <div class="col-md-4">
             <systelab-datepicker

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "21.4.1",
+  "version": "21.5.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/components/_datepicker.scss
+++ b/projects/systelab-components/sass/components/_datepicker.scss
@@ -8,6 +8,12 @@
 $icon-margin-right: 10px;
 /* $icon-margin-left: defines the margin-left of the arrow buttons.*/
 $icon-margin-left: 40px;
+/* Disabled input palette, shared by the input and its icon so both fade the same way. It is
+   theme independent on purpose: the disabled background stays light in every theme, matching
+   the rest of the library (spinner, numpad, searcher). */
+$disabled-background: #e9ecef;
+$disabled-color: #333;
+$disabled-opacity: 0.6;
 
 /* Base layout of the widget, no longer provided by any third party theme. */
 systelab-datepicker-calendar {
@@ -62,7 +68,7 @@ systelab-datepicker-calendar {
   }
 
   .slab-datepicker-input {
-    color: var(--ag-foreground-color);
+    color: var(--slab_foreground_primary);
     background: var(--slab_background_primary);
     border-radius: 0.25rem;
     padding: 1px .25em;
@@ -81,9 +87,9 @@ systelab-datepicker-calendar {
     }
 
     &:disabled {
-      background-color: #e9ecef;
-      opacity: 0.6 !important;
-      color: #333;
+      background-color: $disabled-background;
+      opacity: $disabled-opacity !important;
+      color: $disabled-color;
       cursor: not-allowed;
     }
   }
@@ -99,16 +105,23 @@ systelab-datepicker-calendar {
 
     .icon-calendar {
       height: 100%;
-      color: black;
+      color: var(--slab_foreground_primary);
       cursor: pointer;
     }
 
     .icon-clock {
       height: 100%;
-      color: black;
+      color: var(--slab_foreground_primary);
       cursor: pointer;
     }
 
+    /* A disabled input keeps its light background in every theme, so its icon has to follow the
+       input text instead of the theme foreground. */
+    input:disabled ~ [class*='icon-'] {
+      color: $disabled-color;
+      opacity: $disabled-opacity;
+      cursor: not-allowed;
+    }
   }
 
   &.input-expand-height {
@@ -149,9 +162,10 @@ systelab-datepicker-calendar {
   &.is-disabled {
     .slab-datepicker-input-wrapper {
       input {
-        opacity: 0.6;
+        opacity: $disabled-opacity;
         cursor: not-allowed !important;
-        background-color: #e9ecef;
+        background-color: $disabled-background;
+        color: $disabled-color;
       }
 
       &.input-expand-height {
@@ -196,11 +210,11 @@ systelab-datepicker-calendar {
 }
 
 .slab-datepicker-panel {
-  color: var(--secondary);
+  color: var(--slab_foreground_primary);
   background-color: var(--slab_background_primary) !important;
   z-index: 100000 !important;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  border: 1px solid #ddd !important;
+  border: 1px solid var(--slab_component_border_color) !important;
   border-radius: 6px !important;
   padding: 0 15px !important;
   width: 280px !important;
@@ -221,13 +235,14 @@ systelab-datepicker-calendar {
             font-weight: 500;
             padding: 6px 2px !important;
             font-size: 11px;
-            color: #666;
+            color: var(--slab_foreground_primary);
+            opacity: 0.7;
             width: 28px;
             text-align: center;
-            
+
             .slab-datepicker-weekday {
               font-weight: 500;
-              color: #666;
+              color: inherit;
               text-align: center;
               font-size: 11px;
               display: inline-block;
@@ -254,17 +269,14 @@ systelab-datepicker-calendar {
               color: var(--slab_foreground_primary);
 
               &.slab-datepicker-day-disabled {
-                opacity: 0.3;
+                opacity: 0.4;
                 background-color: transparent !important;
-                color: var(--text-color-secondary);
+                color: var(--slab_foreground_primary);
               }
               &.slab-datepicker-day-selected {
                 background-color: var(--primary) !important;
                 color: var(--text-color-secondary) !important;
                 font-weight: 500;
-                &:hover {
-                  color: var(--slab_foreground_primary) !important;
-                }
               }
               &:not(.slab-datepicker-day-selected):not(.slab-datepicker-day-disabled):hover {
                 background: var(--slab_table_row_hover_background);
@@ -280,8 +292,8 @@ systelab-datepicker-calendar {
 
           .slab-datepicker-other-month {
             .slab-datepicker-day {
-              opacity: 0.3;
-              color: #ccc;
+              opacity: 0.45;
+              color: var(--slab_foreground_primary);
             }
           }
         }
@@ -293,7 +305,7 @@ systelab-datepicker-calendar {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-top: 1px solid #e0e0e0;
+    border-top: 1px solid var(--slab_component_border_color);
     background-color: transparent;
     margin-top: 20px;
 
@@ -307,7 +319,7 @@ systelab-datepicker-calendar {
       .slab-datepicker-increment-button,
       .slab-datepicker-decrement-button {
         background: transparent !important;
-        color:  var(--primary) !important;
+        color:  var(--text-color) !important;
         margin: 5px 0;
         width: 32px !important;
         height: 32px !important;
@@ -322,14 +334,14 @@ systelab-datepicker-calendar {
         }
 
         &:focus {
-          box-shadow: 0 0 0 0.2rem rgba(255, 107, 53, 0.25) !important;
+          box-shadow: Vars.$slab-focus-component-shadow !important;
         }
       }
 
       > span {
         font-size: 18px;
         font-weight: 500;
-        color: #333;
+        color: var(--slab_foreground_primary);
         min-width: 40px;
         text-align: center;
       }
@@ -343,7 +355,7 @@ systelab-datepicker-calendar {
       span {
         font-size: 18px;
         font-weight: 500;
-        color: #333;
+        color: var(--slab_foreground_primary);
       }
     }
   }
@@ -397,7 +409,7 @@ systelab-datepicker-calendar {
     justify-content: space-between;
     align-items: center;
     background: transparent !important;
-    color: #333;
+    color: var(--slab_foreground_primary);
     padding: 10px 0;
     position: relative;
     border: none !important;
@@ -445,7 +457,7 @@ systelab-datepicker-calendar {
       gap: 0.5rem;
       
       .slab-datepicker-year {
-        color: #333;
+        color: var(--slab_foreground_primary);
         font-size: 14px;
         line-height: 1.2;
         padding: 0.375rem;
@@ -453,7 +465,7 @@ systelab-datepicker-calendar {
 
       .slab-datepicker-month {
         width: 100% !important;
-        color: #333;
+        color: var(--slab_foreground_primary);
         font-size: 16px;
         line-height: 1.2;
         padding: 0.375rem;

--- a/projects/systelab-components/sass/components/_datepicker.scss
+++ b/projects/systelab-components/sass/components/_datepicker.scss
@@ -1,17 +1,98 @@
 @use "../variables" as Vars;
 
-/* This styles are used to override the default primeng styles for datepicker (https://www.primefaces.org/primeng/#/datepicker).*/
+/* Styles for the systelab datepicker (systelab-datepicker, systelab-date-time and the
+   systelab-datepicker-calendar widget behind them). Every class follows the slab- prefix: the
+   p-datepicker-* names of the former PrimeNG based implementation are gone. */
 
 /* $icon-margin-right: defines the margin-right of the arrow buttons.*/
 $icon-margin-right: 10px;
 /* $icon-margin-left: defines the margin-left of the arrow buttons.*/
 $icon-margin-left: 40px;
 
-p-datepicker {
+/* Base layout of the widget, no longer provided by any third party theme. */
+systelab-datepicker-calendar {
+  display: block;
+  width: 100%;
 
+  .slab-datepicker-panel {
+    position: fixed;
+    box-sizing: border-box;
 
-  .p-datepicker-input-wrapper,
-  .p-inputwrapper {
+    &.slab-datepicker-panel-inline {
+      position: static;
+    }
+  }
+
+  .slab-datepicker-day-view {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+
+    th, td {
+      border: none;
+    }
+  }
+
+  .slab-datepicker-day-cell {
+    text-align: center;
+  }
+
+  .slab-datepicker-day {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-drag: none;
+
+    &.slab-datepicker-day-disabled {
+      cursor: default;
+      pointer-events: none;
+    }
+  }
+
+  .slab-datepicker-time-picker {
+    .slab-datepicker-increment-button,
+    .slab-datepicker-decrement-button {
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      background: transparent;
+    }
+  }
+
+  .slab-datepicker-input {
+    color: var(--ag-foreground-color);
+    background: var(--slab_background_primary);
+    border-radius: 0.25rem;
+    padding: 1px .25em;
+    width: 100%;
+    height: Vars.$form-elements-height;
+    border: 1px solid var(--slab_component_border_color);
+    font: normal Vars.$slab-base-body-font-size Vars.$slab-base-body-font-family;
+
+    &:focus {
+      border-color: Vars.$slab-focus-component-border-color !important;
+      box-shadow: Vars.$slab-focus-component-shadow !important;
+    }
+
+    &:hover:enabled:not(:focus) {
+      border-color:  var(--slab_component_border_color) !important;
+    }
+
+    &:disabled {
+      background-color: #e9ecef;
+      opacity: 0.6 !important;
+      color: #333;
+      cursor: not-allowed;
+    }
+  }
+
+  .slab-datepicker-input-wrapper {
+    position: relative;
+    display: inline-flex;
+    width: 100%;
+
     input::-ms-clear {
       display: none;
     }
@@ -66,12 +147,7 @@ p-datepicker {
   }
 
   &.is-disabled {
-    .p-state-disabled, .p-widget:disabled {
-      opacity: 0.6;
-    }
-
-    .p-datepicker-input-wrapper,
-    .p-inputwrapper {
+    .slab-datepicker-input-wrapper {
       input {
         opacity: 0.6;
         cursor: not-allowed !important;
@@ -82,35 +158,15 @@ p-datepicker {
         height: 100% !important;
       }
     }
-
-    .p-datepicker-header {
-      background: Vars.$medium-gray;
-    }
-
-    .p-datepicker-calendar {
-
-      tbody {
-        tr {
-          td {
-            a, span {
-              &.p-state-active {
-                background-color: Vars.$medium-gray !important;
-              }
-            }
-          }
-        }
-      }
-    }
-
   }
 }
 
-.p-datepicker-inline {
+.slab-datepicker-panel-inline {
   flex-direction: column;
   border: 1px solid var(--slab_component_border_color) !important;
 }
 
-.p-datepicker-panel,
+.slab-datepicker-panel,
 .p-overlay-panel {
   z-index: 100000 !important;
 }
@@ -139,7 +195,7 @@ p-datepicker {
   }
 }
 
-.p-datepicker-panel.p-component {
+.slab-datepicker-panel {
   color: var(--secondary);
   background-color: var(--slab_background_primary) !important;
   z-index: 100000 !important;
@@ -151,13 +207,9 @@ p-datepicker {
   margin-top: 5px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15) !important;
 
-  .p-datepicker-calendar-container {
-    .p-datepicker-calendar {
-      .p-datepicker-header {
-        display: none !important;
-      }
-
-      .p-datepicker-day-view {
+  .slab-datepicker-calendar-container {
+    .slab-datepicker-calendar {
+      .slab-datepicker-day-view {
         margin: 0 !important;
 
         thead {
@@ -165,7 +217,7 @@ p-datepicker {
           border: none !important;
           background: transparent !important;
           
-          .p-datepicker-weekday-cell {
+          .slab-datepicker-weekday-cell {
             font-weight: 500;
             padding: 6px 2px !important;
             font-size: 11px;
@@ -173,7 +225,7 @@ p-datepicker {
             width: 28px;
             text-align: center;
             
-            .p-datepicker-weekday {
+            .slab-datepicker-weekday {
               font-weight: 500;
               color: #666;
               text-align: center;
@@ -186,10 +238,10 @@ p-datepicker {
         }
 
         tbody {
-          .p-datepicker-day-cell {
+          .slab-datepicker-day-cell {
             padding: 3px !important;
 
-            .p-datepicker-day {
+            .slab-datepicker-day {
               border-radius: 50% !important;
               width: 28px;
               height: 28px;
@@ -199,13 +251,14 @@ p-datepicker {
               font-weight: 400;
               margin: 0 auto;
               font-size: 13px;
+              color: var(--slab_foreground_primary);
 
-              &.p-disabled {
+              &.slab-datepicker-day-disabled {
                 opacity: 0.3;
                 background-color: transparent !important;
                 color: var(--text-color-secondary);
               }
-              &.p-datepicker-day-selected {
+              &.slab-datepicker-day-selected {
                 background-color: var(--primary) !important;
                 color: var(--text-color-secondary) !important;
                 font-weight: 500;
@@ -213,14 +266,20 @@ p-datepicker {
                   color: var(--slab_foreground_primary) !important;
                 }
               }
-              &:not(.p-datepicker-day-selected):not(.p-disabled):hover {
+              &:not(.slab-datepicker-day-selected):not(.slab-datepicker-day-disabled):hover {
                 background: var(--slab_table_row_hover_background);
               }
             }
           }
 
-          .p-datepicker-other-month {
-            .p-datepicker-day {
+          .slab-datepicker-today {
+            .slab-datepicker-day:not(.slab-datepicker-day-selected) {
+              background-color: var(--slab_table_row_even_background);
+            }
+          }
+
+          .slab-datepicker-other-month {
+            .slab-datepicker-day {
               opacity: 0.3;
               color: #ccc;
             }
@@ -230,48 +289,7 @@ p-datepicker {
     }
   }
 
-  .p-datepicker-buttonbar {
-    display: flex;
-    justify-content: space-between;
-    gap: 10px;
-    padding: 15px 0 0 0 !important;
-    background-color: transparent !important;
-    border: none !important;
-    margin-top: 15px;
-    border-top: 1px solid #e0e0e0;
-    
-    .p-button {
-      border-radius: 15px !important;
-      padding: 6px 16px !important;
-      font-size: 14px !important;
-      font-weight: 400 !important;
-      border: 1px solid !important;
-      
-      &:first-child {
-        background: transparent !important;
-        border-color: #007bff !important;
-        color: #007bff !important;
-        
-        &:hover {
-          background: #007bff !important;
-          color: white !important;
-        }
-      }
-      
-      &:last-child {
-        background: transparent !important;
-        border-color: #dc3545 !important;
-        color: #dc3545 !important;
-        
-        &:hover {
-          background: #dc3545 !important;
-          color: white !important;
-        }
-      }
-    }
-  }
-
-  .p-datepicker-time-picker {
+  .slab-datepicker-time-picker {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -279,15 +297,15 @@ p-datepicker {
     background-color: transparent;
     margin-top: 20px;
 
-    .p-datepicker-hour-picker,
-    .p-datepicker-minute-picker {
+    .slab-datepicker-hour-picker,
+    .slab-datepicker-minute-picker {
       display: flex;
       flex-direction: column;
       align-items: center;
       margin: 0 15px;
 
-      .p-datepicker-increment-button,
-      .p-datepicker-decrement-button {
+      .slab-datepicker-increment-button,
+      .slab-datepicker-decrement-button {
         background: transparent !important;
         color:  var(--primary) !important;
         margin: 5px 0;
@@ -306,11 +324,6 @@ p-datepicker {
         &:focus {
           box-shadow: 0 0 0 0.2rem rgba(255, 107, 53, 0.25) !important;
         }
-
-        .p-icon {
-          width: 12px !important;
-          height: 12px !important;
-        }
       }
 
       > span {
@@ -322,7 +335,7 @@ p-datepicker {
       }
     }
 
-    .p-datepicker-separator {
+    .slab-datepicker-separator {
       display: flex;
       align-items: center;
       margin: 0 5px;
@@ -378,7 +391,7 @@ p-datepicker {
   }
 }
 
-.p-datepicker-panel {
+.slab-datepicker-panel {
   .slab-datepicker-header {
     display: flex;
     justify-content: space-between;
@@ -423,24 +436,27 @@ p-datepicker {
       }
     }
     
-    .p-datepicker-title {
+    .slab-datepicker-title {
       text-align: center;
       font-weight: 500;
       flex: 1;
       display: flex;
       flex-direction: column;
+      gap: 0.5rem;
       
-      .p-datepicker-year {
+      .slab-datepicker-year {
         color: #333;
         font-size: 14px;
         line-height: 1.2;
+        padding: 0.375rem;
       }
-      
-      .p-datepicker-month {
+
+      .slab-datepicker-month {
         width: 100% !important;
         color: #333;
         font-size: 16px;
         line-height: 1.2;
+        padding: 0.375rem;
       }
     }
   }
@@ -461,48 +477,11 @@ p-datepicker {
 systelab-datepicker {
   margin-right: 5px;
 
-
-  .p-inputtext,
-  .p-datepicker-input {
-    color: var(--ag-foreground-color);
-    background: var(--slab_background_primary);
-    border-radius: 0.25rem;
-    padding: 1px .25em;
-    width: 100%;
-    height: Vars.$form-elements-height;
-    border: 1px solid var(--slab_component_border_color);
-    font: normal Vars.$slab-base-body-font-size Vars.$slab-base-body-font-family;
-
-    &:focus {
-      border-color: Vars.$slab-focus-component-border-color !important;
-      box-shadow: Vars.$slab-focus-component-shadow !important;
-    }
-
-    &:hover:enabled:not(:focus) {
-      border-color:  var(--slab_component_border_color) !important;
-    }
-
-    &:disabled {
-      background-color: #e9ecef;
-      opacity: 0.6 !important;
-      color: #333;
-      cursor: not-allowed;
-    }
-  }
-
-  .p-datepicker-input-wrapper {
-    position: relative;
-    display: inline-flex;
-    width: 100%;
-  }
-
-
   &.custom-height {
-    p-datepicker {
+    systelab-datepicker-calendar {
       height: 100%;
 
-      .p-datepicker-input-wrapper,
-      .p-inputwrapper {
+      .slab-datepicker-input-wrapper {
         height: 100%;
       }
 
@@ -517,11 +496,10 @@ systelab-datepicker {
 
 systelab-date-time {
   &.custom-height {
-    p-datepicker {
+    systelab-datepicker-calendar {
       height: 100%;
 
-      .p-datepicker-input-wrapper,
-      .p-inputwrapper {
+      .slab-datepicker-input-wrapper {
         height: 100%;
       }
 

--- a/projects/systelab-components/src/lib/colorpicker/colorpicker.component.spec.ts
+++ b/projects/systelab-components/src/lib/colorpicker/colorpicker.component.spec.ts
@@ -19,7 +19,6 @@ import { ColorUtilService } from '../utilities/color.util.service';
 import { LoadingService } from '../loading/loading.service';
 import { CommonModule } from '@angular/common';
 import { AngularSplitModule } from 'angular-split';
-import { DatePickerModule } from 'primeng/datepicker';
 import { ContextMenuModule } from 'primeng/contextmenu';
 import { SharedModule } from 'primeng/api';
 
@@ -57,7 +56,6 @@ export class ColorpickerTestComponent {
 		CommonModule,
 		FormsModule,
 		SharedModule,
-		DatePickerModule,
 		DragDropModule,
 		OverlayModule,
 		ContextMenuModule,

--- a/projects/systelab-components/src/lib/contextmenu/context-menu.component.spec.ts
+++ b/projects/systelab-components/src/lib/contextmenu/context-menu.component.spec.ts
@@ -5,7 +5,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { ButtonModule } from 'primeng/button';
-import { DatePickerModule } from 'primeng/datepicker';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { SystelabTranslateModule } from 'systelab-translate';
 import { ContextMenuComponent } from './context-menu.component';
@@ -110,7 +109,6 @@ describe('Systelab Context Menu', () => {
 				FormsModule,
 				OverlayModule,
 				ButtonModule,
-				DatePickerModule,
 				SystelabTranslateModule,
 			],
 			providers: [

--- a/projects/systelab-components/src/lib/contextpanel/context-panel.component.spec.ts
+++ b/projects/systelab-components/src/lib/contextpanel/context-panel.component.spec.ts
@@ -5,7 +5,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { ButtonModule } from 'primeng/button';
-import { DatePickerModule } from 'primeng/datepicker';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { SystelabTranslateModule } from 'systelab-translate';
 import { ContextPanelComponent } from './context-panel.component';
@@ -46,7 +45,6 @@ describe('Systelab Context Panel', () => {
 				FormsModule,
 				OverlayModule,
 				ButtonModule,
-				DatePickerModule,
 				SystelabTranslateModule,
 			],
 			providers: [

--- a/projects/systelab-components/src/lib/datepicker/README.md
+++ b/projects/systelab-components/src/lib/datepicker/README.md
@@ -2,6 +2,16 @@
 
 The datepicker allows users to enter a date either through text input, or by choosing a date from the calendar.
 
+It has no third party dependency: the calendar itself is the `systelab-datepicker-calendar` component
+(`DatepickerCalendarComponent`), written with plain Angular and TypeScript, and `systelab-datepicker` adds on top of it
+the systelab look, the relative date shortcuts (`3d`, `-2w`, `1m`, ...), the loose date inference (`011219`) and the
+warning states. `systelab-date-time` adds the hour/minute spinners.
+
+Every CSS class uses the `slab-` prefix of the library (`slab-datepicker-panel`, `slab-datepicker-day-cell`,
+`slab-datepicker-day`, `slab-datepicker-day-selected`, `slab-datepicker-today`, `slab-datepicker-other-month`,
+`slab-datepicker-time-picker`, ...). The `p-datepicker-*` names of the previous PrimeNG based implementation no longer
+exist: see the root `README.md` for the full mapping.
+
 ## Using the component
 ```
 <systelab-datepicker [(currentDate)]="toDate" [error]="true" [markPreviousAfterDate]="true" [required]="true" [inputExpandHeight]="true" [inputFontSize]="true" [showTodayButton]="false"></systelab-datepicker>
@@ -77,3 +87,39 @@ The default value is retrieved from the translation system (language). In case o
 | disabled | boolean | false | If true the component is shown disabled |
 | resetTimeWhenChangingCurrentDate | boolean | false | If true the time is reset when day calendar changes |
 | showCalendar | boolean | true | If true the calendar is showed else only timepicker is showed |
+
+## systelab-datepicker-calendar
+
+The calendar widget used by the two components above. It is exported for reuse, but applications are expected to use
+`systelab-datepicker` / `systelab-date-time`, which add the systelab behaviour on top of it.
+
+| Name | Type | Default | Description |
+| ---- |:----:|:-------:| ----------- |
+| dateFormat | string | mm/dd/yy | Date format, with the tokens listed above |
+| firstDayOfWeek | number | 0 | First day of the week shown in the grid (0 = Sunday) |
+| translations | DatePickerTranslations | English names | `dayNames`, `dayNamesShort`, `dayNamesMin`, `monthNames`, `monthNamesShort` used to render, format and parse |
+| inline | boolean | false | Renders the calendar without input, always visible |
+| disabled | boolean | false | Disables the input and the calendar |
+| required | boolean | false | Sets the input as required |
+| readonlyInput | boolean | false | Sets the input as read only (used on tablets) |
+| keepInvalid | boolean | false | Keeps the typed text when it cannot be parsed |
+| showOtherMonths | boolean | true | Renders the days of the previous/next month |
+| selectOtherMonths | boolean | false | Makes those days selectable |
+| showTime | boolean | false | Shows an hour/minute picker below the grid |
+| timeOnly | boolean | false | Shows only the hour/minute picker |
+| minDate / maxDate | Date | | Selectable range |
+| disabledDates | Array&lt;Date&gt; | | Individual dates that cannot be selected |
+| disabledDays | Array&lt;number&gt; | | Week days (0-6) that cannot be selected |
+| tabindex | number | 0 | Tab index of the input |
+| autofocus | boolean | false | Focuses the input once rendered |
+| icon | string | | Class of the icon rendered inside the input (`icon-calendar`, `icon-clock`) |
+| inputId | string | | Id set on the input |
+| headerTemplate / footerTemplate | TemplateRef | | Templates rendered at the top and at the bottom of the panel |
+
+Outputs: `onFocus`, `onBlur`, `onSelect`, `onInput`, `onClear`, `onMonthChange`, `onYearChange`. The value is exposed
+through `ngModel` (the component is a `ControlValueAccessor`).
+
+The component is signal based and runs with `OnPush`: the inputs above and its state (`value`, `currentMonth`,
+`currentYear`, `currentHour`, `currentMinute`, `overlayVisible`) are properties backed by signals, and `months`,
+`weekDays`, `hourDisplay`, `minuteDisplay` and `inputFieldValue` are derived from them with `computed()`. Assigning any
+of them from code (`calendar.minDate = …`) is reactive as well, so there is nothing to invalidate or mark for check.

--- a/projects/systelab-components/src/lib/datepicker/datepicker-calendar.component.html
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-calendar.component.html
@@ -1,0 +1,113 @@
+@if (!inline) {
+  <div class="slab-datepicker-input-wrapper slab-form-icon w-100"
+    [class.slab-datepicker-input-focus]="focus || overlayVisible">
+    <input #inputfield type="text" autocomplete="off" role="combobox" aria-autocomplete="none" aria-haspopup="dialog"
+      class="slab-datepicker-input"
+      [attr.id]="inputId"
+      [attr.tabindex]="tabindex ?? 0"
+      [attr.required]="required ? '' : null"
+      [attr.readonly]="readonlyInput ? '' : null"
+      [attr.disabled]="disabled ? '' : null"
+      [attr.aria-required]="required"
+      [attr.aria-expanded]="overlayVisible"
+      [value]="inputFieldValue"
+      (focus)="onInputFocus($event)"
+      (blur)="onInputBlur($event)"
+      (click)="onInputClick()"
+      (keydown)="onInputKeydown($event)"
+      (input)="onUserInput($event)"/>
+    @if (icon) {
+      <i [class]="icon" (click)="onIconClick($event)"></i>
+    }
+  </div>
+}
+
+@if (inline || overlayVisible) {
+  <div #panel class="slab-datepicker-panel"
+    [class.slab-datepicker-panel-inline]="inline"
+    [class.slab-datepicker-panel-timeonly]="timeOnly"
+    [class.slab-datepicker-panel-disabled]="disabled"
+    [attr.role]="inline ? null : 'dialog'"
+    (mousedown)="onPanelMouseDown($event)">
+
+    @if (headerTemplate) {
+      <ng-container [ngTemplateOutlet]="headerTemplate"></ng-container>
+    }
+
+    @if (!timeOnly) {
+      <div class="slab-datepicker-calendar-container">
+        @for (month of months; track month.month) {
+          <div class="slab-datepicker-calendar">
+            <table class="slab-datepicker-day-view" role="grid">
+              <thead>
+                <tr>
+                  @for (weekDay of weekDays; track $index) {
+                    <th class="slab-datepicker-weekday-cell" scope="col">
+                      <span class="slab-datepicker-weekday">{{ weekDay }}</span>
+                    </th>
+                  }
+                </tr>
+              </thead>
+              <tbody>
+                @for (week of month.weeks; track $index) {
+                  <tr>
+                    @for (date of week; track $index) {
+                      <td [class]="date.cellClass" [attr.aria-label]="date.day">
+                        @if (date.visible) {
+                          <span [class]="date.dayClass"
+                          (click)="onDateSelect($event, date)">{{ date.day }}</span>
+                        }
+                      </td>
+                    }
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      </div>
+    }
+
+    @if (showTime || timeOnly) {
+      <div class="slab-datepicker-time-picker">
+        <div class="slab-datepicker-hour-picker">
+          <button type="button" class="slab-datepicker-increment-button icon-angle-up" tabindex="-1"
+            [disabled]="disabled"
+            (mousedown)="onTimePickerElementMouseDown($event, 0, 1)"
+            (mouseup)="onTimePickerElementMouseUp($event)"
+            (mouseleave)="onTimePickerElementMouseLeave()"
+          (keydown.enter)="incrementHour($event)"></button>
+          <span>{{ hourDisplay }}</span>
+          <button type="button" class="slab-datepicker-decrement-button icon-angle-down" tabindex="-1"
+            [disabled]="disabled"
+            (mousedown)="onTimePickerElementMouseDown($event, 0, -1)"
+            (mouseup)="onTimePickerElementMouseUp($event)"
+            (mouseleave)="onTimePickerElementMouseLeave()"
+          (keydown.enter)="decrementHour($event)"></button>
+        </div>
+        <div class="slab-datepicker-separator">
+          <span>:</span>
+        </div>
+        <div class="slab-datepicker-minute-picker">
+          <button type="button" class="slab-datepicker-increment-button icon-angle-up" tabindex="-1"
+            [disabled]="disabled"
+            (mousedown)="onTimePickerElementMouseDown($event, 1, 1)"
+            (mouseup)="onTimePickerElementMouseUp($event)"
+            (mouseleave)="onTimePickerElementMouseLeave()"
+          (keydown.enter)="incrementMinute($event)"></button>
+          <span>{{ minuteDisplay }}</span>
+          <button type="button" class="slab-datepicker-decrement-button icon-angle-down" tabindex="-1"
+            [disabled]="disabled"
+            (mousedown)="onTimePickerElementMouseDown($event, 1, -1)"
+            (mouseup)="onTimePickerElementMouseUp($event)"
+            (mouseleave)="onTimePickerElementMouseLeave()"
+          (keydown.enter)="decrementMinute($event)"></button>
+        </div>
+      </div>
+    }
+
+    @if (footerTemplate) {
+      <ng-container [ngTemplateOutlet]="footerTemplate"></ng-container>
+    }
+  </div>
+}

--- a/projects/systelab-components/src/lib/datepicker/datepicker-calendar.component.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-calendar.component.spec.ts
@@ -1,0 +1,509 @@
+import { Component, provideZoneChangeDetection } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule, By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DatepickerCalendarComponent, DatePickerTranslations } from './datepicker-calendar.component';
+
+const ES_TRANSLATIONS: DatePickerTranslations = {
+	dayNames:        ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'],
+	dayNamesShort:   ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'],
+	dayNamesMin:     ['D', 'L', 'M', 'X', 'J', 'V', 'S'],
+	monthNames:      ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre',
+		'Noviembre', 'Diciembre'],
+	monthNamesShort: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+};
+
+@Component({
+	selector:   'systelab-datepicker-calendar-test',
+	template:   `
+		            <systelab-datepicker-calendar [(ngModel)]="currentDate" [dateFormat]="dateFormat"
+		                                          [firstDayOfWeek]="firstDayOfWeek" [translations]="translations"
+		                                          [minDate]="minDate" [maxDate]="maxDate"
+		                                          [showTime]="showTime" [timeOnly]="timeOnly"
+		                                          [selectOtherMonths]="selectOtherMonths"
+		                                          [showOtherMonths]="showOtherMonths"
+		                                          (onSelect)="selectedDate = $event">
+		            </systelab-datepicker-calendar>
+	            `,
+	standalone: false
+})
+export class DatepickerCalendarTestComponent {
+	public currentDate: Date = new Date(2020, 2, 15);
+	public dateFormat = 'dd/mm/yy';
+	public firstDayOfWeek = 1;
+	public translations = ES_TRANSLATIONS;
+	public minDate: Date;
+	public maxDate: Date;
+	public showTime = false;
+	public timeOnly = false;
+	public selectOtherMonths = false;
+	public showOtherMonths = true;
+	public selectedDate: Date;
+}
+
+describe('Systelab DatepickerCalendarComponent', () => {
+
+	let fixture: ComponentFixture<DatepickerCalendarTestComponent>;
+	let calendar: DatepickerCalendarComponent;
+
+	const getInput = (): HTMLInputElement => fixture.debugElement.query(By.css('input')).nativeElement;
+
+	const openPanel = (): void => {
+		getInput().click();
+		fixture.detectChanges();
+	};
+
+	const getPanel = (): HTMLElement => fixture.debugElement.nativeElement.querySelector('.slab-datepicker-panel');
+
+	const getDayCells = (): Array<HTMLElement> =>
+		Array.from(fixture.debugElement.nativeElement.querySelectorAll('.slab-datepicker-day'));
+
+	const getDay = (day: number): HTMLElement =>
+		getDayCells().find(cell => !cell.parentElement.classList.contains('slab-datepicker-other-month') &&
+			cell.textContent.trim() === String(day));
+
+	const type = (text: string): void => {
+		const input = getInput();
+		input.value = text;
+		input.dispatchEvent(new Event('keydown'));
+		input.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+	};
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [DatepickerCalendarComponent, DatepickerCalendarTestComponent],
+			imports:      [BrowserModule, BrowserAnimationsModule, FormsModule],
+			providers:    [provideZoneChangeDetection()]
+		}).compileComponents();
+	});
+
+	beforeEach(async () => {
+		fixture = TestBed.createComponent(DatepickerCalendarTestComponent);
+		fixture.detectChanges();
+		await fixture.whenStable();
+		fixture.detectChanges();
+		calendar = fixture.debugElement.query(By.directive(DatepickerCalendarComponent)).componentInstance;
+	});
+
+	afterEach(() => fixture.destroy());
+
+	it('should instantiate', () => {
+		expect(calendar).toBeDefined();
+	});
+
+	describe('input field', () => {
+
+		it('should show the model value formatted with the given format', () => {
+			expect(getInput().value).toEqual('15/03/2020');
+		});
+
+		it('should reformat the value when the format changes', () => {
+			fixture.componentInstance.dateFormat = 'yy-mm-dd';
+			fixture.detectChanges();
+			expect(getInput().value).toEqual('2020-03-15');
+		});
+
+		it('should format day and month names with the given translations', () => {
+			fixture.componentInstance.dateFormat = 'DD, d MM yy';
+			fixture.detectChanges();
+			expect(getInput().value).toEqual('Domingo, 15 Marzo 2020');
+		});
+
+		it('should be empty when there is no value', async () => {
+			fixture.componentInstance.currentDate = null;
+			fixture.detectChanges();
+			await fixture.whenStable();
+			expect(getInput().value).toEqual('');
+		});
+	});
+
+	describe('typing', () => {
+
+		it('should update the model with a valid date', () => {
+			type('01/12/2019');
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2019, 11, 1));
+		});
+
+		it('should accept two digit years when the format asks for them', () => {
+			fixture.componentInstance.dateFormat = 'dd/mm/y';
+			fixture.detectChanges();
+			type('01/12/19');
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2019, 11, 1));
+		});
+
+		it('should reject a two digit year when the format asks for four digits', () => {
+			type('01/12/19');
+			expect(fixture.componentInstance.currentDate).toBeNull();
+		});
+
+		it('should reject a date that does not exist', () => {
+			type('31/02/2019');
+			expect(fixture.componentInstance.currentDate).toBeNull();
+		});
+
+		it('should reject text that does not match the format', () => {
+			type('not a date');
+			expect(fixture.componentInstance.currentDate).toBeNull();
+		});
+
+		it('should clear the model when the input is emptied', () => {
+			type('');
+			expect(fixture.componentInstance.currentDate).toBeNull();
+		});
+
+		it('should keep the typed text when keepInvalid is set', () => {
+			calendar.keepInvalid = true;
+			type('nonsense');
+			expect(fixture.componentInstance.currentDate as any).toEqual('nonsense');
+		});
+
+		it('should ignore input events not preceded by a keydown', () => {
+			const input = getInput();
+			input.value = '01/12/2019';
+			input.dispatchEvent(new Event('input'));
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2020, 2, 15));
+		});
+	});
+
+	describe('panel', () => {
+
+		it('should not render the panel until it is opened', () => {
+			expect(getPanel()).toBeNull();
+		});
+
+		it('should render the panel when the input is clicked', () => {
+			openPanel();
+			expect(getPanel()).not.toBeNull();
+		});
+
+		it('should render the panel when the input gets the focus', () => {
+			getInput().dispatchEvent(new Event('focus'));
+			fixture.detectChanges();
+			expect(calendar.overlayVisible).toBeTruthy();
+		});
+
+		it('should close the panel when clicking outside', () => {
+			openPanel();
+			document.dispatchEvent(new MouseEvent('mousedown'));
+			fixture.detectChanges();
+			expect(calendar.overlayVisible).toBeFalsy();
+			expect(getPanel()).toBeNull();
+		});
+
+		it('should close the panel on escape', () => {
+			openPanel();
+			getInput().dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+			fixture.detectChanges();
+			expect(calendar.overlayVisible).toBeFalsy();
+		});
+
+		it('should render the panel inline without an input', () => {
+			calendar.inline = true;
+			calendar.ngOnInit();
+			fixture.detectChanges();
+			expect(fixture.debugElement.query(By.css('input'))).toBeNull();
+			expect(getPanel()).not.toBeNull();
+		});
+	});
+
+	describe('day grid', () => {
+
+		beforeEach(() => openPanel());
+
+		it('should show the week day names starting on the configured first day of week', () => {
+			const weekDays = Array.from(fixture.debugElement.nativeElement.querySelectorAll('.slab-datepicker-weekday'))
+				.map((element: HTMLElement) => element.textContent.trim());
+			expect(weekDays).toEqual(['L', 'M', 'X', 'J', 'V', 'S', 'D']);
+		});
+
+		it('should place the days of the month on the right week day', () => {
+			// 1st of March 2020 was a Sunday, so with Monday as first day of week it is the 7th cell.
+			const firstWeek = fixture.debugElement.nativeElement.querySelectorAll('tbody tr')[0];
+			expect(firstWeek.children[6].textContent.trim()).toEqual('1');
+		});
+
+		it('should mark the selected day', () => {
+			const selected = fixture.debugElement.nativeElement.querySelectorAll('.slab-datepicker-day-selected');
+			expect(selected.length).toEqual(1);
+			expect(selected[0].textContent.trim()).toEqual('15');
+		});
+
+		it('should show the days of the other months', () => {
+			const otherMonth = fixture.debugElement.nativeElement.querySelectorAll('.slab-datepicker-other-month');
+			expect(otherMonth.length).toBeGreaterThan(0);
+			expect(otherMonth[0].children.length).toEqual(1);
+		});
+
+		it('should not render the days of the other months when showOtherMonths is false', () => {
+			fixture.componentInstance.showOtherMonths = false;
+			fixture.detectChanges();
+			const otherMonth = fixture.debugElement.nativeElement.querySelectorAll('.slab-datepicker-other-month');
+			expect(otherMonth.length).toBeGreaterThan(0);
+			expect(otherMonth[0].children.length).toEqual(0);
+		});
+
+		it('should select a day and emit the selection', fakeAsync(() => {
+			getDay(20).click();
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2020, 2, 20));
+			expect(fixture.componentInstance.selectedDate).toEqual(new Date(2020, 2, 20));
+			tick(200);
+			fixture.detectChanges();
+			expect(calendar.overlayVisible).toBeFalsy();
+		}));
+
+		it('should not select days out of the other months when selectOtherMonths is false', () => {
+			const otherMonthDay = fixture.debugElement.nativeElement
+				.querySelector('.slab-datepicker-other-month .slab-datepicker-day');
+			expect(otherMonthDay.classList).toContain('slab-datepicker-day-disabled');
+			otherMonthDay.click();
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2020, 2, 15));
+		});
+
+		it('should select days of the other months when selectOtherMonths is true', () => {
+			fixture.componentInstance.selectOtherMonths = true;
+			fixture.detectChanges();
+			const otherMonthDay = fixture.debugElement.nativeElement
+				.querySelector('.slab-datepicker-other-month .slab-datepicker-day');
+			expect(otherMonthDay.classList).not.toContain('slab-datepicker-day-disabled');
+		});
+
+		it('should disable the days before minDate and after maxDate', () => {
+			fixture.componentInstance.minDate = new Date(2020, 2, 10);
+			fixture.componentInstance.maxDate = new Date(2020, 2, 20);
+			fixture.detectChanges();
+			expect(getDay(9).classList).toContain('slab-datepicker-day-disabled');
+			expect(getDay(10).classList).not.toContain('slab-datepicker-day-disabled');
+			expect(getDay(20).classList).not.toContain('slab-datepicker-day-disabled');
+			expect(getDay(21).classList).toContain('slab-datepicker-day-disabled');
+		});
+
+		it('should not update the model when clicking a disabled day', () => {
+			fixture.componentInstance.minDate = new Date(2020, 2, 10);
+			fixture.detectChanges();
+			getDay(9).click();
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2020, 2, 15));
+		});
+	});
+
+	describe('navigation', () => {
+
+		beforeEach(() => openPanel());
+
+		it('should go to the previous month', () => {
+			calendar.navBackward();
+			expect(calendar.currentMonth).toEqual(1);
+			expect(calendar.currentYear).toEqual(2020);
+		});
+
+		it('should go to the previous year when going back from january', () => {
+			calendar.currentMonth = 0;
+			calendar.navBackward();
+			expect(calendar.currentMonth).toEqual(11);
+			expect(calendar.currentYear).toEqual(2019);
+		});
+
+		it('should go to the next month', () => {
+			calendar.navForward();
+			expect(calendar.currentMonth).toEqual(3);
+		});
+
+		it('should go to the next year when going forward from december', () => {
+			calendar.currentMonth = 11;
+			calendar.navForward();
+			expect(calendar.currentMonth).toEqual(0);
+			expect(calendar.currentYear).toEqual(2021);
+		});
+
+		it('should jump one year backward and forward', () => {
+			calendar.navYearBackward();
+			expect(calendar.currentYear).toEqual(2019);
+			calendar.navYearForward();
+			expect(calendar.currentYear).toEqual(2020);
+		});
+
+		it('should rebuild the grid when navigating', () => {
+			calendar.navForward();
+			fixture.detectChanges();
+			expect(calendar.months[0].month).toEqual(3);
+			expect(getDay(30)).toBeDefined();
+			expect(getDay(31)).toBeUndefined();
+		});
+
+		it('should not navigate when it is disabled', () => {
+			calendar.disabled = true;
+			calendar.navForward();
+			expect(calendar.currentMonth).toEqual(2);
+		});
+	});
+
+	describe('time', () => {
+
+		beforeEach(async () => {
+			fixture.componentInstance.showTime = true;
+			fixture.componentInstance.currentDate = new Date(2020, 2, 15, 10, 30);
+			fixture.detectChanges();
+			await fixture.whenStable();
+			fixture.detectChanges();
+			openPanel();
+		});
+
+		it('should append the time to the input value', () => {
+			expect(getInput().value).toEqual('15/03/2020 10:30');
+		});
+
+		it('should show the time picker', () => {
+			expect(fixture.debugElement.nativeElement.querySelector('.slab-datepicker-time-picker')).not.toBeNull();
+			expect(calendar.hourDisplay).toEqual('10');
+			expect(calendar.minuteDisplay).toEqual('30');
+		});
+
+		it('should increment and decrement the hour', () => {
+			const buttons = fixture.debugElement.nativeElement
+				.querySelectorAll('.slab-datepicker-hour-picker button');
+			buttons[0].dispatchEvent(new MouseEvent('mousedown'));
+			buttons[0].dispatchEvent(new MouseEvent('mouseup'));
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate.getHours()).toEqual(11);
+
+			buttons[1].dispatchEvent(new MouseEvent('mousedown'));
+			buttons[1].dispatchEvent(new MouseEvent('mouseup'));
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate.getHours()).toEqual(10);
+		});
+
+		it('should increment the minute and roll over', () => {
+			calendar.setTime(23, 59);
+			const buttons = fixture.debugElement.nativeElement
+				.querySelectorAll('.slab-datepicker-minute-picker button');
+			buttons[0].dispatchEvent(new MouseEvent('mousedown'));
+			buttons[0].dispatchEvent(new MouseEvent('mouseup'));
+			fixture.detectChanges();
+			expect(fixture.componentInstance.currentDate.getMinutes()).toEqual(0);
+		});
+
+		it('should parse a date and a time', () => {
+			type('01/12/2019 08:45');
+			expect(fixture.componentInstance.currentDate).toEqual(new Date(2019, 11, 1, 8, 45));
+		});
+
+		it('should reject an invalid time', () => {
+			type('01/12/2019 25:45');
+			expect(fixture.componentInstance.currentDate).toBeNull();
+		});
+
+		it('should keep the time inside the minDate boundary', () => {
+			fixture.componentInstance.minDate = new Date(2020, 2, 15, 12, 0);
+			fixture.detectChanges();
+			calendar.setTime(11, 0);
+			calendar.decrementHour(new Event('click'));
+			expect(calendar.currentHour).toEqual(12);
+			expect(calendar.currentMinute).toEqual(0);
+		});
+	});
+
+	describe('time only', () => {
+
+		beforeEach(async () => {
+			fixture.componentInstance.timeOnly = true;
+			fixture.componentInstance.currentDate = new Date(2020, 2, 15, 10, 30);
+			fixture.detectChanges();
+			await fixture.whenStable();
+			fixture.detectChanges();
+			openPanel();
+		});
+
+		it('should show only the time in the input', () => {
+			expect(getInput().value).toEqual('10:30');
+		});
+
+		it('should not show the day grid', () => {
+			expect(fixture.debugElement.nativeElement.querySelector('.slab-datepicker-calendar-container')).toBeNull();
+			expect(fixture.debugElement.nativeElement.querySelector('.slab-datepicker-time-picker')).not.toBeNull();
+		});
+
+		it('should parse a time keeping today as date', () => {
+			type('08:45');
+			expect(fixture.componentInstance.currentDate.getHours()).toEqual(8);
+			expect(fixture.componentInstance.currentDate.getMinutes()).toEqual(45);
+		});
+	});
+
+	describe('clear', () => {
+
+		it('should reset the value and the input', () => {
+			calendar.clear();
+			fixture.detectChanges();
+			expect(calendar.value).toBeNull();
+			expect(getInput().value).toEqual('');
+			expect(fixture.componentInstance.currentDate).toBeNull();
+		});
+	});
+
+	describe('formatting and parsing', () => {
+
+		it('should format with every supported token', () => {
+			const date = new Date(2020, 2, 5);
+			expect(calendar.formatDate(date, 'd/m/y')).toEqual('5/3/20');
+			expect(calendar.formatDate(date, 'dd/mm/yy')).toEqual('05/03/2020');
+			expect(calendar.formatDate(date, 'D DD M MM')).toEqual('Jue Jueves Mar Marzo');
+			expect(calendar.formatDate(date, 'oo')).toEqual('065');
+			expect(calendar.formatDate(date, '\'day\' dd')).toEqual('day 05');
+			expect(calendar.formatDate(date, '@')).toEqual(String(date.getTime()));
+		});
+
+		it('should parse with every supported token', () => {
+			expect(calendar.parseDate('5/3/20', 'd/m/y')).toEqual(new Date(2020, 2, 5));
+			expect(calendar.parseDate('05/03/2020', 'dd/mm/yy')).toEqual(new Date(2020, 2, 5));
+			expect(calendar.parseDate('Jueves 05 Marzo 2020', 'DD dd MM yy')).toEqual(new Date(2020, 2, 5));
+			expect(calendar.parseDate('065/2020', 'oo/yy')).toEqual(new Date(2020, 2, 5));
+		});
+
+		it('should throw when the value does not match the format', () => {
+			expect(() => calendar.parseDate('05-03-2020', 'dd/mm/yy')).toThrow();
+			expect(() => calendar.parseDate('05/03/2020extra', 'dd/mm/yy')).toThrow();
+			expect(() => calendar.parseDate('30/02/2020', 'dd/mm/yy')).toThrow();
+		});
+
+		it('should return null for an empty value', () => {
+			expect(calendar.parseDate('', 'dd/mm/yy')).toBeNull();
+		});
+
+		it('should parse and format times', () => {
+			expect(calendar.parseTime('08:45')).toEqual({hour: 8, minute: 45});
+			expect(() => calendar.parseTime('08')).toThrow();
+			expect(() => calendar.parseTime('24:00')).toThrow();
+			expect(() => calendar.parseTime('08:60')).toThrow();
+			expect(calendar.formatTime(new Date(2020, 2, 5, 8, 5))).toEqual('08:05');
+		});
+	});
+
+	describe('selectable', () => {
+
+		it('should honour minDate, maxDate, disabledDates and disabledDays', () => {
+			calendar.minDate = new Date(2020, 2, 10);
+			calendar.maxDate = new Date(2020, 2, 20);
+			expect(calendar.isSelectable(9, 2, 2020, false)).toBeFalsy();
+			expect(calendar.isSelectable(15, 2, 2020, false)).toBeTruthy();
+			expect(calendar.isSelectable(21, 2, 2020, false)).toBeFalsy();
+			expect(calendar.isSelectable(15, 1, 2020, false)).toBeFalsy();
+			expect(calendar.isSelectable(15, 2, 2019, false)).toBeFalsy();
+
+			calendar.minDate = undefined;
+			calendar.maxDate = undefined;
+			calendar.disabledDates = [new Date(2020, 2, 15)];
+			expect(calendar.isDateDisabled(15, 2, 2020)).toBeTruthy();
+			expect(calendar.isSelectable(15, 2, 2020, false)).toBeFalsy();
+
+			calendar.disabledDates = undefined;
+			calendar.disabledDays = [0, 6];
+			expect(calendar.isSelectable(15, 2, 2020, false)).toBeFalsy();
+			expect(calendar.isSelectable(16, 2, 2020, false)).toBeTruthy();
+		});
+	});
+});

--- a/projects/systelab-components/src/lib/datepicker/datepicker-calendar.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-calendar.component.ts
@@ -1,0 +1,1318 @@
+import {
+	afterRenderEffect,
+	AfterViewInit,
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	ElementRef,
+	EventEmitter,
+	forwardRef,
+	Input,
+	OnDestroy,
+	OnInit,
+	Output,
+	Renderer2,
+	Signal,
+	signal,
+	TemplateRef,
+	ViewChild,
+	WritableSignal
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+/** Localized names used to render and to parse/format dates. */
+export interface DatePickerTranslations {
+	dayNames?: Array<string>;
+	dayNamesShort?: Array<string>;
+	dayNamesMin?: Array<string>;
+	monthNames?: Array<string>;
+	monthNamesShort?: Array<string>;
+}
+
+/**
+ * View model for a single cell of the day grid. Everything the template needs is precalculated
+ * when the month is built, so no method is evaluated during change detection.
+ */
+export interface DatePickerDayCell {
+	day: number;
+	month: number;
+	year: number;
+	otherMonth: boolean;
+	today: boolean;
+	selectable: boolean;
+	selected: boolean;
+	visible: boolean;
+	cellClass: string;
+	dayClass: string;
+}
+
+export interface DatePickerMonthView {
+	month: number;
+	year: number;
+	weeks: Array<Array<DatePickerDayCell>>;
+}
+
+const DEFAULT_TRANSLATIONS: DatePickerTranslations = {
+	dayNames:        ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+	dayNamesShort:   ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+	dayNamesMin:     ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+	monthNames:      ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October',
+		'November', 'December'],
+	monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+};
+
+const TICKS_TO_1970 = ((1970 - 1) * 365 + Math.floor(1970 / 4) - Math.floor(1970 / 100) + Math.floor(1970 / 400)) * 24 * 60 * 60 * 10000000;
+
+const PANEL_MARGIN = 5;
+
+export const DATEPICKER_CALENDAR_VALUE_ACCESSOR = {
+	provide:     NG_VALUE_ACCESSOR,
+	useExisting: forwardRef(() => DatepickerCalendarComponent),
+	multi:       true
+};
+
+@Component({
+	selector:        'systelab-datepicker-calendar',
+	templateUrl:     'datepicker-calendar.component.html',
+	providers:       [DATEPICKER_CALENDAR_VALUE_ACCESSOR],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	standalone:      false
+})
+export class DatepickerCalendarComponent implements OnInit, AfterViewInit, OnDestroy, ControlValueAccessor {
+
+	private readonly $dateFormat = signal('mm/dd/yy');
+	private readonly $firstDayOfWeek = signal(0);
+	private readonly $translations = signal<DatePickerTranslations>(undefined);
+	private readonly $inline = signal(false);
+	private readonly $disabled = signal(false);
+	private readonly $required = signal(false);
+	private readonly $readonlyInput = signal(false);
+	private readonly $keepInvalid = signal(false);
+	private readonly $showOtherMonths = signal(true);
+	private readonly $selectOtherMonths = signal(false);
+	private readonly $showTime = signal(false);
+	private readonly $timeOnly = signal(false);
+	private readonly $minDate = signal<Date>(undefined);
+	private readonly $maxDate = signal<Date>(undefined);
+	private readonly $disabledDates = signal<Array<Date>>(undefined);
+	private readonly $disabledDays = signal<Array<number>>(undefined);
+	private readonly $tabindex = signal<number>(undefined);
+	private readonly $icon = signal<string>(undefined);
+	private readonly $inputId = signal<string>(undefined);
+	private readonly $headerTemplate = signal<TemplateRef<any>>(undefined);
+	private readonly $footerTemplate = signal<TemplateRef<any>>(undefined);
+
+	@Input()
+	public set dateFormat(value: string) {
+		this.$dateFormat.set(value);
+	}
+
+	public get dateFormat(): string {
+		return this.$dateFormat();
+	}
+
+	@Input()
+	public set firstDayOfWeek(value: number) {
+		this.$firstDayOfWeek.set(value);
+	}
+
+	public get firstDayOfWeek(): number {
+		return this.$firstDayOfWeek();
+	}
+
+	@Input()
+	public set translations(value: DatePickerTranslations) {
+		this.$translations.set(value);
+	}
+
+	public get translations(): DatePickerTranslations {
+		return this.$translations();
+	}
+
+	@Input()
+	public set inline(value: boolean) {
+		this.$inline.set(value);
+	}
+
+	public get inline(): boolean {
+		return this.$inline();
+	}
+
+	@Input()
+	public set disabled(value: boolean) {
+		this.$disabled.set(value);
+	}
+
+	public get disabled(): boolean {
+		return this.$disabled();
+	}
+
+	@Input()
+	public set required(value: boolean) {
+		this.$required.set(value);
+	}
+
+	public get required(): boolean {
+		return this.$required();
+	}
+
+	@Input()
+	public set readonlyInput(value: boolean) {
+		this.$readonlyInput.set(value);
+	}
+
+	public get readonlyInput(): boolean {
+		return this.$readonlyInput();
+	}
+
+	@Input()
+	public set keepInvalid(value: boolean) {
+		this.$keepInvalid.set(value);
+	}
+
+	public get keepInvalid(): boolean {
+		return this.$keepInvalid();
+	}
+
+	@Input()
+	public set showOtherMonths(value: boolean) {
+		this.$showOtherMonths.set(value);
+	}
+
+	public get showOtherMonths(): boolean {
+		return this.$showOtherMonths();
+	}
+
+	@Input()
+	public set selectOtherMonths(value: boolean) {
+		this.$selectOtherMonths.set(value);
+	}
+
+	public get selectOtherMonths(): boolean {
+		return this.$selectOtherMonths();
+	}
+
+	@Input()
+	public set showTime(value: boolean) {
+		this.$showTime.set(value);
+	}
+
+	public get showTime(): boolean {
+		return this.$showTime();
+	}
+
+	@Input()
+	public set timeOnly(value: boolean) {
+		this.$timeOnly.set(value);
+	}
+
+	public get timeOnly(): boolean {
+		return this.$timeOnly();
+	}
+
+	@Input()
+	public set minDate(value: Date) {
+		this.$minDate.set(value);
+	}
+
+	public get minDate(): Date {
+		return this.$minDate();
+	}
+
+	@Input()
+	public set maxDate(value: Date) {
+		this.$maxDate.set(value);
+	}
+
+	public get maxDate(): Date {
+		return this.$maxDate();
+	}
+
+	@Input()
+	public set disabledDates(value: Array<Date>) {
+		this.$disabledDates.set(value);
+	}
+
+	public get disabledDates(): Array<Date> {
+		return this.$disabledDates();
+	}
+
+	@Input()
+	public set disabledDays(value: Array<number>) {
+		this.$disabledDays.set(value);
+	}
+
+	public get disabledDays(): Array<number> {
+		return this.$disabledDays();
+	}
+
+	@Input()
+	public set tabindex(value: number) {
+		this.$tabindex.set(value);
+	}
+
+	public get tabindex(): number {
+		return this.$tabindex();
+	}
+
+	@Input()
+	public set icon(value: string) {
+		this.$icon.set(value);
+	}
+
+	public get icon(): string {
+		return this.$icon();
+	}
+
+	@Input()
+	public set inputId(value: string) {
+		this.$inputId.set(value);
+	}
+
+	public get inputId(): string {
+		return this.$inputId();
+	}
+
+	@Input()
+	public set headerTemplate(value: TemplateRef<any>) {
+		this.$headerTemplate.set(value);
+	}
+
+	public get headerTemplate(): TemplateRef<any> {
+		return this.$headerTemplate();
+	}
+
+	@Input()
+	public set footerTemplate(value: TemplateRef<any>) {
+		this.$footerTemplate.set(value);
+	}
+
+	public get footerTemplate(): TemplateRef<any> {
+		return this.$footerTemplate();
+	}
+
+	/** Only read once, when the view is created, so it does not need to be reactive. */
+	@Input() public autofocus = false;
+
+	@Output() public onFocus = new EventEmitter<FocusEvent>();
+	@Output() public onBlur = new EventEmitter<FocusEvent>();
+	@Output() public onSelect = new EventEmitter<Date>();
+	@Output() public onInput = new EventEmitter<Event>();
+	@Output() public onClear = new EventEmitter<void>();
+	@Output() public onMonthChange = new EventEmitter<{ month: number, year: number }>();
+	@Output() public onYearChange = new EventEmitter<{ month: number, year: number }>();
+
+	@ViewChild('inputfield') public inputfieldViewChild: ElementRef<HTMLInputElement>;
+	@ViewChild('panel') public panelViewChild: ElementRef<HTMLElement>;
+
+	private readonly $value: WritableSignal<any> = signal(null);
+	private readonly $currentMonth = signal<number>(undefined);
+	private readonly $currentYear = signal<number>(undefined);
+	private readonly $currentHour = signal(0);
+	private readonly $currentMinute = signal(0);
+	private readonly $overlayVisible = signal(false);
+	private readonly $focus = signal(false);
+
+	public get value(): any {
+		return this.$value();
+	}
+
+	public set value(value: any) {
+		this.$value.set(value);
+	}
+
+	public get currentMonth(): number {
+		return this.$currentMonth();
+	}
+
+	public set currentMonth(value: number) {
+		this.$currentMonth.set(value);
+	}
+
+	public get currentYear(): number {
+		return this.$currentYear();
+	}
+
+	public set currentYear(value: number) {
+		this.$currentYear.set(value);
+	}
+
+	public get currentHour(): number {
+		return this.$currentHour();
+	}
+
+	public get currentMinute(): number {
+		return this.$currentMinute();
+	}
+
+	public get overlayVisible(): boolean {
+		return this.$overlayVisible();
+	}
+
+	public get focus(): boolean {
+		return this.$focus();
+	}
+
+	/** Text shown in the input, derived from the value and the format. */
+	private readonly $inputFieldValue: Signal<string> = computed(() => this.formatDateTime(this.$value()));
+
+	/** Week day headers, starting on the configured first day of week. */
+	private readonly $weekDays: Signal<Array<string>> = computed(() => {
+		const dayLabels = this.getTranslation('dayNamesMin');
+		const weekDays: Array<string> = [];
+		let dayIndex = this.$firstDayOfWeek() ?? 0;
+		for (let i = 0; i < 7; i++) {
+			weekDays.push(dayLabels[dayIndex]);
+			dayIndex = dayIndex === 6 ? 0 : dayIndex + 1;
+		}
+		return weekDays;
+	});
+
+	/**
+	 * The rendered month. Being a derivation there is nothing to invalidate: it is rebuilt when the
+	 * displayed month, the value, the selectable range or the translations change, and only when
+	 * the panel that reads it is on screen.
+	 */
+	private readonly $months: Signal<Array<DatePickerMonthView>> = computed(() => {
+		const month = this.$currentMonth();
+		const year = this.$currentYear();
+		if (month === undefined || year === undefined) {
+			return [];
+		}
+		return [this.createMonth(month, year)];
+	});
+
+	private readonly $hourDisplay = computed(() => this.pad(this.$currentHour()));
+	private readonly $minuteDisplay = computed(() => this.pad(this.$currentMinute()));
+
+	public get inputFieldValue(): string {
+		return this.$inputFieldValue();
+	}
+
+	public get weekDays(): Array<string> {
+		return this.$weekDays();
+	}
+
+	public get months(): Array<DatePickerMonthView> {
+		return this.$months();
+	}
+
+	public get hourDisplay(): string {
+		return this.$hourDisplay();
+	}
+
+	public get minuteDisplay(): string {
+		return this.$minuteDisplay();
+	}
+
+	private isKeydown = false;
+	private hideTimer: any;
+	private focusTimer: any;
+	private timePickerTimer: any;
+	private unlistenScroll: () => void;
+	private unlistenResize: () => void;
+	private unlistenDocumentClick: () => void;
+
+	private onModelChange: (value: any) => void = () => {
+	};
+	private onModelTouched: () => void = () => {
+	};
+
+	constructor(public el: ElementRef, protected renderer: Renderer2) {
+		// The panel is a fixed element: every time it is shown (and on every render while it is
+		// open) it is measured and placed below the input, or above it when it does not fit.
+		afterRenderEffect(() => {
+			if (this.$overlayVisible()) {
+				this.alignOverlay();
+			}
+		});
+	}
+
+	public ngOnInit(): void {
+		const date = this.isValidDate(this.$value()) ? this.$value() : new Date();
+		this.$currentMonth.set(date.getMonth());
+		this.$currentYear.set(date.getFullYear());
+		this.initTime(date);
+	}
+
+	public ngAfterViewInit(): void {
+		if (this.autofocus && this.inputfieldViewChild) {
+			// Deferred so that opening the panel on focus does not happen in the middle of a
+			// change detection cycle.
+			this.focusTimer = setTimeout(() => {
+				this.focusTimer = null;
+				this.inputfieldViewChild?.nativeElement.focus();
+			});
+		}
+	}
+
+	public ngOnDestroy(): void {
+		this.clearTimePickerTimer();
+		[this.hideTimer, this.focusTimer].forEach(timer => {
+			if (timer) {
+				clearTimeout(timer);
+			}
+		});
+		this.hideTimer = this.focusTimer = null;
+		this.unbindOverlayListeners();
+	}
+
+	// ------------------------------------------------------------------ ControlValueAccessor
+
+	public writeValue(value: any): void {
+		let parsed = value;
+		if (parsed && typeof parsed === 'string') {
+			try {
+				parsed = this.parseDateTime(parsed);
+			} catch {
+				if (!this.keepInvalid) {
+					parsed = null;
+				}
+			}
+		}
+		this.$value.set(parsed);
+		this.updateInputfield();
+		this.updateUI();
+	}
+
+	public registerOnChange(fn: (value: any) => void): void {
+		this.onModelChange = fn;
+	}
+
+	public registerOnTouched(fn: () => void): void {
+		this.onModelTouched = fn;
+	}
+
+	public setDisabledState(isDisabled: boolean): void {
+		this.$disabled.set(isDisabled);
+	}
+
+	// ------------------------------------------------------------------ Public API
+
+	public clear(): void {
+		this.$value.set(null);
+		this.onModelChange(null);
+		this.updateInputfield();
+		this.onClear.emit();
+	}
+
+	public navBackward(event?: Event): void {
+		if (this.disabled) {
+			event?.preventDefault();
+			return;
+		}
+		if (this.$currentMonth() === 0) {
+			this.$currentMonth.set(11);
+			this.$currentYear.update(year => year - 1);
+		} else {
+			this.$currentMonth.update(month => month - 1);
+		}
+		this.onMonthChange.emit({month: this.$currentMonth() + 1, year: this.$currentYear()});
+	}
+
+	public navForward(event?: Event): void {
+		if (this.disabled) {
+			event?.preventDefault();
+			return;
+		}
+		if (this.$currentMonth() === 11) {
+			this.$currentMonth.set(0);
+			this.$currentYear.update(year => year + 1);
+		} else {
+			this.$currentMonth.update(month => month + 1);
+		}
+		this.onMonthChange.emit({month: this.$currentMonth() + 1, year: this.$currentYear()});
+	}
+
+	public navYearBackward(event?: Event): void {
+		if (this.disabled) {
+			event?.preventDefault();
+			return;
+		}
+		this.$currentYear.update(year => year - 1);
+		this.onYearChange.emit({month: this.$currentMonth() + 1, year: this.$currentYear()});
+	}
+
+	public navYearForward(event?: Event): void {
+		if (this.disabled) {
+			event?.preventDefault();
+			return;
+		}
+		this.$currentYear.update(year => year + 1);
+		this.onYearChange.emit({month: this.$currentMonth() + 1, year: this.$currentYear()});
+	}
+
+	public showOverlay(): void {
+		if (this.inline || this.overlayVisible || this.disabled) {
+			return;
+		}
+		this.updateUI();
+		this.$overlayVisible.set(true);
+		this.bindOverlayListeners();
+	}
+
+	public hideOverlay(): void {
+		if (this.hideTimer) {
+			clearTimeout(this.hideTimer);
+			this.hideTimer = null;
+		}
+		if (!this.overlayVisible) {
+			return;
+		}
+		this.$overlayVisible.set(false);
+		this.unbindOverlayListeners();
+	}
+
+	/** Places the panel right below the input, flipping it above when there is not enough room. */
+	public alignOverlay(): void {
+		if (this.inline || !this.panelViewChild || !this.el?.nativeElement) {
+			return;
+		}
+		const panel = this.panelViewChild.nativeElement;
+		const inputRect = (this.inputfieldViewChild?.nativeElement ?? this.el.nativeElement).getBoundingClientRect();
+		let top = inputRect.bottom;
+		if (top + panel.offsetHeight > window.innerHeight) {
+			const flipped = inputRect.top - panel.offsetHeight - PANEL_MARGIN;
+			top = flipped > 0 ? flipped : Math.max(window.innerHeight - panel.offsetHeight, 0);
+		}
+		let left = inputRect.left;
+		if (left + panel.offsetWidth > window.innerWidth) {
+			left = Math.max(window.innerWidth - panel.offsetWidth, 0);
+		}
+		this.renderer.setStyle(panel, 'position', 'fixed');
+		this.renderer.setStyle(panel, 'top', `${Math.round(top)}px`);
+		this.renderer.setStyle(panel, 'left', `${Math.round(left)}px`);
+	}
+
+	public isSelectable(day: number, month: number, year: number, otherMonth: boolean): boolean {
+		if (otherMonth && !this.selectOtherMonths) {
+			return false;
+		}
+		let validMin = true;
+		let validMax = true;
+		if (this.minDate) {
+			if (this.minDate.getFullYear() > year) {
+				validMin = false;
+			} else if (this.minDate.getFullYear() === year) {
+				if (this.minDate.getMonth() > month) {
+					validMin = false;
+				} else if (this.minDate.getMonth() === month && this.minDate.getDate() > day) {
+					validMin = false;
+				}
+			}
+		}
+		if (this.maxDate) {
+			if (this.maxDate.getFullYear() < year) {
+				validMax = false;
+			} else if (this.maxDate.getFullYear() === year) {
+				if (this.maxDate.getMonth() < month) {
+					validMax = false;
+				} else if (this.maxDate.getMonth() === month && this.maxDate.getDate() < day) {
+					validMax = false;
+				}
+			}
+		}
+		return validMin && validMax && !this.isDateDisabled(day, month, year) && !this.isDayDisabled(day, month, year);
+	}
+
+	public isDateDisabled(day: number, month: number, year: number): boolean {
+		if (this.disabledDates) {
+			return this.disabledDates.some(disabledDate => disabledDate.getFullYear() === year &&
+				disabledDate.getMonth() === month && disabledDate.getDate() === day);
+		}
+		return false;
+	}
+
+	public isDayDisabled(day: number, month: number, year: number): boolean {
+		if (this.disabledDays) {
+			return this.disabledDays.indexOf(new Date(year, month, day).getDay()) !== -1;
+		}
+		return false;
+	}
+
+	public isSelected(day: number, month: number, year: number): boolean {
+		return this.isValidDate(this.value) && this.value.getDate() === day && this.value.getMonth() === month &&
+			this.value.getFullYear() === year;
+	}
+
+	// ------------------------------------------------------------------ Template handlers
+
+	public onInputFocus(event: FocusEvent): void {
+		this.$focus.set(true);
+		this.showOverlay();
+		this.onFocus.emit(event);
+	}
+
+	public onInputClick(): void {
+		if (!this.overlayVisible) {
+			this.showOverlay();
+		}
+	}
+
+	public onInputBlur(event: FocusEvent): void {
+		this.$focus.set(false);
+		this.onBlur.emit(event);
+		if (!this.keepInvalid) {
+			this.updateInputfield();
+		}
+		this.onModelTouched();
+	}
+
+	public onInputKeydown(event: KeyboardEvent): void {
+		this.isKeydown = true;
+		if (event.key === 'Escape' && this.overlayVisible) {
+			this.hideOverlay();
+			event.preventDefault();
+		}
+	}
+
+	public onUserInput(event: Event): void {
+		// Guard kept for parity with the previous implementation: only real typing updates the model.
+		if (!this.isKeydown) {
+			return;
+		}
+		this.isKeydown = false;
+		const text = (event.target as HTMLInputElement).value;
+		try {
+			const parsed = this.parseValueFromString(text);
+			if (parsed === null || this.isValidSelection(parsed)) {
+				this.updateModel(parsed);
+				this.updateUI();
+			} else if (this.keepInvalid) {
+				this.updateModel(parsed);
+			}
+		} catch {
+			this.updateModel(this.keepInvalid ? text : null);
+		}
+		this.onInput.emit(event);
+	}
+
+	public onIconClick(event: Event): void {
+		event.preventDefault();
+		if (this.disabled) {
+			return;
+		}
+		this.inputfieldViewChild?.nativeElement.focus();
+		if (!this.overlayVisible) {
+			this.showOverlay();
+		}
+	}
+
+	public onDateSelect(event: Event, cell: DatePickerDayCell): void {
+		if (this.disabled || !cell.selectable) {
+			event.preventDefault();
+			return;
+		}
+		this.selectDate(cell);
+		if (!this.inline) {
+			this.hideTimer = setTimeout(() => {
+				this.hideTimer = null;
+				this.hideOverlay();
+			}, 150);
+		}
+		this.updateInputfield();
+		event.preventDefault();
+	}
+
+	public onPanelMouseDown(event: MouseEvent): void {
+		// Avoids losing the input focus (and therefore closing the panel) when interacting with it.
+		const target = event.target as HTMLElement;
+		if (target && target.tagName !== 'INPUT') {
+			event.preventDefault();
+		}
+	}
+
+	public incrementHour(event: Event): void {
+		this.$currentHour.update(hour => hour >= 23 ? 0 : hour + 1);
+		this.constrainTime();
+		event.preventDefault();
+	}
+
+	public decrementHour(event: Event): void {
+		this.$currentHour.update(hour => hour <= 0 ? 23 : hour - 1);
+		this.constrainTime();
+		event.preventDefault();
+	}
+
+	public incrementMinute(event: Event): void {
+		this.$currentMinute.update(minute => minute >= 59 ? 0 : minute + 1);
+		this.constrainTime();
+		event.preventDefault();
+	}
+
+	public decrementMinute(event: Event): void {
+		this.$currentMinute.update(minute => minute <= 0 ? 59 : minute - 1);
+		this.constrainTime();
+		event.preventDefault();
+	}
+
+	public onTimePickerElementMouseDown(event: MouseEvent, type: number, direction: number): void {
+		if (!this.disabled) {
+			this.repeat(event, null, type, direction);
+			event.preventDefault();
+		}
+	}
+
+	public onTimePickerElementMouseUp(event: Event): void {
+		if (!this.disabled) {
+			this.clearTimePickerTimer();
+			this.updateTime();
+		}
+	}
+
+	public onTimePickerElementMouseLeave(): void {
+		if (!this.disabled && this.timePickerTimer) {
+			this.clearTimePickerTimer();
+			this.updateTime();
+		}
+	}
+
+	// ------------------------------------------------------------------ Model
+
+	/**
+	 * Writes the formatted value into the input. The text is already bound through
+	 * `inputFieldValue`, but the element has to be written to explicitly to discard what the user
+	 * typed when it could not be parsed (the bound value did not change in that case).
+	 */
+	public updateInputfield(): void {
+		if (this.inputfieldViewChild?.nativeElement) {
+			// Formatted here instead of reading the derived value, so that it is also right when the
+			// bound date was modified in place and the signal therefore did not change.
+			this.inputfieldViewChild.nativeElement.value = this.formatDateTime(this.value);
+		}
+	}
+
+	public updateUI(): void {
+		const date = this.isValidDate(this.value) ? this.value : new Date();
+		this.$currentMonth.set(date.getMonth());
+		this.$currentYear.set(date.getFullYear());
+		if (this.showTime || this.timeOnly) {
+			this.setTime(date.getHours(), date.getMinutes());
+		}
+	}
+
+	public formatDateTime(date: any): string {
+		if (!this.isValidDate(date)) {
+			return this.keepInvalid && typeof date === 'string' ? date : '';
+		}
+		if (!this.isValidDateForTimeConstraints(date)) {
+			return '';
+		}
+		if (this.timeOnly) {
+			return this.formatTime(date);
+		}
+		let formatted = this.formatDate(date, this.dateFormat);
+		if (this.showTime) {
+			formatted += ' ' + this.formatTime(date);
+		}
+		return formatted;
+	}
+
+	/** Ported from the jQuery UI datepicker formatDate. */
+	public formatDate(date: Date, format: string): string {
+		if (!date) {
+			return '';
+		}
+		let iFormat = 0;
+		const lookAhead = (match: string): boolean => {
+			const matches = iFormat + 1 < format.length && format.charAt(iFormat + 1) === match;
+			if (matches) {
+				iFormat++;
+			}
+			return matches;
+		};
+		const formatNumber = (match: string, value: number, len: number): string => {
+			let num = '' + value;
+			if (lookAhead(match)) {
+				while (num.length < len) {
+					num = '0' + num;
+				}
+			}
+			return num;
+		};
+		const formatName = (match: string, value: number, shortNames: Array<string>, longNames: Array<string>): string =>
+			lookAhead(match) ? longNames[value] : shortNames[value];
+
+		let output = '';
+		let literal = false;
+		for (iFormat = 0; iFormat < format.length; iFormat++) {
+			if (literal) {
+				if (format.charAt(iFormat) === '\'' && !lookAhead('\'')) {
+					literal = false;
+				} else {
+					output += format.charAt(iFormat);
+				}
+				continue;
+			}
+			switch (format.charAt(iFormat)) {
+				case 'd':
+					output += formatNumber('d', date.getDate(), 2);
+					break;
+				case 'D':
+					output += formatName('D', date.getDay(), this.getTranslation('dayNamesShort'), this.getTranslation('dayNames'));
+					break;
+				case 'o':
+					output += formatNumber('o', Math.round((new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() -
+						new Date(date.getFullYear(), 0, 0).getTime()) / 86400000), 3);
+					break;
+				case 'm':
+					output += formatNumber('m', date.getMonth() + 1, 2);
+					break;
+				case 'M':
+					output += formatName('M', date.getMonth(), this.getTranslation('monthNamesShort'), this.getTranslation('monthNames'));
+					break;
+				case 'y':
+					output += lookAhead('y') ? date.getFullYear() : (date.getFullYear() % 100 < 10 ? '0' : '') + (date.getFullYear() % 100);
+					break;
+				case '@':
+					output += date.getTime();
+					break;
+				case '!':
+					output += date.getTime() * 10000 + TICKS_TO_1970;
+					break;
+				case '\'':
+					if (lookAhead('\'')) {
+						output += '\'';
+					} else {
+						literal = true;
+					}
+					break;
+				default:
+					output += format.charAt(iFormat);
+			}
+		}
+		return output;
+	}
+
+	public formatTime(date: Date): string {
+		if (!date) {
+			return '';
+		}
+		return `${this.pad(date.getHours())}:${this.pad(date.getMinutes())}`;
+	}
+
+	/** Ported from the jQuery UI datepicker parseDate. Throws when the value does not match the format. */
+	public parseDate(value: string, format: string): Date {
+		if (format === null || format === undefined || value === null || value === undefined) {
+			throw new Error('Invalid arguments');
+		}
+		value = typeof value === 'object' ? String(value) : value + '';
+		if (value === '') {
+			return null;
+		}
+
+		const shortYearCutoff = (new Date().getFullYear() % 100) + 10;
+		let iFormat = 0;
+		let iValue = 0;
+		let year = -1;
+		let month = -1;
+		let day = -1;
+		let doy = -1;
+		let literal = false;
+		let date: Date;
+
+		const lookAhead = (match: string): boolean => {
+			const matches = iFormat + 1 < format.length && format.charAt(iFormat + 1) === match;
+			if (matches) {
+				iFormat++;
+			}
+			return matches;
+		};
+		const getNumber = (match: string): number => {
+			const isDoubled = lookAhead(match);
+			const size = match === '@' ? 14 : match === '!' ? 20 : match === 'y' && isDoubled ? 4 : match === 'o' ? 3 : 2;
+			const minSize = match === 'y' ? size : 1;
+			const digits = new RegExp('^\\d{' + minSize + ',' + size + '}');
+			const num = value.substring(iValue)
+				.match(digits);
+			if (!num) {
+				throw new Error('Missing number at position ' + iValue);
+			}
+			iValue += num[0].length;
+			return parseInt(num[0], 10);
+		};
+		const getName = (match: string, shortNames: Array<string>, longNames: Array<string>): number => {
+			const arr = lookAhead(match) ? longNames : shortNames;
+			const names: Array<[number, string]> = arr.map((name, index) => [index, name] as [number, string]);
+			names.sort((a, b) => -(a[1].length - b[1].length));
+			for (const [index, name] of names) {
+				if (value.substr(iValue, name.length)
+					.toLowerCase() === name.toLowerCase()) {
+					iValue += name.length;
+					return index + 1;
+				}
+			}
+			throw new Error('Unknown name at position ' + iValue);
+		};
+		const checkLiteral = (): void => {
+			if (value.charAt(iValue) !== format.charAt(iFormat)) {
+				throw new Error('Unexpected literal at position ' + iValue);
+			}
+			iValue++;
+		};
+
+		for (iFormat = 0; iFormat < format.length; iFormat++) {
+			if (literal) {
+				if (format.charAt(iFormat) === '\'' && !lookAhead('\'')) {
+					literal = false;
+				} else {
+					checkLiteral();
+				}
+				continue;
+			}
+			switch (format.charAt(iFormat)) {
+				case 'd':
+					day = getNumber('d');
+					break;
+				case 'D':
+					getName('D', this.getTranslation('dayNamesShort'), this.getTranslation('dayNames'));
+					break;
+				case 'o':
+					doy = getNumber('o');
+					break;
+				case 'm':
+					month = getNumber('m');
+					break;
+				case 'M':
+					month = getName('M', this.getTranslation('monthNamesShort'), this.getTranslation('monthNames'));
+					break;
+				case 'y':
+					year = getNumber('y');
+					break;
+				case '@':
+					date = new Date(getNumber('@'));
+					year = date.getFullYear();
+					month = date.getMonth() + 1;
+					day = date.getDate();
+					break;
+				case '!':
+					date = new Date((getNumber('!') - TICKS_TO_1970) / 10000);
+					year = date.getFullYear();
+					month = date.getMonth() + 1;
+					day = date.getDate();
+					break;
+				case '\'':
+					if (lookAhead('\'')) {
+						checkLiteral();
+					} else {
+						literal = true;
+					}
+					break;
+				default:
+					checkLiteral();
+			}
+		}
+
+		if (iValue < value.length) {
+			const extra = value.substr(iValue);
+			if (!/^\s+/.test(extra)) {
+				throw new Error('Extra/unparsed characters found in date: ' + extra);
+			}
+		}
+
+		if (year === -1) {
+			year = new Date().getFullYear();
+		} else if (year < 100) {
+			year += new Date().getFullYear() - (new Date().getFullYear() % 100) + (year <= shortYearCutoff ? 0 : -100);
+		}
+
+		if (doy > -1) {
+			month = 1;
+			day = doy;
+			let dim: number;
+			do {
+				dim = this.getDaysCountInMonth(month - 1, year);
+				if (day <= dim) {
+					break;
+				}
+				month++;
+				day -= dim;
+			} while (true);
+		}
+
+		date = this.daylightSavingAdjust(new Date(year, month - 1, day));
+		if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
+			throw new Error('Invalid date');
+		}
+		return date;
+	}
+
+	public parseTime(value: string): { hour: number, minute: number } {
+		const tokens = value.split(':');
+		if (tokens.length !== 2) {
+			throw new Error('Invalid time');
+		}
+		const hour = parseInt(tokens[0], 10);
+		const minute = parseInt(tokens[1], 10);
+		if (isNaN(hour) || isNaN(minute) || hour > 23 || minute > 59) {
+			throw new Error('Invalid time');
+		}
+		return {hour, minute};
+	}
+
+	public parseDateTime(text: string): Date {
+		const parts = text.split(' ');
+		let date: Date;
+		if (this.timeOnly) {
+			date = new Date();
+			this.populateTime(date, parts[0]);
+		} else if (this.showTime) {
+			const timeString = parts.pop();
+			date = this.parseDate(parts.join(' '), this.dateFormat);
+			this.populateTime(date, timeString);
+		} else {
+			date = this.parseDate(text, this.dateFormat);
+		}
+		return date;
+	}
+
+	public parseValueFromString(text: string): Date {
+		if (!text || text.trim().length === 0) {
+			return null;
+		}
+		return this.parseDateTime(text);
+	}
+
+	// ------------------------------------------------------------------ Internals
+
+	protected selectDate(cell: DatePickerDayCell): void {
+		let date = new Date(cell.year, cell.month, cell.day);
+		if (this.showTime) {
+			date.setHours(this.currentHour, this.currentMinute, 0, 0);
+		}
+		if (this.minDate && this.minDate > date) {
+			date = this.minDate;
+			this.setTime(date.getHours(), date.getMinutes());
+		}
+		if (this.maxDate && this.maxDate < date) {
+			date = this.maxDate;
+			this.setTime(date.getHours(), date.getMinutes());
+		}
+		this.updateModel(date);
+		this.onSelect.emit(date);
+	}
+
+	protected updateModel(value: any): void {
+		this.$value.set(value);
+		this.onModelChange(value);
+	}
+
+	protected updateTime(): void {
+		const value = this.isValidDate(this.value) ? new Date(this.value.getTime()) : new Date();
+		value.setHours(this.currentHour, this.currentMinute, 0, 0);
+		this.updateModel(value);
+		this.onSelect.emit(value);
+		this.updateInputfield();
+	}
+
+	protected repeat(event: MouseEvent, interval: number, type: number, direction: number): void {
+		const i = interval || 500;
+		this.clearTimePickerTimer();
+		this.timePickerTimer = setTimeout(() => this.repeat(event, 100, type, direction), i);
+
+		if (type === 0) {
+			if (direction === 1) {
+				this.incrementHour(event);
+			} else {
+				this.decrementHour(event);
+			}
+		} else {
+			if (direction === 1) {
+				this.incrementMinute(event);
+			} else {
+				this.decrementMinute(event);
+			}
+		}
+		this.updateInputfield();
+	}
+
+	protected clearTimePickerTimer(): void {
+		if (this.timePickerTimer) {
+			clearTimeout(this.timePickerTimer);
+			this.timePickerTimer = null;
+		}
+	}
+
+	/** Keeps the edited time inside the minDate/maxDate boundaries when they fall on the selected day. */
+	protected constrainTime(): void {
+		const value = this.isValidDate(this.value) ? this.value : null;
+		const valueDateString = value ? value.toDateString() : null;
+		if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+			if (this.currentHour < this.minDate.getHours()) {
+				this.setTime(this.minDate.getHours(), this.minDate.getMinutes());
+			} else if (this.currentHour === this.minDate.getHours() && this.currentMinute < this.minDate.getMinutes()) {
+				this.setTime(this.currentHour, this.minDate.getMinutes());
+			}
+		}
+		if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+			if (this.currentHour > this.maxDate.getHours()) {
+				this.setTime(this.maxDate.getHours(), this.maxDate.getMinutes());
+			} else if (this.currentHour === this.maxDate.getHours() && this.currentMinute > this.maxDate.getMinutes()) {
+				this.setTime(this.currentHour, this.maxDate.getMinutes());
+			}
+		}
+	}
+
+	protected initTime(date: Date): void {
+		if (this.showTime) {
+			this.setTime(date.getHours(), date.getMinutes());
+		} else {
+			this.setTime(0, 0);
+		}
+	}
+
+	public setTime(hour: number, minute: number): void {
+		this.$currentHour.set(hour);
+		this.$currentMinute.set(minute);
+	}
+
+	protected populateTime(value: Date, timeString: string): void {
+		const time = this.parseTime(timeString);
+		value.setHours(time.hour, time.minute, 0, 0);
+	}
+
+	protected isValidSelection(value: Date): boolean {
+		return this.isSelectable(value.getDate(), value.getMonth(), value.getFullYear(), false);
+	}
+
+	protected isValidDate(date: any): boolean {
+		return date instanceof Date && !isNaN(date.getTime());
+	}
+
+	protected isValidDateForTimeConstraints(date: Date): boolean {
+		if (this.keepInvalid) {
+			return true;
+		}
+		return (!this.minDate || date >= this.minDate) && (!this.maxDate || date <= this.maxDate);
+	}
+
+	protected createMonth(month: number, year: number): DatePickerMonthView {
+		const weeks: Array<Array<DatePickerDayCell>> = [];
+		const firstDay = this.getFirstDayOfMonthIndex(month, year);
+		const daysLength = this.getDaysCountInMonth(month, year);
+		const prev = this.getPreviousMonthAndYear(month, year);
+		const next = this.getNextMonthAndYear(month, year);
+		const prevMonthDaysLength = this.getDaysCountInMonth(prev.month, prev.year);
+		const today = new Date();
+		const monthRows = Math.ceil((daysLength + firstDay) / 7);
+		let dayNo = 1;
+
+		for (let i = 0; i < monthRows; i++) {
+			const week: Array<DatePickerDayCell> = [];
+			if (i === 0) {
+				for (let j = prevMonthDaysLength - firstDay + 1; j <= prevMonthDaysLength; j++) {
+					week.push(this.createDayCell(j, prev.month, prev.year, true, today));
+				}
+				const remainingDaysLength = 7 - week.length;
+				for (let j = 0; j < remainingDaysLength; j++) {
+					week.push(this.createDayCell(dayNo++, month, year, false, today));
+				}
+			} else {
+				for (let j = 0; j < 7; j++) {
+					if (dayNo > daysLength) {
+						week.push(this.createDayCell(dayNo - daysLength, next.month, next.year, true, today));
+					} else {
+						week.push(this.createDayCell(dayNo, month, year, false, today));
+					}
+					dayNo++;
+				}
+			}
+			weeks.push(week);
+		}
+		return {month, year, weeks};
+	}
+
+	protected createDayCell(day: number, month: number, year: number, otherMonth: boolean, today: Date): DatePickerDayCell {
+		const isToday = today.getDate() === day && today.getMonth() === month && today.getFullYear() === year;
+		const selectable = this.isSelectable(day, month, year, otherMonth);
+		const selected = this.isSelected(day, month, year);
+
+		let cellClass = 'slab-datepicker-day-cell';
+		if (otherMonth) {
+			cellClass += ' slab-datepicker-other-month';
+		}
+		if (isToday) {
+			cellClass += ' slab-datepicker-today';
+		}
+
+		let dayClass = 'slab-datepicker-day';
+		if (selected && selectable) {
+			dayClass += ' slab-datepicker-day-selected';
+		}
+		if (this.disabled || !selectable) {
+			dayClass += ' slab-datepicker-day-disabled';
+		}
+
+		return {
+			day, month, year, otherMonth,
+			today:   isToday,
+			selectable, selected,
+			visible: !otherMonth || this.showOtherMonths,
+			cellClass, dayClass
+		};
+	}
+
+	protected getFirstDayOfMonthIndex(month: number, year: number): number {
+		const day = new Date(year, month, 1);
+		const dayIndex = day.getDay() + this.getSundayIndex();
+		return dayIndex >= 7 ? dayIndex - 7 : dayIndex;
+	}
+
+	protected getSundayIndex(): number {
+		const firstDayOfWeek = this.firstDayOfWeek ?? 0;
+		return firstDayOfWeek > 0 ? 7 - firstDayOfWeek : 0;
+	}
+
+	protected getDaysCountInMonth(month: number, year: number): number {
+		return 32 - this.daylightSavingAdjust(new Date(year, month, 32))
+			.getDate();
+	}
+
+	protected getPreviousMonthAndYear(month: number, year: number): { month: number, year: number } {
+		return month === 0 ? {month: 11, year: year - 1} : {month: month - 1, year};
+	}
+
+	protected getNextMonthAndYear(month: number, year: number): { month: number, year: number } {
+		return month === 11 ? {month: 0, year: year + 1} : {month: month + 1, year};
+	}
+
+	protected daylightSavingAdjust(date: Date): Date {
+		if (!date) {
+			return null;
+		}
+		date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
+		return date;
+	}
+
+	protected getTranslation(key: keyof DatePickerTranslations): Array<string> {
+		const value = this.translations ? this.translations[key] : undefined;
+		return value?.length ? value : DEFAULT_TRANSLATIONS[key];
+	}
+
+	protected pad(value: number): string {
+		return value < 10 ? `0${value}` : `${value}`;
+	}
+
+	// The overlay only listens to the document while it is open.
+	protected bindOverlayListeners(): void {
+		if (this.unlistenDocumentClick) {
+			return;
+		}
+		this.unlistenDocumentClick = this.renderer.listen('document', 'mousedown', (event: MouseEvent) => {
+			if (this.overlayVisible && !this.el.nativeElement.contains(event.target)) {
+				this.hideOverlay();
+			}
+		});
+		this.unlistenScroll = this.renderer.listen('window', 'scroll', () => this.alignOverlay());
+		this.unlistenResize = this.renderer.listen('window', 'resize', () => this.hideOverlay());
+	}
+
+	protected unbindOverlayListeners(): void {
+		this.unlistenDocumentClick?.();
+		this.unlistenScroll?.();
+		this.unlistenResize?.();
+		this.unlistenDocumentClick = null;
+		this.unlistenScroll = null;
+		this.unlistenResize = null;
+	}
+}

--- a/projects/systelab-components/src/lib/datepicker/datepicker-time.component.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-time.component.spec.ts
@@ -9,8 +9,7 @@ import { DatepickerTimeComponent } from './datepicker-time.component';
 import { TouchspinComponent } from '../spinner/spinner.component';
 import { SystelabTranslateModule } from 'systelab-translate';
 import { DatepickerComponent } from './datepicker.component';
-import { ButtonModule } from 'primeng/button';
-import { DatePickerModule } from 'primeng/datepicker';
+import { DatepickerCalendarComponent } from './datepicker-calendar.component';
 import { ButtonComponent } from '../button/button.component';
 
 @Component({
@@ -95,6 +94,7 @@ describe('Systelab DatepickerTimeComponent', () => {
 		await TestBed.configureTestingModule({
 			declarations: [
 				TouchspinComponent,
+				DatepickerCalendarComponent,
 				DatepickerComponent,
 				ButtonComponent,
 				DatepickerTimeComponent,
@@ -105,8 +105,6 @@ describe('Systelab DatepickerTimeComponent', () => {
 				BrowserAnimationsModule,
 				FormsModule,
 				OverlayModule,
-				ButtonModule,
-				DatePickerModule,
 				SystelabTranslateModule,
 			],
 			providers: [
@@ -181,7 +179,7 @@ describe('Systelab DatepickerTimeComponent', () => {
 	});
 
 	it('should be two calendars because one of the datepicker has showCalendar false', () => {
-		expect(fixture.debugElement.nativeElement.querySelectorAll('p-datepicker').length).toEqual(2);
+		expect(fixture.debugElement.nativeElement.querySelectorAll('systelab-datepicker-calendar').length).toEqual(2);
 	});
 
 });

--- a/projects/systelab-components/src/lib/datepicker/datepicker-time.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker-time.component.ts
@@ -3,7 +3,6 @@ import { DatepickerComponent } from './datepicker.component';
 import { TouchSpinValues } from '../spinner/touch.spin-values';
 import { I18nService } from 'systelab-translate';
 import { DataTransformerService } from './date-transformer.service';
-import { PrimeNG } from 'primeng/config';
 
 @Component({
     selector: 'systelab-date-time',
@@ -22,8 +21,8 @@ export class DatepickerTimeComponent extends DatepickerComponent {
 	public touchSpinHourValues: TouchSpinValues;
 	public touchSpinMinutesValues: TouchSpinValues;
 
-	constructor(myRenderer: Renderer2, i18nService: I18nService, dataTransformerService: DataTransformerService, config: PrimeNG) {
-		super(myRenderer, i18nService, dataTransformerService, config);
+	constructor(myRenderer: Renderer2, i18nService: I18nService, dataTransformerService: DataTransformerService) {
+		super(myRenderer, i18nService, dataTransformerService);
 
 		this.touchSpinHourValues = new TouchSpinValues(0, 0, 23, 1);
 		this.touchSpinMinutesValues = new TouchSpinValues(0, 0, 59, 1);

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.html
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.html
@@ -1,6 +1,7 @@
-<p-datepicker #calendar [(ngModel)]="currentDate" [showIcon]="false"
+<systelab-datepicker-calendar #calendar [(ngModel)]="currentDate"
   [dateFormat]="language.dateFormatValue"
   [firstDayOfWeek]="language.firstDayOfWeek"
+  [translations]="language.translations"
   (onFocus)="saveEventOnFocus($event)"
   (onBlur)="changeDate()"
   (onSelect)="selectDate()"
@@ -8,8 +9,7 @@
   [showOtherMonths]="showOtherMonths"
   [selectOtherMonths]="selectOtherMonths"
   [minDate]="minDate"
-  [focusTrap]="false"
-              [autofocus]="autofocus"
+  [autofocus]="autofocus"
   [maxDate]="maxDate"
   [inline]="inline"
   [keepInvalid]="keepInvalid"
@@ -19,40 +19,37 @@
   [style.font-size.px]="inputFontSize"
   [showTime]="withIntegratedTime"
   [timeOnly]="onlyTime"
-  [showTransitionOptions]="'1ms linear'"
-  [hideTransitionOptions]="'1ms linear'"
-  appendTo="body"
   [tabindex]="tabindex"
+  [icon]="onlyTime ? 'icon-clock' : 'icon-calendar'"
+  [headerTemplate]="onlyTime ? null : headerTpl"
+  [footerTemplate]="inline ? null : footerTpl"
   [ngClass]="{'date-error': formatError || error || (required && !currentDate), 'is-disabled': disabled, 'warning-date': tooFarDate || previousAfterDate, 'input-expand-height':inputExpandHeight}">
-  @if (!onlyTime) {
-    <ng-template pTemplate="header">
-      <div id="{{datepickerId}}" class="slab-datepicker-header">
-        <div class="left-buttons">
-          <a id="previousYear" class="icon-angle-double-left slab-icon-medium" (click)="prevYear()"></a>
-          <a id="previousMonth" class="icon-angle-left slab-icon-medium" (click)="prevMonth()"></a>
-        </div>
-        <div class="p-datepicker-title d-flex align-items-center justify-content-center">
-          <span class="p-datepicker-year">{{ currentCalendar.currentYear }}</span>
-          <span class="p-datepicker-month">{{ language.translations.monthNames[currentCalendar.currentMonth] }}</span>
-        </div>
-        <div class="right-buttons">
-          <a id="nextMonth" class="icon-angle-right slab-icon-medium" (click)="nextMonth()"></a>
-          <a id="nextYear" class="icon-angle-double-right slab-icon-medium" (click)="nextYear()"></a>
-        </div>
-      </div>
-    </ng-template>
-  }
-  <ng-template pTemplate="footer">
-    @if (!inline) {
-      <div class="p-3 d-flex border-top">
-        @if (showTodayButton) {
-          <systelab-button id="today" size="small" class="mr-auto"
-          (click)="setTodayDate()">{{ 'COMMON_TODAY' | translate | async }}</systelab-button>
-        }
-        <systelab-button id="clear" size="small" type="danger" class="ml-auto"
-        (click)="clearDate($event)">{{ 'COMMON_CLEAR' | translate | async }}</systelab-button>
-      </div>
-    }
-  </ng-template>
-</p-datepicker>
+</systelab-datepicker-calendar>
 
+<ng-template #headerTpl>
+  <div id="{{datepickerId}}" class="slab-datepicker-header">
+    <div class="left-buttons">
+      <a id="previousYear" class="icon-angle-double-left slab-icon-medium" (click)="prevYear()"></a>
+      <a id="previousMonth" class="icon-angle-left slab-icon-medium" (click)="prevMonth()"></a>
+    </div>
+    <div class="slab-datepicker-title d-flex align-items-center justify-content-center">
+      <span class="slab-datepicker-year">{{ currentCalendar.currentYear }}</span>
+      <span class="slab-datepicker-month">{{ language.translations.monthNames[currentCalendar.currentMonth] }}</span>
+    </div>
+    <div class="right-buttons">
+      <a id="nextMonth" class="icon-angle-right slab-icon-medium" (click)="nextMonth()"></a>
+      <a id="nextYear" class="icon-angle-double-right slab-icon-medium" (click)="nextYear()"></a>
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #footerTpl>
+  <div class="p-3 d-flex border-top">
+    @if (showTodayButton) {
+      <systelab-button id="today" size="small" class="mr-auto"
+      (click)="setTodayDate()">{{ 'COMMON_TODAY' | translate | async }}</systelab-button>
+    }
+    <systelab-button id="clear" size="small" type="danger" class="ml-auto"
+    (click)="clearDate($event)">{{ 'COMMON_CLEAR' | translate | async }}</systelab-button>
+  </div>
+</ng-template>

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.i18n.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.i18n.spec.ts
@@ -5,12 +5,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ButtonModule } from 'primeng/button';
-import { DatePickerModule } from 'primeng/datepicker';
 import { of } from 'rxjs';
 import { I18nService, SystelabTranslateModule } from 'systelab-translate';
 import { ButtonComponent } from '../button/button.component';
 import { TouchspinComponent } from '../spinner/spinner.component';
+import { DatepickerCalendarComponent } from './datepicker-calendar.component';
 import { DatepickerComponent } from './datepicker.component';
 
 export class USMockI18nService {
@@ -192,6 +191,7 @@ describe('Systelab US DatepickerComponent', () => {
 		await TestBed.configureTestingModule({
 			declarations: [
 				TouchspinComponent,
+				DatepickerCalendarComponent,
 				DatepickerComponent,
 				ButtonComponent,
 				DatepickerTestComponent,
@@ -201,8 +201,6 @@ describe('Systelab US DatepickerComponent', () => {
 				BrowserAnimationsModule,
 				FormsModule,
 				OverlayModule,
-				ButtonModule,
-				DatePickerModule,
 				SystelabTranslateModule,
 			],
 			providers: [
@@ -288,6 +286,7 @@ describe('Systelab ES DatepickerComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
     declarations: [TouchspinComponent,
+        DatepickerCalendarComponent,
         DatepickerComponent,
         ButtonComponent,
         DatepickerTestComponent],
@@ -295,8 +294,6 @@ describe('Systelab ES DatepickerComponent', () => {
         BrowserAnimationsModule,
         FormsModule,
         OverlayModule,
-        ButtonModule,
-        DatePickerModule,
         SystelabTranslateModule],
     providers: [{ provide: I18nService, useClass: ESMockI18nService }, provideHttpClient(withInterceptorsFromDi())]
 })
@@ -375,6 +372,7 @@ describe('Systelab ZH DatepickerComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
     declarations: [TouchspinComponent,
+        DatepickerCalendarComponent,
         DatepickerComponent,
         ButtonComponent,
         DatepickerTestComponent],
@@ -382,8 +380,6 @@ describe('Systelab ZH DatepickerComponent', () => {
         BrowserAnimationsModule,
         FormsModule,
         OverlayModule,
-        ButtonModule,
-        DatePickerModule,
         SystelabTranslateModule],
     providers: [{ provide: I18nService, useClass: ZHMockI18nService }, provideHttpClient(withInterceptorsFromDi())]
 })
@@ -461,13 +457,12 @@ describe('Systelab ES DatepickerComponent, check translations', () => {
 		await TestBed.configureTestingModule({
     declarations: [TouchspinComponent,
         ButtonComponent,
+        DatepickerCalendarComponent,
         DatepickerComponent],
     imports: [BrowserModule,
         BrowserAnimationsModule,
         FormsModule,
         OverlayModule,
-        ButtonModule,
-        DatePickerModule,
         SystelabTranslateModule],
     providers: [{ provide: I18nService, useClass: ESMockI18nService2 }, provideHttpClient(withInterceptorsFromDi())]
 })
@@ -496,7 +491,7 @@ describe('Systelab ES DatepickerComponent, check translations', () => {
 	it('month should be in spanish translation', () => {
 		fixture.whenStable().then(() => {
 			const currentDate=new Date();
-			const monthSpan = fixture.debugElement.query(By.css(`.p-datepicker-month`));
+			const monthSpan = fixture.debugElement.query(By.css(`.slab-datepicker-month`));
 			expect(monthSpan.nativeElement.textContent.trim())
 				.toEqual(getMonth(currentDate));
 			});
@@ -511,7 +506,7 @@ describe('Systelab ES DatepickerComponent, check translations', () => {
 			nextMonth.dispatchEvent(new Event('click'));
 			fixture.detectChanges();
 
-			const monthSpan = fixture.debugElement.query(By.css(`.p-datepicker-month`));
+			const monthSpan = fixture.debugElement.query(By.css(`.slab-datepicker-month`));
 			expect(monthSpan.nativeElement.textContent.trim())
 				.toEqual(getMonth(nextMonthDate));
 			});

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.spec.ts
@@ -6,11 +6,10 @@ import { FormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { differenceInCalendarDays, differenceInCalendarMonths, differenceInCalendarYears } from 'date-fns';
-import { ButtonModule } from 'primeng/button';
-import { DatePicker, DatePickerModule } from 'primeng/datepicker';
 import { SystelabTranslateModule } from 'systelab-translate';
 import { ButtonComponent } from '../button/button.component';
 import { TouchspinComponent } from '../spinner/spinner.component';
+import { DatepickerCalendarComponent } from './datepicker-calendar.component';
 import { DatepickerComponent } from './datepicker.component';
 
 @Component({
@@ -71,15 +70,15 @@ export class AuxFunctionClass {
 	}
 
 	public static isVisiblePopupVisible(fixture: ComponentFixture<DatepickerTestComponent>): boolean {
-		return (fixture.debugElement.nativeElement.querySelector('.p-datepicker-calendar-container') !== null);
+		return (fixture.debugElement.nativeElement.querySelector('.slab-datepicker-calendar-container') !== null);
 	}
 
 	public static getVisibleYearInPopup(fixture: ComponentFixture<DatepickerTestComponent>): number {
-		return parseInt(fixture.debugElement.nativeElement.querySelector('.p-datepicker-year').firstChild.nodeValue, 10);
+		return parseInt(fixture.debugElement.nativeElement.querySelector('.slab-datepicker-year').firstChild.nodeValue, 10);
 	}
 
 	public static getVisibleMonthInPopup(fixture: ComponentFixture<DatepickerTestComponent>): string {
-		return fixture.debugElement.nativeElement.querySelector('.p-datepicker-month').firstChild.nodeValue;
+		return fixture.debugElement.nativeElement.querySelector('.slab-datepicker-month').firstChild.nodeValue;
 	}
 
 	public static isRedBackground(fixture: ComponentFixture<DatepickerTestComponent>): boolean {
@@ -127,6 +126,7 @@ describe('Systelab DatepickerComponent', () => {
 		await TestBed.configureTestingModule({
 			declarations: [
 				TouchspinComponent,
+				DatepickerCalendarComponent,
 				DatepickerComponent,
 				ButtonComponent,
 				DatepickerTestComponent,
@@ -136,8 +136,6 @@ describe('Systelab DatepickerComponent', () => {
 				BrowserAnimationsModule,
 				FormsModule,
 				OverlayModule,
-				ButtonModule,
-				DatePickerModule,
 				SystelabTranslateModule,
 			],
 			providers: [
@@ -458,18 +456,18 @@ describe('Systelab DatepickerComponent', () => {
 	describe('Set of specs for calendar with inputs showOtherMonths', () => {
 		const setup = (showOtherMonths = true) => {
 
-			const fixtureDatePicker = TestBed.createComponent(DatePicker);
-			const calendarComponent = fixtureDatePicker.componentInstance;
+			const fixtureCalendar = TestBed.createComponent(DatepickerCalendarComponent);
+			const calendarComponent = fixtureCalendar.componentInstance;
 
-			 calendarComponent.showOtherMonths = showOtherMonths;
-			fixtureDatePicker.detectChanges();
+			calendarComponent.showOtherMonths = showOtherMonths;
+			fixtureCalendar.detectChanges();
 
-			const button = fixtureDatePicker.debugElement.query(By.css('.p-inputtext')).nativeElement;
-			button.click();
-			fixtureDatePicker.detectChanges();
+			const input = fixtureCalendar.debugElement.query(By.css('.slab-datepicker-input')).nativeElement;
+			input.click();
+			fixtureCalendar.detectChanges();
 
-			const datesContainer = fixtureDatePicker.debugElement.query(By.css('.p-datepicker-calendar-container'));
-			const otherMonthDates = datesContainer.queryAll(By.css('.p-datepicker-other-month'));
+			const datesContainer = fixtureCalendar.debugElement.query(By.css('.slab-datepicker-calendar-container'));
+			const otherMonthDates = datesContainer.queryAll(By.css('.slab-datepicker-other-month'));
 
 			return {otherMonthDates};
 		};
@@ -478,6 +476,8 @@ describe('Systelab DatepickerComponent', () => {
 		it('Calendar show other months days', () => {
 			const {otherMonthDates} = setup(true);
 
+			expect(otherMonthDates.length)
+				.toBeGreaterThan(0);
 			for (const otherMonthDate of otherMonthDates) {
 				expect(otherMonthDate.children.length)
 					.toEqual(1);
@@ -490,6 +490,8 @@ describe('Systelab DatepickerComponent', () => {
 		it('Calendar do not show other months days', () => {
 			const {otherMonthDates} = setup(false);
 
+			expect(otherMonthDates.length)
+				.toBeGreaterThan(0);
 			for (const otherMonthDate of otherMonthDates) {
 				expect(otherMonthDate.children.length)
 					.toEqual(0);

--- a/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
+++ b/projects/systelab-components/src/lib/datepicker/datepicker.component.ts
@@ -1,9 +1,23 @@
-import { AfterViewInit, Component, DoCheck, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
-import { addDays } from 'date-fns';
-import { DatePicker } from 'primeng/datepicker';
+import {
+	AfterViewInit,
+	Component,
+	DestroyRef,
+	DoCheck,
+	ElementRef,
+	EventEmitter,
+	HostListener,
+	inject,
+	Input,
+	OnInit,
+	Output,
+	Renderer2,
+	ViewChild
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
 import { I18nService } from 'systelab-translate';
 import { DataTransformerService } from './date-transformer.service';
-import { PrimeNG } from 'primeng/config';
+import { DatepickerCalendarComponent, DatePickerTranslations } from './datepicker-calendar.component';
 
 @Component({
 	selector:    'systelab-datepicker',
@@ -57,7 +71,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 
 	@Output() public currentDateChange = new EventEmitter<Date>();
 
-	@ViewChild('calendar', {static: true}) public currentCalendar: DatePicker;
+	@ViewChild('calendar', {static: true}) public currentCalendar: DatepickerCalendarComponent;
 
 	public inputChanged = false;
 	protected _currentDate: Date;
@@ -73,9 +87,10 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	public datepickerId: string = (Math.random() * (999999999999 - 1)).toString();
 	public formatError: boolean;
 
-	private headerElement: any = document.getElementById(this.datepickerId);
+	private readonly translateService = inject(TranslateService, {optional: true});
+	private readonly destroyRef = inject(DestroyRef);
 
-	constructor(protected myRenderer: Renderer2, protected i18nService: I18nService, protected dataTransformerService: DataTransformerService, protected config: PrimeNG) {
+	constructor(protected myRenderer: Renderer2, protected i18nService: I18nService, protected dataTransformerService: DataTransformerService) {
 	}
 
 	public ngOnInit() {
@@ -87,104 +102,32 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		if (navigator.userAgent.indexOf('iPad') > -1 || navigator.userAgent.indexOf('Android') > -1) {
 			this.isTablet = true;
 		}
+
+		// The day and month names are reloaded when the language changes.
+		this.translateService?.onLangChange
+			.pipe(takeUntilDestroyed(this.destroyRef))
+			.subscribe(() => {
+				this.currentLanguage = this.i18nService.getCurrentLanguage();
+				this.getLanguage();
+			});
 	}
 
 	public ngAfterViewInit() {
-		if (!this.inline) {
-			this.addIconToDatepicker();
-		}
-
-		if (this.currentCalendar && this.autofocus) {
-			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
-			if (inputElement) {
-				inputElement.focus();
-			}
-		}
-
-		if (this.currentCalendar) {
-			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
-			if (inputElement) {
-				const tabindexValue = this.tabindex ?? 0;
-				inputElement.setAttribute('tabindex', tabindexValue.toString());
-			}
-		}
+		// The input, its icon, the tab index and the autofocus are handled declaratively by the
+		// calendar component, so there is nothing left to patch in the DOM here.
 	}
 
-	private addIconToDatepicker(): void {
-		if (!this.currentCalendar) {
-			return;
-		}
-
-		const datepickerElement = this.currentCalendar.el.nativeElement;
-
-		// Función que intenta agregar el icono
-		const attemptAddIcon = (): boolean => {
-			const inputElement = datepickerElement.querySelector('input');
-			if (!inputElement || !inputElement.parentElement) {
-				return false;
-			}
-
-			const parentWrapper = inputElement.parentElement;
-
-			// Verificar si ya existe un icono
-			if (parentWrapper.querySelector('i.icon-calendar, i.icon-clock')) {
-				return true;
-			}
-
-			// Crear y configurar el icono
-			const iconElement = document.createElement('i');
-			iconElement.className = this.onlyTime ? 'icon-clock' : 'icon-calendar';
-
-			// Configurar el contenedor
-			parentWrapper.classList.add('slab-form-icon', 'w-100');
-			parentWrapper.style.position = 'relative';
-			parentWrapper.appendChild(iconElement);
-
-			return true;
-		};
-
-		// Intentar agregar el icono inmediatamente
-		if (attemptAddIcon()) {
-			return;
-		}
-
-		// Si no funciona, usar MutationObserver para esperar cambios en el DOM
-		const observer = new MutationObserver((mutations) => {
-			for (const mutation of mutations) {
-				if (mutation.type === 'childList' || mutation.type === 'attributes') {
-					if (attemptAddIcon()) {
-						observer.disconnect();
-						return;
-					}
-				}
-			}
-		});
-
-		// Observar cambios en el elemento datepicker
-		observer.observe(datepickerElement, {
-			childList:  true,
-			subtree:    true,
-			attributes: true
-		});
-
-		// Desconectar el observer después de 5 segundos como medida de seguridad
-		setTimeout(() => observer.disconnect(), 5000);
-	}
-
-	public ngDoCheck() {
+	@HostListener('window:resize')
+	public onWindowResize(): void {
 		if (window.innerWidth !== this.currentDocSize) {
 			this.currentDocSize = window.innerWidth;
 			this.closeDatepicker();
 		}
+	}
 
-		if (this.headerElement !== document.getElementById(this.datepickerId)) {
-			this.headerElement = document.getElementById(this.datepickerId);
-			if (this.headerElement) {
-				this.repositionateCalendar(new ElementRef(this.headerElement.parentElement.parentElement));
-			}
-		}
-
-		if (this.currentLanguage !== this.i18nService.getCurrentLanguage()) {
+	public ngDoCheck() {
+		// Only needed when there is no translate service to notify the language changes.
+		if (!this.translateService && this.currentLanguage !== this.i18nService.getCurrentLanguage()) {
 			this.currentLanguage = this.i18nService.getCurrentLanguage();
 			this.getLanguage();
 		}
@@ -266,7 +209,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		if (event.code === 'Enter' || event.code === 'Tab') {
 			const inputElement = this.currentCalendar.el.nativeElement.querySelector('input');
 			inputElement.blur();
-			this.currentCalendar.onBlur.emit(event);
+			this.currentCalendar.onBlur.emit(event as unknown as FocusEvent);
 			this.closeDatepicker();
 		} else {
 			this.inputChanged = true;
@@ -279,45 +222,23 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	}
 
 	public repositionateCalendar(element?: ElementRef): void {
-
-		try {
-			const {inputElementTop, inputElementHeight, datepickerElementHeight} = this.inputElement.nativeElement.getBoundingClientRect();
-			if (inputElementTop + inputElementHeight + datepickerElementHeight > window.innerHeight) {
-				const newTop: number = inputElementTop + inputElementHeight - (datepickerElementHeight + inputElementHeight + 10);
-				this.myRenderer.setAttribute(element.nativeElement, 'top', newTop + 'px');
-			}
-		} catch (ex) {
-		}
+		this.currentCalendar?.alignOverlay();
 	}
 
 	public nextMonth(): void {
-		if (this.currentCalendar) {
-			this.currentCalendar.navForward(null);
-		}
+		this.currentCalendar?.navForward();
 	}
 
 	public prevMonth(): void {
-		if (this.currentCalendar) {
-			this.currentCalendar.navBackward(null);
-		}
+		this.currentCalendar?.navBackward();
 	}
 
 	public nextYear(): void {
-		if (this.currentCalendar) {
-			// En PrimeNG 20, navegar un año adelante
-			for (let i = 0; i < 12; i++) {
-				this.currentCalendar.navForward(null);
-			}
-		}
+		this.currentCalendar?.navYearForward();
 	}
 
 	public prevYear(): void {
-		if (this.currentCalendar) {
-			// En PrimeNG 20, navegar un año atrás
-			for (let i = 0; i < 12; i++) {
-				this.currentCalendar.navBackward(null);
-			}
-		}
+		this.currentCalendar?.navYearBackward();
 	}
 
 	public clearDate(event): void {
@@ -347,7 +268,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	private checkPreviousAfterDate(): void {
 		if (this._currentDate) {
 			this._currentDate.setHours(0, 0, 0, 0);
-			const pastDate = addDays(new Date(), this.warnDaysBefore * -1);
+			const pastDate = this.addDays(new Date(), this.warnDaysBefore * -1);
 			pastDate.setHours(0, 0, 0, 0);
 			this.previousAfterDate = this._currentDate.getTime() <= pastDate.getTime();
 		} else {
@@ -358,11 +279,17 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 	private checkTooFarDate() {
 		if (this._currentDate) {
 			this._currentDate.setHours(0, 0, 0, 0);
-			const futureDate = addDays(new Date(), this.warnDaysAfter);
+			const futureDate = this.addDays(new Date(), this.warnDaysAfter);
 			this.tooFarDate = this._currentDate.getTime() >= futureDate.getTime();
 		} else {
 			this.tooFarDate = false;
 		}
+	}
+
+	private addDays(date: Date, amount: number): Date {
+		const result = new Date(date.getTime());
+		result.setDate(result.getDate() + amount);
+		return result;
 	}
 
 	private getLanguage(): void {
@@ -371,7 +298,7 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		const weekDaysNamesShort: Array<string> = [];
 		const monthNames: Array<string> = [];
 		const monthNamesShort: Array<string> = [];
-		 
+
 		this.i18nService.get(['COMMON_SUNDAY', 'COMMON_MONDAY', 'COMMON_TUESDAY', 'COMMON_WEDNESDAY', 'COMMON_THURSDAY', 'COMMON_FRIDAY', 'COMMON_SATURDAY'])
 			.subscribe((res) => {
 				weekDaysNames.push(res.COMMON_SUNDAY, res.COMMON_MONDAY, res.COMMON_TUESDAY, res.COMMON_WEDNESDAY, res.COMMON_THURSDAY, res.COMMON_FRIDAY, res.COMMON_SATURDAY);
@@ -392,14 +319,16 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 				monthNamesShort.push(res.JOB_MONTHS_1, res.JOB_MONTHS_2, res.JOB_MONTHS_3, res.JOB_MONTHS_4, res.JOB_MONTHS_5, res.JOB_MONTHS_6, res.JOB_MONTHS_7, res.JOB_MONTHS_8, res.JOB_MONTHS_9, res.JOB_MONTHS_10, res.JOB_MONTHS_11, res.JOB_MONTHS_12);
 			});
 
+		const translations: DatePickerTranslations = {
+			dayNames:        weekDaysNames,
+			dayNamesShort:   weekDaysNamesShort,
+			dayNamesMin:     weekDaysNamesShort,
+			monthNames:      monthNames,
+			monthNamesShort: monthNamesShort
+		};
+
 		this.language = {
-			translations: {
-				dayNames:        weekDaysNames,
-				dayNamesShort:   weekDaysNamesShort,
-				dayNamesMin:     weekDaysNamesShort,
-				monthNames:      monthNames,
-				monthNamesShort: monthNamesShort
-			}
+			translations: translations
 		};
 
 		this.language.firstDayOfWeek = this.i18nService.getFirstDayOfWeek();
@@ -408,7 +337,5 @@ export class DatepickerComponent implements OnInit, AfterViewInit, DoCheck {
 		if (this.currentCalendar) {
 			this.currentCalendar.dateFormat = this.dateFormat || this.language.dateFormatValue;
 		}
-
-		this.config.setTranslation(this.language.translations);
 	}
 }

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -23,6 +23,7 @@ import { ApplicationHeaderComponent } from './applicationframe/header/app-header
 import { ApplicationSidebarLargeComponent } from './applicationframe/sidebar/app-sidebar-large.component';
 import { DatepickerComponent } from './datepicker/datepicker.component';
 import { DatepickerTimeComponent } from './datepicker/datepicker-time.component';
+import { DatepickerCalendarComponent } from './datepicker/datepicker-calendar.component';
 import { TouchspinComponent } from './spinner/spinner.component';
 import { ModulabSelect } from './select/select.component';
 import { ApplicationFrameComponent } from './applicationframe/application-frame.component';
@@ -75,7 +76,6 @@ import { MessagePopupViewComponent } from './modal/message-popup/message-popup-v
 import { ApplicationSidebarSmallComponent } from './applicationframe/sidebar/app-sidebar-small.component';
 import { PaginatorComponent } from './paginator/paginator.component';
 import { PaginatorPageComponent } from './paginator/paginator-page.component';
-import { DatePickerModule } from 'primeng/datepicker';
 import { ContextMenuModule } from 'primeng/contextmenu';
 import { ChipButtonComponent } from './chip-button/chip-button.component';
 import { AutofocusDirective } from './directives/autofocus.directive';
@@ -126,7 +126,6 @@ const providers = [
 	imports:      [
 		CommonModule,
 		FormsModule,
-		DatePickerModule,
 		AutoCompleteModule,
 		DragDropModule,
 		OverlayModule,
@@ -168,6 +167,7 @@ const providers = [
 		GenderSelect,
 		TouchspinComponent,
 		ModulabSelect,
+		DatepickerCalendarComponent,
 		DatepickerComponent,
 		DatepickerTimeComponent,
 		SearcherDialog,
@@ -248,6 +248,7 @@ const providers = [
 		PeriodSelect,
 		TimeUnitSelectComponent,
 		GenderSelect,
+		DatepickerCalendarComponent,
 		DatepickerComponent,
 		TouchspinComponent,
 		ModulabSelect,

--- a/projects/systelab-components/src/public-api.ts
+++ b/projects/systelab-components/src/public-api.ts
@@ -27,6 +27,7 @@ export * from './lib/select/period-combobox.component';
 export * from './lib/select/select.component';
 export * from './lib/select/select.component';
 export * from './lib/select/time-unit-combobox.component';
+export * from './lib/datepicker/datepicker-calendar.component';
 export * from './lib/datepicker/datepicker.component';
 export * from './lib/datepicker/datepicker-time.component';
 export * from './lib/spinner/touch.spin-values';


### PR DESCRIPTION
# PR Details

## Description

The calendar behind `systelab-datepicker` and `systelab-date-time` is no longer the PrimeNG `p-datepicker`. It is now
the new `systelab-datepicker-calendar` component (`DatepickerCalendarComponent`), written with plain Angular and
TypeScript, which is the engine of both.

- `DatepickerCalendarComponent` is a `ControlValueAccessor` that renders the input, the panel, the month grid and the
  hour/minute pickers. It keeps its state in **signals**, derives the rendered month, the week day names and the text of
  the input with `computed()`, and runs with `ChangeDetectionStrategy.OnPush`, so an open calendar is only refreshed when
  something it shows really changes. Every input and every state member is still a plain property (backed by a signal
  through an accessor), so template bindings and imperative assignment both keep working — and both are now reactive.
- `DatepickerComponent` and `DatepickerTimeComponent` keep the default change detection on purpose, because their
  `currentDate` is often modified in place by the applications. They keep on top of the calendar the systelab look, the
  relative date shortcuts (`3d`, `-2w`, `1m`, ...), the loose date inference (`011219`), the warning states and, for
  `systelab-date-time`, the hour/minute spinners.
- All the `@Input()`, `@Output()` and public methods of both components are kept, so **no change is needed in the
  applications** using them. The only removed member is the PrimeNG config service that both received as their **fourth
  constructor argument**: any class extending them has to drop it from its `super(...)` call.
- The markup uses the `slab-` prefix of the library instead of the `p-` prefixed PrimeNG class names, and the calendar
  takes its colors from the library CSS variables (`--slab_foreground_primary`, `--slab_table_row_even_background`, ...)
  instead of the PrimeNG theme palette, so **the dark theme is honoured**. The full mapping of the old class names to
  the new ones is documented in the root `README.md`, for applications with their own styles or end to end selectors
  over the calendar.
- The panel is no longer appended to `body`: it is rendered inside the component as a `position: fixed` element, the
  same approach the combobox already uses.
- `DatepickerComponent` subscribes to the language changes of the translate service instead of checking the current
  language on every change detection cycle (it still falls back to the check when no `TranslateService` is provided).

PrimeNG stays a peer dependency of the library, since it is still used by other components (contextmenu, autocomplete,
button, tree, overlay). This PR only removes the datepicker dependency on it.

## Related Issue

Closes #434 — *Create a new datepicker (JS library) instead of PrimeNG usage*.

It also removes the datepicker from the components blocking #750 (*Upgrade primeng to latest major*) and fixes #1127
(*Datepicker dark mode styles are broken*).

## Motivation and Context

The datepicker was the last component whose behaviour depended on PrimeNG, and that dependency was a recurring source of
problems: the PrimeNG theme palette does not follow the systelab CSS variables, so the calendar was broken in dark mode;
the overlay appended to `body` was hard to position and to test; and every PrimeNG major upgrade required reworking the
component. Owning the calendar removes the third party from the equation, lets it use the library variables and signals,
and gives it the identifiers needed by `systelab-components-test` accessors.

## How Has This Been Tested

- `npm test` — full library suite on headless Chrome: **721 specs, all passing** (67.86% statements / 55.03% branches).
  The datepicker folder alone runs 156 specs.
- The new `datepicker-calendar.component.spec.ts` adds 500+ lines of specs for the calendar itself (rendering of the
  grid, navigation by month and year, selection, other-month days, min/max and disabled dates/days, time picker, parsing
  and formatting with the different `dateFormat` tokens, translations, `ControlValueAccessor` and the panel visibility).
- The existing `datepicker.component.spec.ts`, `datepicker-time.component.spec.ts` and
  `datepicker.component.i18n.spec.ts` were updated to look for the panel inside the component and for the `slab-`
  classes, and keep covering the behaviour of the two public components.
- `npm run lint` is clean over the datepicker folder, and `npm run build-lib` and `npm run build-showcase` both succeed
  (the showcase keeps only the pre-existing initial bundle budget warning).
- Manually verified on the showcase datepicker page, **in both the light and the dark theme**: date selection, keyboard
  input with the relative dates and the loose formats, min/max limits, inline mode (a new example was added to the
  showcase page for it), the date-time variant and the language change.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/) (21.4.1 → 21.5.0)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [ ] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
