### PR TITLE
Implement the chips autocomplete without PrimeNG (#484)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,47 @@ npm publish
 
 # Breaking changes
 
+## Version 21.6.0
+
+The **chips** (`systelab-chips`) does not use PrimeNG anymore. The autocomplete is now implemented with plain Angular
+and TypeScript inside `ChipsComponent`, which keeps its state in **signals** and runs with
+`ChangeDetectionStrategy.OnPush`.
+
+- All the `@Input()` (`texts`, `disabled`, `readonly`), the `@Output()` (`filtered`), the `filter` accessor and the
+  `search()` and `onKeyEnter()` methods are kept, so no change is needed in the applications.
+- The `autoComplete` **ViewChild** is gone, because there is no PrimeNG `AutoComplete` behind the component anymore.
+  Code calling `chips.autoComplete.hide()` (or `show()`) has to call `chips.hide()` / `chips.show()` instead. The
+  component also exposes `inputViewChild`, `panelViewChild`, `containerViewChild`, `panelVisible`, `showPanel`,
+  `highlightedIndex` and `focus`.
+- **The `p-` prefixed class names are gone**: the markup now uses the `slab-` prefix of the library. Applications with
+  their own styles or end to end selectors over the chips have to rename them:
+
+| Before | Now |
+| ------ | --- |
+| `p-autocomplete` | *removed*, use the `systelab-chips` element |
+| `p-autocomplete-input-multiple` | `slab-chips-container` |
+| `p-focus` | `slab-chips-focus` |
+| `p-disabled` | `slab-chips-disabled` |
+| `p-autocomplete-chip-item`, `p-autocomplete-chip`, `p-chip` | `slab-chips-chip` |
+| `p-autocomplete-token-label`, `p-chip-label` | `slab-chips-chip-label` |
+| `p-autocomplete-chip-icon` (`pi pi-times-circle`) | `slab-chips-chip-remove` (a `×`, as in `systelab-chip-button`) |
+| `p-autocomplete-input-chip` | `slab-chips-input-chip` |
+| `p-autocomplete-input` | `slab-chips-input` |
+| `p-autocomplete-overlay`, `p-autocomplete-list` | `slab-chips-panel`, `slab-chips-list` |
+| `p-autocomplete-option` | `slab-chips-item` |
+| `p-focus` (on an option) | `slab-chips-item-highlighted` |
+
+- The suggestions panel is no longer appended to `body`: it is rendered inside the component as a `position: fixed`
+  element (the same approach as the datepicker and the combobox). Tests looking for the panel outside the component
+  must be updated.
+- The panel is only shown when there is at least one suggestion, and the chips now support **Arrow up / Arrow down** to
+  highlight a suggestion, **Escape** to close the panel and **Backspace** over an empty input to remove the last chip.
+  The panel is also closed when the input loses the focus, when the window is resized and when the click is outside the
+  component.
+- The chips take their colors from the `--primary`, `--slab_component_border_color`, `--slab_background_primary` and
+  `--slab_table_row_hover_background` variables of the library instead of the PrimeNG theme palette, so they also
+  honour the dark theme.
+
 ## Version 21.x.x - Angular 21
 
 [Angular 21 news](https://blog.angular.dev/announcing-angular-v21-57946c34f14b)

--- a/projects/showcase/src/app/showcase.module.ts
+++ b/projects/showcase/src/app/showcase.module.ts
@@ -88,7 +88,6 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { ShowcasePaginatorComponent } from './components/paginator/showcase-paginator-component';
 import { ShowcaseBarsGridComponent } from './components/grid/showcase-inner-bars-grid.component';
 import { A11yModule } from '@angular/cdk/a11y';
-import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ShowcaseInnerTreeComboBox } from './components/combobox/showcase-inner-tree-combobox.component';
 import { ShowcaseToastComponent } from './components/toast/showcase-toast.component';
 import { ShowcaseSpyMenuComponent } from './components/spy-menu/showcase-spy-menu.component';
@@ -225,7 +224,6 @@ import { AngularSplitModule } from 'angular-split';
         OverlayModule,
         SystelabTranslateModule,
         SystelabPreferencesModule,
-        AutoCompleteModule,
         CdkTreeModule,
         SystelabComponentsModule.forRoot()
     ],

--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "21.4.1",
+  "version": "21.6.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/sass/components/_chips.scss
+++ b/projects/systelab-components/sass/components/_chips.scss
@@ -1,54 +1,140 @@
 @use "../variables" as Vars;
 
