### PR TITLE
1197 - systelab-accordion shows incorrect expand/collapse icon orient…

### DIFF
--- a/projects/systelab-components/package.json
+++ b/projects/systelab-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-components",
-  "version": "20.2.9",
+  "version": "20.2.10",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-components/src/lib/accordion/accordion.component.html
+++ b/projects/systelab-components/src/lib/accordion/accordion.component.html
@@ -1,6 +1,6 @@
 <div class="slab-flex-1 d-flex flex-column">
     <div class="accordion-header d-flex align-items-center font-weight-bold px-3" [ngStyle]="{'backgroundColor': headerColor}" (click)="isCollapsed = !isCollapsed">
-        <i class="d-flex justify-content-center align-items-center position-relative" [class.icon-chevron-circle-up]="!isCollapsed" [class.icon-chevron-circle-down]="isCollapsed" [ngClass]="{'text-primary': !iconColor}" [ngStyle]="{'color': iconColor}"></i>
+        <i class="d-flex justify-content-center align-items-center position-relative" [class.icon-chevron-circle-down]="!isCollapsed" [class.icon-chevron-circle-right]="isCollapsed" [ngClass]="{'text-primary': !iconColor}" [ngStyle]="{'color': iconColor}"></i>
         <span class="d-block ml-3">{{ headerTitle }}</span>
     </div>
     <div class="collapsible-content d-flex" [class.collapsed]="isCollapsed"


### PR DESCRIPTION
# PR Details

## Description

Updated the `systelab-accordion` component to correct the expand/collapse icon orientation.

The accordion now displays:
- `icon-chevron-circle-down` when the section is expanded.
- `icon-chevron-circle-right` when the section is collapsed.

Additionally, the package version has been increased from `20.2.9` to `20.2.10`.

## Related Issue

#1197 - systelab-accordion shows incorrect expand/collapse icon orientation

## Motivation and Context

The accordion icons did not correctly represent the current state of the component, resulting in a confusing user experience and behavior that was not aligned with common UI conventions.

This change updates the icon orientation so that the visual indicator matches the accordion state and provides a more intuitive interaction pattern across all consumers of the component.

## How Has This Been Tested

- Built the library successfully.
- Verified the behavior of `systelab-accordion` in a local development environment.
- Confirmed that:
  - Expanded accordions display the downward icon.
  - Collapsed accordions display the right-facing icon.
  - Expand/collapse functionality remains unchanged.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following Semantic Versioning
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right project with the proper status (In Progress)