+/* Styles for the systelab chips (systelab-chips). Every class follows the slab- prefix: the
+   p-autocomplete-* names of the former PrimeNG based implementation are gone. */
+
 $chip-item-height: calc(#{Vars.$form-elements-height} - 6px);
 $chips-container-max-height: calc(#{Vars.$form-elements-height} * 5);
+$chips-panel-max-height: calc(#{Vars.$form-elements-height} * 6);
+
 systelab-chips {
-  .p-autocomplete {
+  display: block;
+  width: 100%;
+
+  .slab-chips-container {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 3px;
+    list-style: none;
+    width: 100%;
+    margin: 0;
     min-height: Vars.$form-elements-height;
     max-height: $chips-container-max-height;
-    &:not(.p-disabled).p-focus .p-autocomplete-input-multiple {
+    overflow-y: auto;
+    cursor: text;
+    border: 1px solid var(--slab_component_border_color);
+    padding: 1px 5px;
+    border-radius: Vars.$input-border-radius;
+    background-color: var(--slab_background_primary);
+
+    &.slab-chips-focus {
       border-color: Vars.$slab-focus-component-border-color !important;
       box-shadow: Vars.$slab-focus-component-shadow !important;
     }
-    .p-autocomplete-input-multiple {
-      width: 100% !important;
-      margin: 0;
-      max-height: $chips-container-max-height;
-      overflow-y: auto;
-      border: 1px solid var(--slab_component_border_color) !important;
-      padding: 1px 5px;
-      border-radius: Vars.$input-border-radius;
 
-      &:hover:enabled:not(:focus) {
-        border-color:  var(--slab_component_border_color) !important;
-      }
-      .pi {
-        font-size: 15px;
-      }
-      .p-autocomplete-chip-item {
-        background-color: var(--primary);
-        border-radius: 20px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: $chip-item-height;
-        .p-autocomplete-chip.p-chip {
-          background-color: transparent;
-          color: white;
-          .p-autocomplete-chip-icon {
-            color: white;
-            height: calc(#{Vars.$form-elements-height}/2);
-            display: flex;
-          }
-        }
-      }
-      .p-autocomplete-input-chip .p-autocomplete-input {
-        height: calc(#{Vars.$form-elements-height} / 2);
+    &.slab-chips-disabled {
+      background-color: #e9ecef;
+      cursor: not-allowed;
+
+      .slab-chips-input {
+        cursor: not-allowed;
       }
     }
   }
 
-  .p-autocomplete-token-label {
-    margin-left: 10px;
+  .slab-chips-chip {
+    background-color: var(--primary);
+    border-radius: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: $chip-item-height;
+    padding: 0 8px;
+    color: white;
+    white-space: nowrap;
+
+    .slab-chips-chip-label {
+      margin-left: 2px;
+    }
+
+    .slab-chips-chip-remove {
+      background: transparent;
+      -webkit-appearance: none;
+      color: white;
+      font-size: 1rem;
+      line-height: 1;
+      cursor: pointer;
+      border: 1px solid white;
+      border-radius: 50%;
+      width: 16px;
+      height: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 7px;
+    }
+  }
+
+  .slab-chips-input-chip {
+    flex: 1 1 auto;
+    display: flex;
+    min-width: 60px;
+  }
+
+  .slab-chips-input {
+    width: 100%;
+    height: calc(#{Vars.$form-elements-height} / 2);
+    border: none;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    color: var(--slab_foreground_primary);
+    font: normal Vars.$slab-base-body-font-size Vars.$slab-base-body-font-family;
+
+    &:focus {
+      outline: 0;
+      border: none;
+      box-shadow: none;
+    }
+
+    &:disabled {
+      background: transparent;
+      color: #333;
+    }
+  }
+
+  .slab-chips-panel {
+    position: fixed;
+    box-sizing: border-box;
+    z-index: 100000;
+    max-height: $chips-panel-max-height;
+    overflow-y: auto;
+    margin-top: 2px;
+    color: var(--slab_foreground_primary);
+    background-color: var(--slab_background_primary);
+    border: 1px solid var(--slab_component_border_color);
+    border-radius: Vars.$input-border-radius;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+
+    .slab-chips-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .slab-chips-item {
+      cursor: pointer;
+      line-height: Vars.$slab-dropdown-line-height;
+      padding: 0 10px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      &.slab-chips-item-highlighted,
+      &:hover {
+        background-color: var(--slab_table_row_hover_background);
+      }
+    }
   }
 }

--- a/projects/systelab-components/src/lib/chips/README.md
+++ b/projects/systelab-components/src/lib/chips/README.md
@@ -2,6 +2,9 @@
 
 Systelab Chips is an input component that provides real-time suggestions when being typed.
 
+It is implemented with plain Angular and TypeScript (it does not use PrimeNG anymore): the state is kept in **signals**
+and the component runs with `ChangeDetectionStrategy.OnPush`.
+
 ## Using the template
 
 ```html
@@ -31,7 +34,33 @@ If you want the defaults the template will look like:
 
 | Name | Parameters | Description |
 | ---- |:----------:| ------------|
-| filtered | | Event emitted with the result  |
+| filtered | Array\<string\> | Event emitted with the result  |
 
+## Behaviour
 
-The styles are defined in the chips.scss Saas file.
+- Typing one character or more shows, after 300 ms without typing, the suggestions of `texts` containing the text
+  (case insensitive). The panel is not shown when nothing matches.
+- **Enter** adds the highlighted suggestion when the panel has been navigated with the keyboard, and the text typed
+  otherwise. **Click** over a suggestion adds it.
+- **Arrow down / Arrow up** move the highlighted suggestion, **Escape** closes the panel, and **Backspace** over an empty
+  input removes the last chip.
+- The `×` of a chip removes it. It is not rendered when the component is disabled or readonly.
+- Clicking anywhere in the container gives the focus to the input. Clicking outside the component, losing the focus of
+  the input and resizing the window close the panel.
+
+## Public API
+
+| Name | Description |
+| ---- | ----------- |
+| filter | Array\<string\> with the values of the chips. Assigning it emits `filtered` |
+| results | Array\<string\> with the suggestions currently offered |
+| search({query}) | Recalculates `results` for a query |
+| show() / hide() | Opens / closes the suggestions panel |
+| panelVisible, showPanel, highlightedIndex, focus | State of the panel and of the input |
+
+## Styles
+
+The styles are defined in the chips.scss Sass file. The classes are `slab-chips-container` (with the
+`slab-chips-focus`, `slab-chips-disabled` and `slab-chips-readonly` modifiers), `slab-chips-chip` (with
+`slab-chips-chip-label` and `slab-chips-chip-remove`), `slab-chips-input-chip`, `slab-chips-input`, and
+`slab-chips-panel` with `slab-chips-list` and `slab-chips-item` (highlighted with `slab-chips-item-highlighted`).

--- a/projects/systelab-components/src/lib/chips/chips.component.html
+++ b/projects/systelab-components/src/lib/chips/chips.component.html
@@ -1,6 +1,45 @@
-<p-autoComplete #autoComplete [suggestions]="results" (completeMethod)="search($event)"
-                (keydown.enter)="onKeyEnter($event)"
-                [multiple]="true"
-                [readonly]="readonly"
-                [disabled]="disabled"
-                [(ngModel)]="filter"></p-autoComplete>
+<ul #container class="slab-chips-container"
+  [class.slab-chips-focus]="focus || showPanel"
+  [class.slab-chips-disabled]="disabled"
+  [class.slab-chips-readonly]="readonly"
+  (click)="onContainerClick()">
+  @for (chip of filter; track $index) {
+    <li class="slab-chips-chip">
+      <span class="slab-chips-chip-label">{{chip}}</span>
+      @if (!disabled && !readonly) {
+        <span class="slab-chips-chip-remove" aria-hidden="true" (click)="removeChip($index, $event)">×</span>
+      }
+    </li>
+  }
+  <li class="slab-chips-input-chip">
+    <input #input type="text" autocomplete="off" role="combobox" aria-autocomplete="list"
+      class="slab-chips-input"
+      [attr.readonly]="readonly ? '' : null"
+      [attr.disabled]="disabled ? '' : null"
+      [attr.aria-expanded]="showPanel"
+      [attr.aria-controls]="showPanel ? instanceId + '-list' : null"
+      [attr.aria-activedescendant]="highlightedIndex >= 0 ? instanceId + '-item-' + highlightedIndex : null"
+      (input)="onInput($event)"
+      (focus)="onInputFocus()"
+      (blur)="onInputBlur()"
+      (keydown)="onKeydown($event)"
+      (keydown.enter)="onKeyEnter($event)"/>
+  </li>
+</ul>
+
+@if (showPanel) {
+  <div #panel class="slab-chips-panel" (mousedown)="onPanelMouseDown($event)">
+    <ul class="slab-chips-list" role="listbox" [id]="instanceId + '-list'">
+      @for (suggestion of results; track $index) {
+        <li class="slab-chips-item" role="option"
+          [id]="instanceId + '-item-' + $index"
+          [class.slab-chips-item-highlighted]="$index === highlightedIndex"
+          [attr.aria-selected]="$index === highlightedIndex"
+          (mouseenter)="onSuggestionMouseEnter($index)"
+          (click)="onSuggestionClick(suggestion)">
+          <span>{{suggestion}}</span>
+        </li>
+      }
+    </ul>
+  </div>
+}

--- a/projects/systelab-components/src/lib/chips/chips.component.spec.ts
+++ b/projects/systelab-components/src/lib/chips/chips.component.spec.ts
@@ -3,10 +3,8 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Component, provideZoneChangeDetection } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ButtonModule } from 'primeng/button';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { ChipsComponent } from './chips.component';
-import { AutoCompleteModule } from 'primeng/autocomplete';
 
 @Component({
     template: `
@@ -37,6 +35,27 @@ const setArrayValue = (fixture: ComponentFixture<ChipsTestComponent>, values: Ar
 	fixture.detectChanges();
 };
 
+const getInput = (fixture: ComponentFixture<ChipsTestComponent>): HTMLInputElement =>
+	fixture.debugElement.query(By.css('input')).nativeElement;
+
+/** Types a text in the input and lets the debounced search run. */
+const typeText = (fixture: ComponentFixture<ChipsTestComponent>, text: string): void => {
+	const inputEl = getInput(fixture);
+	inputEl.dispatchEvent(new Event('focus'));
+	inputEl.value = text;
+	inputEl.dispatchEvent(new Event('input'));
+	tick(300);
+	fixture.detectChanges();
+};
+
+const getSuggestions = (fixture: ComponentFixture<ChipsTestComponent>): Array<string> =>
+	fixture.debugElement.queryAll(By.css('.slab-chips-item'))
+		.map(item => item.nativeElement.innerText);
+
+const getChips = (fixture: ComponentFixture<ChipsTestComponent>): Array<string> =>
+	fixture.debugElement.queryAll(By.css('.slab-chips-chip-label'))
+		.map(chip => chip.nativeElement.innerText);
+
 describe('Systelab Chips', () => {
 
 	let fixture: ComponentFixture<ChipsTestComponent>;
@@ -48,8 +67,6 @@ describe('Systelab Chips', () => {
 				NoopAnimationsModule,
 				FormsModule,
 				BrowserDynamicTestingModule,
-				ButtonModule,
-				AutoCompleteModule,
 			],
 			declarations: [
 				ChipsComponent,
@@ -69,13 +86,10 @@ describe('Systelab Chips', () => {
 		fixture.componentInstance.disabled = true;
 		fixture.detectChanges();
 		await fixture.whenStable();
-		const inputDefaultEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		expect(inputDefaultEl.disabled).toBeTrue();
-		const inputMultipleEl = fixture.debugElement.query(By.css('ul input'));
-		expect(inputMultipleEl.nativeElement.disabled).toBeTrue();
-		const multiContainer = fixture.debugElement.query(By.css('p-autocomplete'));
-		console.log(multiContainer);
-		expect(multiContainer.nativeElement.children[0].className).toContain('p-disabled');
+
+		expect(getInput(fixture).disabled).toBeTrue();
+		const container = fixture.debugElement.query(By.css('.slab-chips-container'));
+		expect(container.nativeElement.className).toContain('slab-chips-disabled');
 	});
 
 	it('should be readonly', () => {
@@ -83,87 +97,125 @@ describe('Systelab Chips', () => {
 		fixture.componentInstance.readonly = true;
 		fixture.detectChanges();
 
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		expect(inputEl.readOnly)
+		expect(getInput(fixture).readOnly)
 			.toEqual(true);
+		const container = fixture.debugElement.query(By.css('.slab-chips-container'));
+		expect(container.nativeElement.className).toContain('slab-chips-readonly');
 	});
 
-	it('should be multiple', () => {
+	it('should allow multiple values', fakeAsync(() => {
 		setArrayValue(fixture, fixture.componentInstance.texts);
-		const autoComplete = fixture.debugElement.query(By.css('p-autoComplete')).componentInstance;
-		expect(autoComplete.multiple).toBeTrue();
-		expect(fixture.componentInstance.texts.length).toBeGreaterThan(1);
-	});
+
+		typeText(fixture, 'Rome');
+		chips.onKeyEnter(new KeyboardEvent('keydown', {key: 'Enter'}));
+		typeText(fixture, 'Oslo');
+		chips.onKeyEnter(new KeyboardEvent('keydown', {key: 'Enter'}));
+		fixture.detectChanges();
+
+		expect(chips.filter).toEqual(['Rome', 'Oslo']);
+		expect(getChips(fixture)).toEqual(['Rome', 'Oslo']);
+		flush();
+	}));
 
 	it('filtered list is correct', fakeAsync(() => {
 		setArrayValue(fixture, fixture.componentInstance.texts);
 
-		const inputEl = fixture.debugElement.query(By.css('input'));
-		inputEl.nativeElement.dispatchEvent(new Event('focus'));
-		inputEl.nativeElement.click();
-		fixture.detectChanges();
+		typeText(fixture, 'b');
 
-		inputEl.nativeElement.value = 'b';
-		inputEl.nativeElement.dispatchEvent(new Event('keydown'));
-		inputEl.nativeElement.dispatchEvent(new Event('input'));
-		inputEl.nativeElement.dispatchEvent(new Event('keyup'));
-		tick(300);
-		fixture.detectChanges();
+		expect(getSuggestions(fixture))
+			.toEqual(['Barcelona', 'Berlín', 'Lisboa', 'St Petersburgo']);
 
-		const listItems = fixture.debugElement.queryAll(By.css('li > span'));
-
-		expect(listItems[0].nativeElement.innerText)
-			.toEqual('Barcelona');
-		expect(listItems[1].nativeElement.innerText)
-			.toEqual('Berlín');
-		expect(listItems[2].nativeElement.innerText)
-			.toEqual('Lisboa');
-		expect(listItems[3].nativeElement.innerText)
-			.toEqual('St Petersburgo');
-		
 		flush();
 	}));
 
-	it('should select item', async () => {
+	it('should not show the panel when nothing matches', fakeAsync(() => {
 		setArrayValue(fixture, fixture.componentInstance.texts);
 
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		inputEl.dispatchEvent(new Event('focus'));
-		inputEl.dispatchEvent(new Event('click'));
+		typeText(fixture, 'zzz');
+
+		expect(fixture.debugElement.query(By.css('.slab-chips-panel'))).toBeNull();
+		flush();
+	}));
+
+	it('should hide the panel when the text is cleared', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		typeText(fixture, 'New');
+		expect(fixture.debugElement.query(By.css('.slab-chips-panel'))).not.toBeNull();
+
+		typeText(fixture, '');
+		expect(fixture.debugElement.query(By.css('.slab-chips-panel'))).toBeNull();
+		expect(chips.panelVisible).toBeFalse();
+		flush();
+	}));
+
+	it('should select item', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+		const emitSpy = spyOn(chips.filtered, 'emit');
+
+		typeText(fixture, 'New');
+
+		const suggestions = fixture.debugElement.queryAll(By.css('.slab-chips-item'));
+		expect(suggestions.length).toEqual(1);
+		suggestions[0].nativeElement.click();
 		fixture.detectChanges();
-		await fixture.whenStable();
 
-		// Simulamos el valor de entrada
-		inputEl.value = 'New';
-		inputEl.dispatchEvent(new Event('input'));
-		fixture.detectChanges();
-		await fixture.whenStable();
-
-		// Esperamos que la lista se haya filtrado
-		const listItems = fixture.debugElement.queryAll(By.css('li'));
-		const firstItemEl = listItems[0].nativeElement; // Seleccionamos el primer ítem
-		firstItemEl.click(); // Simulamos el click en el primer ítem
-		fixture.detectChanges();
-
-		await fixture.whenStable();
-
-		// Verificamos que el valor de autocompletado esté correctamente seleccionado
-		expect(fixture.componentInstance.texts[0]).toEqual('New York');
+		expect(chips.filter).toEqual(['New York']);
+		expect(getChips(fixture)).toEqual(['New York']);
+		expect(getInput(fixture).value).toEqual('');
+		expect(fixture.debugElement.query(By.css('.slab-chips-panel'))).toBeNull();
+		expect(emitSpy).toHaveBeenCalledOnceWith(['New York']);
 		expect(fixture.componentInstance.texts.length).toEqual(11);
-	});
+		flush();
+	}));
+
+	it('should select the highlighted item with the keyboard', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		typeText(fixture, 'b');
+		const inputEl = getInput(fixture);
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown'}));
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown'}));
+		fixture.detectChanges();
+
+		expect(chips.highlightedIndex).toEqual(1);
+		const highlighted = fixture.debugElement.queryAll(By.css('.slab-chips-item-highlighted'));
+		expect(highlighted.length).toEqual(1);
+		expect(highlighted[0].nativeElement.innerText).toEqual('Berlín');
+
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+		fixture.detectChanges();
+
+		expect(chips.filter).toEqual(['Berlín']);
+		flush();
+	}));
+
+	it('should close the panel with the escape key', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		typeText(fixture, 'b');
+		expect(chips.panelVisible).toBeTrue();
+
+		getInput(fixture).dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+		fixture.detectChanges();
+
+		expect(chips.panelVisible).toBeFalse();
+		expect(fixture.debugElement.query(By.css('.slab-chips-panel'))).toBeNull();
+		flush();
+	}));
 
 	it('should handle enter key press', fakeAsync(() => {
 		setArrayValue(fixture, fixture.componentInstance.texts);
 
 		// Simulate user input
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+		const inputEl = getInput(fixture);
 		inputEl.value = 'TestValue';
 
 		// Create a KeyboardEvent
-		const event = new KeyboardEvent('keydown', { key: 'Enter' });
+		const event = new KeyboardEvent('keydown', {key: 'Enter'});
 
 		// Manually assign the target property
-		Object.defineProperty(event, 'target', { value: inputEl, writable: true });
+		Object.defineProperty(event, 'target', {value: inputEl, writable: true});
 
 		// Explicitly call the onKeyEnter method
 		chips.onKeyEnter(event);
@@ -180,9 +232,114 @@ describe('Systelab Chips', () => {
 		chips.onKeyEnter(event);
 		expect(emitSpy).toHaveBeenCalledWith(chips.filter);
 
-		// Verify that the hide() method was called
-		const hideSpy = spyOn(chips.autoComplete, 'hide');
-		chips.onKeyEnter(event);
-		expect(hideSpy).toHaveBeenCalled();
+		// Verify that the panel is hidden
+		expect(chips.panelVisible).toBeFalse();
+		flush();
+	}));
+
+	it('should remove a chip when its remove icon is clicked', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		typeText(fixture, 'Rome');
+		chips.onKeyEnter(new KeyboardEvent('keydown', {key: 'Enter'}));
+		typeText(fixture, 'Oslo');
+		chips.onKeyEnter(new KeyboardEvent('keydown', {key: 'Enter'}));
+		fixture.detectChanges();
+
+		const emitSpy = spyOn(chips.filtered, 'emit');
+		fixture.debugElement.queryAll(By.css('.slab-chips-chip-remove'))[0].nativeElement.click();
+		fixture.detectChanges();
+
+		expect(chips.filter).toEqual(['Oslo']);
+		expect(getChips(fixture)).toEqual(['Oslo']);
+		expect(emitSpy).toHaveBeenCalledOnceWith(['Oslo']);
+		flush();
+	}));
+
+	it('should not show the remove icon when disabled or readonly', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		chips.filter = ['Rome'];
+		fixture.detectChanges();
+		expect(fixture.debugElement.queryAll(By.css('.slab-chips-chip-remove')).length).toEqual(1);
+
+		fixture.componentInstance.readonly = true;
+		fixture.detectChanges();
+		expect(fixture.debugElement.queryAll(By.css('.slab-chips-chip-remove')).length).toEqual(0);
+
+		fixture.componentInstance.readonly = false;
+		fixture.componentInstance.disabled = true;
+		fixture.detectChanges();
+		expect(fixture.debugElement.queryAll(By.css('.slab-chips-chip-remove')).length).toEqual(0);
+		flush();
+	}));
+
+	it('should remove the last chip with the backspace key on an empty input', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		chips.filter = ['Rome', 'Oslo'];
+		fixture.detectChanges();
+
+		const inputEl = getInput(fixture);
+		inputEl.value = '';
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', {key: 'Backspace'}));
+		fixture.detectChanges();
+
+		expect(chips.filter).toEqual(['Rome']);
+
+		inputEl.value = 'Ro';
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', {key: 'Backspace'}));
+		fixture.detectChanges();
+
+		expect(chips.filter).toEqual(['Rome']);
+		flush();
+	}));
+
+	it('should not search when disabled or readonly', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+		fixture.componentInstance.disabled = true;
+		fixture.detectChanges();
+
+		typeText(fixture, 'b');
+
+		expect(chips.panelVisible).toBeFalse();
+		expect(fixture.debugElement.query(By.css('.slab-chips-panel'))).toBeNull();
+		flush();
+	}));
+
+	it('should focus the input when the container is clicked', () => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		fixture.debugElement.query(By.css('.slab-chips-container')).nativeElement.click();
+		fixture.detectChanges();
+
+		expect(document.activeElement).toBe(getInput(fixture));
+	});
+
+	it('should hide the panel when the input loses the focus', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		typeText(fixture, 'b');
+		expect(chips.panelVisible).toBeTrue();
+
+		getInput(fixture).dispatchEvent(new Event('blur'));
+		fixture.detectChanges();
+
+		expect(chips.panelVisible).toBeFalse();
+		expect(chips.focus).toBeFalse();
+		flush();
+	}));
+
+	it('should hide the panel when clicking outside the component', fakeAsync(() => {
+		setArrayValue(fixture, fixture.componentInstance.texts);
+
+		typeText(fixture, 'b');
+		expect(chips.panelVisible).toBeTrue();
+
+		document.dispatchEvent(new MouseEvent('mousedown'));
+		fixture.detectChanges();
+
+		expect(chips.panelVisible).toBeFalse();
+		flush();
 	}));
 });

--- a/projects/systelab-components/src/lib/chips/chips.component.ts
+++ b/projects/systelab-components/src/lib/chips/chips.component.ts
@@ -1,61 +1,357 @@
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { firstValueFrom, of } from 'rxjs';
-import { AutoComplete } from 'primeng/autocomplete';
+import {
+	afterRenderEffect,
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	ElementRef,
+	EventEmitter,
+	Input,
+	OnDestroy,
+	Output,
+	Renderer2,
+	Signal,
+	signal,
+	ViewChild,
+	WritableSignal
+} from '@angular/core';
 
-@Component({
-    selector: 'systelab-chips',
-    templateUrl: 'chips.component.html',
-    standalone: false
-})
-export class ChipsComponent {
-
-	@Output() public filtered = new EventEmitter<Array<string>>();
-	@ViewChild('autoComplete') autoComplete: AutoComplete;
-
-	@Input() public texts: Array<string> = [];
-	@Input() public disabled = false;
-	@Input() public readonly = false;
-
-	public results: Array<string> = [];
-
-	private newData: string;
-	private _filter: Array<string> = [];
-
-	get filter(): Array<string> {
-		return this._filter;
-	}
-
-	set filter(event) {
-		this._filter = event;
-		this.filtered.emit(event);
-	}
-
-	public search(event): void {
-		firstValueFrom(of(this.texts))
-			.then(
-				data => {
-					if (data) {
-						data = data.filter(x => x.toLowerCase()
-							.includes(event.query.toLowerCase()));
-					}
-					if (data) {
-						this.newData = event.query;
-					} else {
-						this.newData = null;
-					}
-					this.results = data;
-				}
-			);
-	}
-
-	public onKeyEnter(event: KeyboardEvent): void {
-		const input = event.target as HTMLInputElement;
-		if (input.value) {
-			this.filter.push(input.value);
-			input.value = '';
-		}
-		this.filtered.emit(this.filter);
-		this.autoComplete.hide();
-	}
+/** Payload of the search, kept compatible with the event the component received from PrimeNG. */
+export interface ChipsSearchEvent {
+	query: string;
 }
 
+/** Distance left between the input and the suggestions panel when it has to be flipped above it. */
+const PANEL_MARGIN = 2;
+
+/** Milliseconds waited after the last keystroke before the suggestions are calculated. */
+const SEARCH_DELAY = 300;
+
+@Component({
+	selector:        'systelab-chips',
+	templateUrl:     'chips.component.html',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	standalone:      false
+})
+export class ChipsComponent implements OnDestroy {
+
+	private static instances = 0;
+
+	/** Prefix of the ids of the panel and of its items, unique for every instance. */
+	public readonly instanceId = `slab-chips-${ChipsComponent.instances++}`;
+
+	@Output() public filtered = new EventEmitter<Array<string>>();
+
+	@ViewChild('input') public inputViewChild: ElementRef<HTMLInputElement>;
+	@ViewChild('panel') public panelViewChild: ElementRef<HTMLElement>;
+	@ViewChild('container') public containerViewChild: ElementRef<HTMLElement>;
+
+	private readonly $texts: WritableSignal<Array<string>> = signal([]);
+	private readonly $disabled = signal(false);
+	private readonly $readonly = signal(false);
+
+	private readonly $results: WritableSignal<Array<string>> = signal([]);
+	private readonly $filter: WritableSignal<Array<string>> = signal([]);
+	private readonly $panelVisible = signal(false);
+	private readonly $highlightedIndex = signal(-1);
+	private readonly $focus = signal(false);
+
+	/** The panel is only rendered when it is open and there is something to show. */
+	private readonly $showPanel: Signal<boolean> = computed(() => this.$panelVisible() && this.$results().length > 0);
+
+	@Input()
+	public set texts(value: Array<string>) {
+		this.$texts.set(value ?? []);
+	}
+
+	public get texts(): Array<string> {
+		return this.$texts();
+	}
+
+	@Input()
+	public set disabled(value: boolean) {
+		this.$disabled.set(value);
+	}
+
+	public get disabled(): boolean {
+		return this.$disabled();
+	}
+
+	@Input()
+	public set readonly(value: boolean) {
+		this.$readonly.set(value);
+	}
+
+	public get readonly(): boolean {
+		return this.$readonly();
+	}
+
+	/** Suggestions currently offered for the text being typed. */
+	public get results(): Array<string> {
+		return this.$results();
+	}
+
+	public set results(value: Array<string>) {
+		this.$results.set(value ?? []);
+	}
+
+	public get filter(): Array<string> {
+		return this.$filter();
+	}
+
+	public set filter(value: Array<string>) {
+		this.$filter.set(value ?? []);
+		this.filtered.emit(this.$filter());
+	}
+
+	public get panelVisible(): boolean {
+		return this.$panelVisible();
+	}
+
+	public get showPanel(): boolean {
+		return this.$showPanel();
+	}
+
+	public get highlightedIndex(): number {
+		return this.$highlightedIndex();
+	}
+
+	public get focus(): boolean {
+		return this.$focus();
+	}
+
+	private searchTimer: any;
+	private unlistenDocumentMouseDown: () => void;
+	private unlistenScroll: () => void;
+	private unlistenResize: () => void;
+
+	constructor(public el: ElementRef, protected renderer: Renderer2) {
+		// The panel is a fixed element: every time it is shown (and on every render while it is
+		// open) it is measured and placed below the container, or above it when it does not fit.
+		afterRenderEffect(() => {
+			if (this.$showPanel()) {
+				this.alignPanel();
+			}
+		});
+	}
+
+	public ngOnDestroy(): void {
+		this.clearSearchTimer();
+		this.unbindPanelListeners();
+	}
+
+	/**
+	 * Calculates the suggestions for a query. Public and receiving a `{query}` event to keep the
+	 * signature the component had when the search was requested by PrimeNG.
+	 */
+	public search(event: ChipsSearchEvent): void {
+		const query = (event?.query ?? '')
+			.toLowerCase();
+		this.$results.set(this.texts.filter(text => text?.toLowerCase()
+			.includes(query)));
+		this.$highlightedIndex.set(-1);
+	}
+
+	public onInput(event: Event): void {
+		if (this.disabled || this.readonly) {
+			return;
+		}
+		const query = (event.target as HTMLInputElement).value;
+		this.clearSearchTimer();
+		if (!query) {
+			this.hide();
+			this.$results.set([]);
+			return;
+		}
+		this.searchTimer = setTimeout(() => {
+			this.searchTimer = null;
+			this.search({query});
+			this.show();
+		}, SEARCH_DELAY);
+	}
+
+	public onInputFocus(): void {
+		this.$focus.set(true);
+	}
+
+	/**
+	 * Closes the panel when the input loses the focus. Clicking the panel does not blur the input,
+	 * because its mousedown is prevented, so the suggestion is still selected.
+	 */
+	public onInputBlur(): void {
+		this.$focus.set(false);
+		this.hide();
+	}
+
+	public onContainerClick(): void {
+		if (!this.disabled) {
+			this.inputViewChild?.nativeElement.focus();
+		}
+	}
+
+	public onKeydown(event: KeyboardEvent): void {
+		switch (event.key) {
+			case 'ArrowDown':
+				this.moveHighlight(1);
+				event.preventDefault();
+				break;
+			case 'ArrowUp':
+				this.moveHighlight(-1);
+				event.preventDefault();
+				break;
+			case 'Escape':
+				if (this.panelVisible) {
+					this.hide();
+					event.preventDefault();
+				}
+				break;
+			case 'Backspace':
+				this.onKeyBackspace(event);
+				break;
+			default:
+				break;
+		}
+	}
+
+	/**
+	 * Enter adds the highlighted suggestion when the user navigated the panel, and the text typed
+	 * otherwise, which is what the component has always done.
+	 */
+	public onKeyEnter(event: KeyboardEvent): void {
+		const input = (event.target ?? this.inputViewChild?.nativeElement) as HTMLInputElement;
+		const highlighted = this.results[this.highlightedIndex];
+		const value = highlighted ?? input?.value;
+		if (value) {
+			this.addChip(value);
+			if (input) {
+				input.value = '';
+			}
+		}
+		this.filtered.emit(this.filter);
+		this.hide();
+	}
+
+	/** Backspace over an empty input removes the last chip. */
+	public onKeyBackspace(event: KeyboardEvent): void {
+		if (this.disabled || this.readonly) {
+			return;
+		}
+		const input = event.target as HTMLInputElement;
+		if (!input?.value && this.filter.length) {
+			this.removeChip(this.filter.length - 1);
+			event.preventDefault();
+		}
+	}
+
+	public onSuggestionClick(suggestion: string): void {
+		this.addChip(suggestion);
+		this.filtered.emit(this.filter);
+		if (this.inputViewChild) {
+			this.inputViewChild.nativeElement.value = '';
+		}
+		this.hide();
+		this.inputViewChild?.nativeElement.focus();
+	}
+
+	public onSuggestionMouseEnter(index: number): void {
+		this.$highlightedIndex.set(index);
+	}
+
+	/** Keeps the focus on the input when the panel is clicked, so the blur does not close it. */
+	public onPanelMouseDown(event: MouseEvent): void {
+		event.preventDefault();
+	}
+
+	public removeChip(index: number, event?: MouseEvent): void {
+		event?.stopPropagation();
+		if (this.disabled || this.readonly) {
+			return;
+		}
+		const values = [...this.filter];
+		values.splice(index, 1);
+		this.filter = values;
+	}
+
+	public show(): void {
+		if (this.disabled || this.readonly || this.panelVisible) {
+			return;
+		}
+		this.$panelVisible.set(true);
+		this.bindPanelListeners();
+	}
+
+	public hide(): void {
+		this.clearSearchTimer();
+		if (!this.panelVisible) {
+			return;
+		}
+		this.$panelVisible.set(false);
+		this.$highlightedIndex.set(-1);
+		this.unbindPanelListeners();
+	}
+
+	/** Places the panel right below the chips container, flipping it above when there is no room. */
+	public alignPanel(): void {
+		const panel = this.panelViewChild?.nativeElement;
+		const container = this.containerViewChild?.nativeElement;
+		if (!panel || !container) {
+			return;
+		}
+		const containerRect = container.getBoundingClientRect();
+		let top = containerRect.bottom;
+		if (top + panel.offsetHeight > window.innerHeight) {
+			const flipped = containerRect.top - panel.offsetHeight - PANEL_MARGIN;
+			top = flipped > 0 ? flipped : Math.max(window.innerHeight - panel.offsetHeight, 0);
+		}
+		let left = containerRect.left;
+		if (left + containerRect.width > window.innerWidth) {
+			left = Math.max(window.innerWidth - containerRect.width, 0);
+		}
+		this.renderer.setStyle(panel, 'top', `${top}px`);
+		this.renderer.setStyle(panel, 'left', `${left}px`);
+		this.renderer.setStyle(panel, 'width', `${containerRect.width}px`);
+	}
+
+	/** Adds a chip without emitting: the caller decides when the change is notified. */
+	private addChip(value: string): void {
+		this.$filter.update(values => [...values, value]);
+	}
+
+	private moveHighlight(offset: number): void {
+		if (!this.showPanel) {
+			return;
+		}
+		const total = this.results.length;
+		const next = this.highlightedIndex + offset;
+		this.$highlightedIndex.set(next < 0 ? total - 1 : next % total);
+	}
+
+	private clearSearchTimer(): void {
+		if (this.searchTimer) {
+			clearTimeout(this.searchTimer);
+			this.searchTimer = null;
+		}
+	}
+
+	// The panel only listens to the document while it is open.
+	private bindPanelListeners(): void {
+		if (this.unlistenDocumentMouseDown) {
+			return;
+		}
+		this.unlistenDocumentMouseDown = this.renderer.listen('document', 'mousedown', (event: MouseEvent) => {
+			if (this.panelVisible && !this.el.nativeElement.contains(event.target)) {
+				this.hide();
+			}
+		});
+		this.unlistenScroll = this.renderer.listen('window', 'scroll', () => this.alignPanel());
+		this.unlistenResize = this.renderer.listen('window', 'resize', () => this.hide());
+	}
+
+	private unbindPanelListeners(): void {
+		this.unlistenDocumentMouseDown?.();
+		this.unlistenScroll?.();
+		this.unlistenResize?.();
+		this.unlistenDocumentMouseDown = null;
+		this.unlistenScroll = null;
+		this.unlistenResize = null;
+	}
+}

--- a/projects/systelab-components/src/lib/select/gender-combobox.component.spec.ts
+++ b/projects/systelab-components/src/lib/select/gender-combobox.component.spec.ts
@@ -11,6 +11,7 @@ import { SystelabPreferencesModule } from 'systelab-preferences';
 import { GridContextMenuCellRendererComponent } from '../grid/contextmenu/grid-context-menu-cell-renderer.component';
 import { GridHeaderContextMenuComponent } from '../grid/contextmenu/grid-header-context-menu-renderer.component';
 import { AgGridModule } from 'ag-grid-angular';
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
 import { CommonModule } from '@angular/common';
 import { GenderSelect } from './gender-combobox.component';
 import { ComboBoxInputRendererComponent } from '../combobox/renderer/combobox-input-renderer.component';
@@ -67,14 +68,32 @@ const clickOnDropDown = (fixture: ComponentFixture<GenderSelectTestComponent>) =
 	fixture.detectChanges();
 };
 
-const clickOnRow = (fixture: ComponentFixture<GenderSelectTestComponent>, id: string) => {
-	const button = fixture.debugElement.nativeElement.querySelector('[row-id=\'' + id + '\']');
+/**
+ * The rows are rendered by ag-grid, which does it out of the change detection of the fixture, so
+ * waiting for the fixture to be stable is not enough: the row has to be waited for.
+ */
+const waitForRow = async (fixture: ComponentFixture<GenderSelectTestComponent>, id: string): Promise<HTMLElement> => {
+	for (let attempt = 0; attempt < 40; attempt++) {
+		const row = fixture.debugElement.nativeElement.querySelector('[row-id=\'' + id + '\']');
+		if (row) {
+			return row;
+		}
+		await new Promise(resolve => setTimeout(resolve, 25));
+		fixture.detectChanges();
+		await fixture.whenStable();
+	}
+	throw new Error(`The row ${id} has not been rendered`);
+};
+
+const clickOnRow = async (fixture: ComponentFixture<GenderSelectTestComponent>, id: string) => {
+	const button = await waitForRow(fixture, id);
 	button.click();
 	fixture.detectChanges();
 };
 
 describe('Systelab Gender selector', () => {
 	let fixture: ComponentFixture<GenderSelectTestComponent>;
+	ModuleRegistry.registerModules([AllCommunityModule]);
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
@@ -110,7 +129,7 @@ describe('Systelab Gender selector', () => {
 	it('should select all', async () => {
 		clickOnDropDown(fixture);
 		await fixture.whenStable();
-		clickOnRow(fixture, 'A');
+		await clickOnRow(fixture, 'A');
 		await fixture.whenStable();
 		expect(fixture.componentInstance.id).toEqual('A');
 
@@ -120,7 +139,7 @@ describe('Systelab Gender selector', () => {
 		clickOnDropDown(fixture);
 		fixture.detectChanges()
 		await fixture.whenStable();
-		clickOnRow(fixture, 'U');
+		await clickOnRow(fixture, 'U');
 		fixture.detectChanges()
 		await fixture.whenStable()
 		expect(fixture.componentInstance.id)
@@ -130,7 +149,7 @@ describe('Systelab Gender selector', () => {
 	it('should select male', async () => {
 		clickOnDropDown(fixture);
 		await fixture.whenStable();
-		clickOnRow(fixture, 'M');
+		await clickOnRow(fixture, 'M');
 		await fixture.whenStable();
 		expect(fixture.componentInstance.id).toEqual('M');
 
@@ -139,7 +158,7 @@ describe('Systelab Gender selector', () => {
 	it('should select female', async () => {
 		clickOnDropDown(fixture);
 		await fixture.whenStable();
-		clickOnRow(fixture, 'F');
+		await clickOnRow(fixture, 'F');
 		await fixture.whenStable();
 		expect(fixture.componentInstance.id).toEqual('F');
 	});

--- a/projects/systelab-components/src/lib/systelab-components.module.ts
+++ b/projects/systelab-components/src/lib/systelab-components.module.ts
@@ -84,7 +84,6 @@ import { DialogHeaderComponent } from './modal/header/dialog-header.component';
 import { ChipsComponent } from './chips/chips.component';
 import { ContextMenuSubmenuItemComponent } from './contextmenu/context-menu-submenu-item.component';
 import { GridHeaderContextMenu } from './grid/contextmenu/grid-header-context-menu.component';
-import { AutoCompleteModule } from 'primeng/autocomplete';
 import { SpyMenuComponent } from './spy-menu/spy-menu.component';
 import { ScrollSpyDirective } from './spy-menu/scroll-spy.directive';
 import { ToastComponent } from './toast/toast.component';
@@ -127,7 +126,6 @@ const providers = [
 		CommonModule,
 		FormsModule,
 		DatePickerModule,
-		AutoCompleteModule,
 		DragDropModule,
 		OverlayModule,
 		ContextMenuModule,


### PR DESCRIPTION
Closes #484.

The autocomplete of `systelab-chips` is now written with plain Angular and TypeScript inside `ChipsComponent`, so the
chips no longer depend on PrimeNG. Same approach as `systelab-datepicker-calendar` (#434): signal based state, `OnPush`,
`slab-` class prefix, library CSS variables (so the dark theme works) and the suggestions panel rendered inside the
component as a `position: fixed` element instead of being appended to `body`.

`AutoCompleteModule` is no longer imported by `SystelabComponentsModule` nor by the showcase.

## API

All the `@Input()` (`texts`, `disabled`, `readonly`), the `@Output()` (`filtered`), the `filter` accessor and the
`search()` / `onKeyEnter()` methods are kept, so no change is needed in the applications.

**Breaking:** the `autoComplete` ViewChild is gone, because there is no PrimeNG `AutoComplete` behind the component
anymore. Code calling `chips.autoComplete.hide()` has to call `chips.hide()` / `chips.show()` instead. The `p-` prefixed
class names are also gone: the mapping to the new `slab-chips-*` ones is documented in the root `README.md`.

## Behaviour

Everything the component did before, plus what PrimeNG used to provide and had to be reimplemented:

- Suggestions of `texts` containing the text typed (case insensitive), after 300 ms without typing. The panel is only
  shown when something matches.
- **Enter** adds the highlighted suggestion when the panel has been navigated with the keyboard, and the text typed
  otherwise (what the component has always done). **Click** over a suggestion adds it.
- **Arrow down / Arrow up** move the highlight, **Escape** closes the panel and **Backspace** over an empty input
  removes the last chip.
- The panel is also closed when the input loses the focus, when the window is resized and when the click is outside the
  component. Clicking the container focuses the input.
- `readonly` and `disabled` neither open the panel nor show the `×` of the chips.

## Tests

- `chips.component.spec.ts` rewritten against the new markup, 17 specs (no PrimeNG imports left).
- Full library suite green (679), `build-lib`, `build-showcase` and `lint` clean.
- Manually checked in the built showcase, light and dark theme: suggestions, keyboard highlight, selection by keyboard
  and by click, Escape, Backspace, outside click, chip removal, container growth with many chips, and the readonly and
  disabled variants.

Version bumped to `21.6.0` (assuming #434 goes in as `21.5.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)